### PR TITLE
removed all traces of integration-state feature

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,14 @@ import React, { Component } from 'react'
 
 import './App.css'
 
-import { updateSettingsInStorage, loadAppStateFromStorage, updateAppStateToStorage, updateNotebookStateToStorage, CLEAR_WORKSPACE_CONFIRMATION, loadSettingsFromStorage, initIntegrationStates, InitNotebookState, DEFAULT_WHITELIST } from './Constants'
+import  { updateSettingsInStorage
+        , loadAppStateFromStorage
+        , updateAppStateToStorage
+        , updateNotebookStateToStorage
+        , CLEAR_WORKSPACE_CONFIRMATION
+        , loadSettingsFromStorage
+        , InitNotebookState
+        , DEFAULT_WHITELIST } from './Constants'
 
 import TopBar from './components/TopBar'
 import MenuBar from './components/MenuBar'
@@ -10,7 +17,7 @@ import Notebook from './screens/Notebook'
 import Help from './screens/Help'
 import SettingsScreen from './screens/Settings'
 import { Screen, AppState, NotebookState, GlobalSettings, BoxType, BoxState } from './Types'
-import { UNTYPED_LAMBDA_INTEGRATION_STATE, createNewUntypedLambdaBoxFromSource, defaultSettings } from './untyped-lambda-integration/AppTypes'
+import { createNewUntypedLambdaBoxFromSource, defaultSettings } from './untyped-lambda-integration/AppTypes'
 import NotebookList from './screens/NotebookList'
 import { UntypedLambdaState, UntypedLambdaSettings, EvaluationStrategy, UntypedLambdaType } from './untyped-lambda-integration/Types'
 import { MacroTable } from '@lambdulus/core'
