### PR TITLE
moved editor prop into abstract interface BoxState, replaced union ty…

### DIFF
--- a/src/Types.ts
+++ b/src/Types.ts
@@ -1,5 +1,4 @@
-import { UntypedLambdaState, UntypedLambdaSettings } from "./untyped-lambda-integration/Types"
-import { NoteState } from "./markdown-integration/AppTypes"
+import { UntypedLambdaSettings } from "./untyped-lambda-integration/Types"
 
 export enum BoxType {
   UNTYPED_LAMBDA = 'UNTYPED_LAMBDA',
@@ -21,27 +20,31 @@ export type NoBox = -2
 // TODO: when building `Exam Mode`  allow only Array<BoxType> or NoBox
 export type BoxesWhitelist = Array<BoxType> | AnyBox | NoBox
 
-export interface AbstractBoxState {
+export interface BoxState {
   type : BoxType,
   __key : string, 
   title : String,
   minimized : boolean,
   settingsOpen : boolean,
+
+  editor : {
+    placeholder : string
+    content : string
+    syntaxError : Error | null
+  }
 }
 
 export interface AbstractSettings {
   type : BoxType,
 }
 
-export interface LispBox extends AbstractBoxState {
+export interface LispBox extends BoxState {
   // TODO: delete this placeholder and implement it
 }
 
 export interface LispSettings extends AbstractSettings {
   // TODO: delete this placeholder and implement it
 }
-
-export type BoxState = UntypedLambdaState | LispBox | NoteState // or other things in the future
 
 export type Settings = UntypedLambdaSettings | LispSettings // or other things in the future
 

--- a/src/components/BoxTitleBar.tsx
+++ b/src/components/BoxTitleBar.tsx
@@ -220,7 +220,7 @@ export default class BoxTitleBar extends Component<Props, State> {
                   break
                 }
                 case BoxType.MARKDOWN: {
-                  updateBoxState({ ...state, isEditing : true })
+                  updateBoxState({ ...state, isEditing : true } as NoteState)
                   break
                 }
               }

--- a/src/markdown-integration/AppTypes.ts
+++ b/src/markdown-integration/AppTypes.ts
@@ -1,17 +1,11 @@
-import { BoxType, AbstractBoxState } from "../Types"
+import { BoxType, BoxState } from "../Types"
 
 
-export interface NoteState extends AbstractBoxState {
+export interface NoteState extends BoxState {
   __key : string
   type : BoxType
   note : string
   isEditing : boolean
-  editor : {
-    placeholder : string
-    content : string
-    caretPosition : number
-    syntaxError : Error | null
-  }
 }
 
 export function createNewMarkdown () : NoteState {
@@ -26,7 +20,6 @@ export function createNewMarkdown () : NoteState {
     editor : {
       placeholder : PromptPlaceholder,
       content : '',
-      caretPosition : 0,
       syntaxError : null
     }
   }
@@ -41,7 +34,6 @@ export function resetMarkdownBox (state : NoteState) : NoteState {
     editor : {
       placeholder : PromptPlaceholder,
       content : '',
-      caretPosition : 0,
       syntaxError : null
     }
   }

--- a/src/markdown-integration/BoxTopBar.tsx
+++ b/src/markdown-integration/BoxTopBar.tsx
@@ -34,7 +34,7 @@ export default function BoxTopBar (props : Props) : JSX.Element {
             onClick={ (e) => {
               e.stopPropagation()
               if (isEditing === false) {
-                updateBoxState({ ...state, isEditing : true})
+                updateBoxState({ ...state, isEditing : true} as NoteState)
               }
             } }
           >
@@ -45,7 +45,7 @@ export default function BoxTopBar (props : Props) : JSX.Element {
             onClick={ (e) => {
               e.stopPropagation()
               if (isEditing === true) {
-                updateBoxState({ ...state, isEditing : false})
+                updateBoxState({ ...state, isEditing : false} as NoteState)
               }
             } }
           >

--- a/src/untyped-lambda-integration/BoxTopBar.tsx
+++ b/src/untyped-lambda-integration/BoxTopBar.tsx
@@ -24,7 +24,7 @@ export default function BoxTopBar (props : Props) : JSX.Element {
       <div
         onClick={ (e) => {
           e.stopPropagation()
-          updateBoxState({ ...state, macrolistOpen : ! macrolistOpen })
+          updateBoxState({ ...state, macrolistOpen : ! macrolistOpen } as UntypedLambdaState)
         } }
         className={ `untyped-lambda--top-bar-custom--button ${macrolistOpen ? 'menu-pressed-open' : ''}` }
         title={ macrolistOpen ? 'Hide Macros' : 'Show All Macros for This Box' }

--- a/src/untyped-lambda-integration/Types.ts
+++ b/src/untyped-lambda-integration/Types.ts
@@ -1,4 +1,4 @@
-import { AbstractSettings, BoxType, AbstractBoxState } from "../Types"
+import { AbstractSettings, BoxType, BoxState } from "../Types"
 import { AST, ASTReduction, ASTReductionType, NormalEvaluator, ApplicativeEvaluator, OptimizeEvaluator, MacroMap } from "@lambdulus/core"
 
 
@@ -54,7 +54,7 @@ export type UntypedLambdaState = UntypedLambdaExpressionState // | UntypedLambda
 
 // TODO: consider abstract Untype Lambda State which will hold all common members
 
-export interface UntypedLambdaExpressionState extends AbstractBoxState {
+export interface UntypedLambdaExpressionState extends BoxState {
   __key : string
   type : BoxType
 
@@ -75,12 +75,6 @@ export interface UntypedLambdaExpressionState extends AbstractBoxState {
 
   macrolistOpen : boolean // this is gonna go out
   macrotable : MacroMap // this is gonna go out - WHY? I don't think so - it's gonna stay
-  
-  editor : {
-    placeholder : string
-    content : string
-    syntaxError : Error | null
-  }
 }
 
 export interface UntypedLambdaSettings extends AbstractSettings {


### PR DESCRIPTION
…pe with hierarchy

This PR refactors the BoxState interface.

Originally, there was an abstract interface, all specific BoxStates implemented it and the type of each Box was an union type between those.
That was kinda cool and flexible, but also seemed needlesly complex.

I removed the union and each Box is said to have the BoxState interface.

I will need to think about whether I like it more or not.