@@ -36,8 +43,6 @@ export default class App extends Component<Props, AppState> {
 
 
     this.state = loadAppStateFromStorage()
-
-    initIntegrationStates(this.state) // TODO: go and refactor the implementation of this fn
 
     this.setScreen = this.setScreen.bind(this)
     this.updateNotebook = this.updateNotebook.bind(this)
@@ -366,9 +371,9 @@ function createNewNotebook (name : string = 'Anonymous Notebook') : NotebookStat
     focusedBoxIndex : undefined,
     allowedBoxes : DEFAULT_WHITELIST,
     settings : loadSettingsFromStorage(),
-    integrationStates : {
-      'UNTYPED_LAMBDA' : UNTYPED_LAMBDA_INTEGRATION_STATE,
-    },
+    // integrationStates : {
+    //   'UNTYPED_LAMBDA' : UNTYPED_LAMBDA_INTEGRATION_STATE,
+    // },
 
     locked : false,
     menuOpen : false,
@@ -387,9 +392,9 @@ function createNewNotebookWithBox (name : string = 'Notebook from Link', box : B
     focusedBoxIndex : 0,
     allowedBoxes : DEFAULT_WHITELIST,
     settings : loadSettingsFromStorage(),
-    integrationStates : {
-      'UNTYPED_LAMBDA' : UNTYPED_LAMBDA_INTEGRATION_STATE,
-    },
+    // integrationStates : {
+    //   'UNTYPED_LAMBDA' : UNTYPED_LAMBDA_INTEGRATION_STATE,
+    // },
 
     locked : false,
     menuOpen : false,

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -1,4 +1,4 @@
-import {  CODE_NAME as UNTYPED_CODE_NAME, decodeUntypedLambdaState, UNTYPED_LAMBDA_INTEGRATION_STATE } from './untyped-lambda-integration/AppTypes'
+import { CODE_NAME as UNTYPED_CODE_NAME, decodeUntypedLambdaState } from './untyped-lambda-integration/AppTypes'
 import { defaultSettings as UntypedLambdaDefaultSettings } from './untyped-lambda-integration/AppTypes'
 
 import { BoxType, Screen, BoxesWhitelist, AppState, GlobalSettings, NotebookState, BoxState } from "./Types"
@@ -38,9 +38,6 @@ export const InitNotebookState : NotebookState = {
   focusedBoxIndex : undefined,
   allowedBoxes : DEFAULT_WHITELIST,
   settings : getDefaultSettings(DEFAULT_WHITELIST),
-  integrationStates : {
-    'UNTYPED_LAMBDA' : UNTYPED_LAMBDA_INTEGRATION_STATE, // TODO: FIX THIS!!!
-  },
 
   locked : false,
   menuOpen : false,
@@ -181,23 +178,5 @@ export function decodeNotebook (notebook : NotebookState) : NotebookState | neve
   return {
     ...notebook,
     boxList,
-  }
-}
-
-// TODO: this should be refactored
-export function initIntegrationStates (appState : AppState) {
-  const { currentNotebook, notebookList } : AppState = appState
-  const notebook = notebookList[currentNotebook]
-
-  for (const [boxType, value] of Object.entries(notebook.integrationStates)) {
-    switch (boxType) {
-      case BoxType.UNTYPED_LAMBDA: {
-        value.macrotable = UNTYPED_LAMBDA_INTEGRATION_STATE.macrotable  // TODO: this is very informed - should be done by specific integration - leaving just for now
-        return
-      }
-    
-      default:
-        break;
-    }
   }
 }

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -1,4 +1,4 @@
-import { UntypedLambdaState, UntypedLambdaSettings, UntypedLambdaIntegrationState } from "./untyped-lambda-integration/Types"
+import { UntypedLambdaState, UntypedLambdaSettings } from "./untyped-lambda-integration/Types"
 import { NoteState } from "./markdown-integration/AppTypes"
 
 export enum BoxType {
@@ -10,7 +10,6 @@ export enum BoxType {
 export enum Screen {
   MAIN,
   HELP,
-  // MACROLIST,
   SETTINGS,
   NOTEBOOKS, // TODO: this will be the final solution to the `Multiple Notebooks` problem
 }
@@ -21,8 +20,6 @@ export type NoBox = -2
 
 // TODO: when building `Exam Mode`  allow only Array<BoxType> or NoBox
 export type BoxesWhitelist = Array<BoxType> | AnyBox | NoBox
-
-export interface AbstractIntegrationState {}
 
 export interface AbstractBoxState {
   type : BoxType,
@@ -48,12 +45,6 @@ export type BoxState = UntypedLambdaState | LispBox | NoteState // or other thin
 
 export type Settings = UntypedLambdaSettings | LispSettings // or other things in the future
 
-export type IntegrationState = UntypedLambdaIntegrationState // | Others
-
-export interface IntegrationStates {
-  [key : string] : IntegrationState  // TODO: FIX THIS!!!
-}
-
 // TODO: this needs to be reconsidered
 export interface GlobalSettings {
   // [UNTYPED_CODE_NAME] : UntypedLambdaSettings
@@ -70,7 +61,6 @@ export interface NotebookState {
   menuOpen : boolean
 
   settings : GlobalSettings // TODO: refactor to use the Dictionary
-  integrationStates : IntegrationStates
 
   __key : string
   name : string
@@ -83,22 +73,3 @@ export interface AppState {
   currentNotebook : number,
   currentScreen : Screen,
 }
-
-
-// // TODO: move to specific integration
-// export interface MacroDefinitionState {
-//   __key : string
-//   type : BoxType
-//   macroName : string
-//   macroExpression : string
-//   singleLetterNames : boolean
-//   editor : {
-//     placeholder : string
-//     content : string
-//     caretPosition : number
-//     syntaxError : Error | null
-//   }
-// }
-
-
-

--- a/src/untyped-lambda-integration/AppTypes.ts
+++ b/src/untyped-lambda-integration/AppTypes.ts
@@ -1,16 +1,44 @@
 import { BoxType } from '../Types'
-import { EvaluationStrategy, UntypedLambdaState, UntypedLambdaSettings, UntypedLambdaType, StepRecord, UntypedLambdaExpressionState, UntypedLambdaIntegrationState, SettingsEnabled, PromptPlaceholder, StepMessage, StepValidity } from "./Types"
-import { ASTReduction, AST, decodeFast as decodeUntypedLambdaFast, Evaluator, NormalEvaluator, None, Expansion, Macro, ASTReductionType, Alpha, Lambda, Beta, Eta, Application, ASTVisitor, Variable, ChurchNumeral, builtinMacros, MacroTable, Token, tokenize, parse, ApplicativeEvaluator, OptimizeEvaluator, NormalAbstractionEvaluator, MacroMap } from '@lambdulus/core'
+import  { EvaluationStrategy
+        , UntypedLambdaState
+        , UntypedLambdaSettings
+        , UntypedLambdaType
+        , StepRecord
+        , UntypedLambdaExpressionState
+        , SettingsEnabled
+        , PromptPlaceholder
+        , StepMessage
+        , StepValidity } from "./Types"
+import  { ASTReduction
+        , AST
+        , decodeFast as decodeUntypedLambdaFast
+        , Evaluator
+        , NormalEvaluator
+        , None
+        , Expansion
+        , Macro
+        , ASTReductionType
+        , Alpha
+        , Lambda
+        , Beta
+        , Eta
+        , Application
+        , ASTVisitor
+        , Variable
+        , ChurchNumeral
+        , builtinMacros
+        , MacroTable
+        , Token
+        , tokenize
+        , parse
+        , ApplicativeEvaluator
+        , OptimizeEvaluator
+        , NormalAbstractionEvaluator
+        , MacroMap } from '@lambdulus/core'
 import { Child, Binary } from '@lambdulus/core/dist/ast'
 import { TreeComparator } from './TreeComparator'
 import { reportEvent } from '../misc'
 
-// import macroctx from './MacroContext'
-
-// NOTE: let instead of const just for now
-export let UNTYPED_LAMBDA_INTEGRATION_STATE : UntypedLambdaIntegrationState = {
-  macrotable : {}
-}
 
 export const ADD_BOX_LABEL = '+ Untyped λ Expression'
 
@@ -46,7 +74,7 @@ export function createNewUntypedLambdaExpression (defaultSettings : UntypedLambd
     // standalones : false,
 
     macrolistOpen : false,
-    macrotable : { ...UNTYPED_LAMBDA_INTEGRATION_STATE.macrotable },
+    macrotable : { },
 
     
     editor : {
@@ -242,7 +270,7 @@ export function resetUntypedLambdaBox (state : UntypedLambdaState) : UntypedLamb
     timeout : 5,
     
     macrolistOpen : false,
-    macrotable : { ...UNTYPED_LAMBDA_INTEGRATION_STATE.macrotable },
+    macrotable : { },
 
     
     editor : {

--- a/src/untyped-lambda-integration/ExerciseBox.tsx
+++ b/src/untyped-lambda-integration/ExerciseBox.tsx
@@ -21,14 +21,12 @@ import Expression from './Expression'
 import { PromptPlaceholder, UntypedLambdaState, Evaluator, StepRecord, Breakpoint, UntypedLambdaType, UntypedLambdaExpressionState, StepMessage, StepValidity } from './Types'
 import { reportEvent } from '../misc'
 import { strategyToEvaluator, findSimplifiedReduction, MacroBeta, toMacroMap, tryMacroContraction } from './AppTypes'
-// import { MContext } from './MacroContext'
 
 
 export interface EvaluationProperties {
   state : UntypedLambdaExpressionState
   isActive : boolean
   isFocused : boolean
-  macroContext : { macrotable : MacroMap }
 
   setBoxState (state : UntypedLambdaExpressionState) : void
   addBox (box : UntypedLambdaState) : void

--- a/src/untyped-lambda-integration/ExpressionBox.tsx
+++ b/src/untyped-lambda-integration/ExpressionBox.tsx
@@ -11,7 +11,6 @@ import {
   ChurchNumeral,
   Macro,
   OptimizeEvaluator,
-  MacroMap,
   ASTReductionType,
 } from "@lambdulus/core"
 
@@ -24,14 +23,12 @@ import Expression from './Expression'
 import { PromptPlaceholder, UntypedLambdaState, Evaluator, StepRecord, Breakpoint, UntypedLambdaType, UntypedLambdaExpressionState, StepMessage, StepValidity } from './Types'
 import { reportEvent } from '../misc'
 import { findSimplifiedReduction, MacroBeta, tryMacroContraction, strategyToEvaluator } from './AppTypes'
-// import { MContext } from './MacroContext'
 
 
 export interface EvaluationProperties {
   state : UntypedLambdaExpressionState
   isActive : boolean
   isFocused : boolean
-  macroContext : { macrotable : MacroMap }
 
   setBoxState (state : UntypedLambdaExpressionState) : void
   addBox (box : UntypedLambdaState) : void
@@ -135,7 +132,7 @@ export default class ExpressionBox extends PureComponent<EvaluationProperties> {
       SLI,
       expandStandalones,
       macrolistOpen : false,
-      macrotable : { }, // ...macrotable, ...this.props.macroContext.macrotable
+      macrotable : { },
       editor : {
         placeholder : PromptPlaceholder.EVAL_MODE,
         content : Object.entries(macrotable).map(([name, definition] : [string, string]) => name + ' := ' + definition + ' ;\n' ).join('') + content,

--- a/src/untyped-lambda-integration/Types.ts
+++ b/src/untyped-lambda-integration/Types.ts
@@ -1,10 +1,6 @@
-import { AbstractSettings, BoxType, AbstractBoxState, AbstractIntegrationState } from "../Types"
+import { AbstractSettings, BoxType, AbstractBoxState } from "../Types"
 import { AST, ASTReduction, ASTReductionType, NormalEvaluator, ApplicativeEvaluator, OptimizeEvaluator, MacroMap } from "@lambdulus/core"
 
-
-export interface UntypedLambdaIntegrationState extends AbstractIntegrationState {
-  macrotable : MacroMap
-}
 
 export enum PromptPlaceholder {
   INIT = 'Type λ (as \\) expression and hit enter',
@@ -18,7 +14,6 @@ export enum UntypedLambdaType {
   EMPTY = 'EMPTY',
   ORDINARY = 'ORDINARY',
   EXERCISE = 'EXERCISE',
-  // MACRO,
 }
 
 export type Breakpoint = {
@@ -87,31 +82,6 @@ export interface UntypedLambdaExpressionState extends AbstractBoxState {
     syntaxError : Error | null
   }
 }
-
-// export interface UntypedLambdaMacroState extends AbstractBoxState {
-//   __key : string
-//   type : BoxType
-
-//   subtype : UntypedLambdaType
-//   expression : string
-//   ast : AST | null
-//   macroName : string
-//   macroExpression : string
-  
-//   SLI : boolean
-//   expandStandalones : boolean
-//   strategy : EvaluationStrategy
-
-//   macrolistOpen : boolean
-//   macrotable : MacroMap
-
-//   editor : {
-//     placeholder : string
-//     content : string
-//     caretPosition : number
-//     syntaxError : Error | null
-//   }
-// }
 
 export interface UntypedLambdaSettings extends AbstractSettings {
   SLI : boolean

--- a/src/untyped-lambda-integration/UntypedLambdaBox.tsx
+++ b/src/untyped-lambda-integration/UntypedLambdaBox.tsx
@@ -3,16 +3,13 @@ import React, { PureComponent } from 'react'
 import { BoxType } from '../Types'
 import { UntypedLambdaState, UntypedLambdaType, UntypedLambdaSettings, PromptPlaceholder, StepMessage, StepValidity } from './Types'
 import ExpressionBox from './ExpressionBox'
-// import Macro from './Macro'
 import MacroList from './MacroList'
-import { UNTYPED_LAMBDA_INTEGRATION_STATE, GLOBAL_SETTINGS_ENABLER, strategyToEvaluator, findSimplifiedReduction, toMacroMap } from './AppTypes'
+import { GLOBAL_SETTINGS_ENABLER, strategyToEvaluator, findSimplifiedReduction, toMacroMap } from './AppTypes'
 import ExerciseBox from './ExerciseBox'
 import Settings from './Settings'
 import EmptyExpression from './EmptyExpression'
 import { reportEvent } from '../misc'
 import { None, Evaluator, Token, tokenize, parse, AST, OptimizeEvaluator, MacroMap } from '@lambdulus/core'
-
-// import macroctx from './MacroContext'
 
 
 interface Props {
@@ -62,7 +59,6 @@ export default class UntypedLambdaBox extends PureComponent<Props> {
               state={ state }
               isActive={ isActive }
               isFocused={ isFocused }
-              macroContext={ UNTYPED_LAMBDA_INTEGRATION_STATE }
               setBoxState={ setBoxState }
               addBox={ addBox }
             />
@@ -74,7 +70,6 @@ export default class UntypedLambdaBox extends PureComponent<Props> {
               state={ state }
               isActive={ isActive }
               isFocused={ isFocused }
-              macroContext={ UNTYPED_LAMBDA_INTEGRATION_STATE }
               setBoxState={ setBoxState }
               addBox={ addBox }
             />


### PR DESCRIPTION
This PR removes the feature intended to support integration-scoped state within the Notebook.

I do not intend to support this, because Macros - for which it was originally intended, are defined locally and not Notebook-wise.