### PR TITLE
test: add App smoke test and run it in CI

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -20,7 +20,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
     - run: npm ci
-    # - run: npm test
+    - run: npm test -- --watchAll=false
     - run: npm run build --if-present
       env:
         # Stopgap: CRA4/webpack4 needs the legacy OpenSSL provider on Node 17+.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
     - run: npm ci
-    # - run: npm test
+    - run: npm test -- --watchAll=false
     - run: npm run build --if-present
       env:
         # Stopgap: CRA4/webpack4 needs the legacy OpenSSL provider on Node 17+.

--- a/.github/workflows/dispatch-pr.yml
+++ b/.github/workflows/dispatch-pr.yml
@@ -34,7 +34,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
     - run: npm ci
-    # - run: npm test
+    - run: npm test -- --watchAll=false
     - run: npm run build --if-present
       env:
         # Stopgap: CRA4/webpack4 needs the legacy OpenSSL provider on Node 17+.

--- a/.github/workflows/purge-pr-deployment.yml
+++ b/.github/workflows/purge-pr-deployment.yml
@@ -34,7 +34,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
     - run: npm ci
-    # - run: npm test
+    - run: npm test -- --watchAll=false
     - run: npm run build --if-present
       env:
         # Stopgap: CRA4/webpack4 needs the legacy OpenSSL provider on Node 17+.

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -2,8 +2,9 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders the app shell (top-level smoke test)', () => {
   const { getByText } = render(<App />);
-  const linkElement = getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  // #bad-screen-message is always rendered by App, independent of screen state
+  const message = getByText(/Lambdulus only runs on screens at least 900 pixels wide\./i);
+  expect(message).toBeInTheDocument();
 });

--- a/src/__mocks__/react-markdown.js
+++ b/src/__mocks__/react-markdown.js
@@ -1,0 +1,15 @@
+// Manual mock for `react-markdown` (picked up automatically by CRA jest).
+// v7 ships ESM-only code that jest cannot parse; tests only need the
+// markdown source rendered, not actual markdown processing.
+const React = require('react');
+
+function ReactMarkdown (props) {
+  return React.createElement(
+    'div',
+    { 'data-testid': 'react-markdown-mock' },
+    props && props.children
+  );
+}
+
+module.exports = ReactMarkdown;
+module.exports.default = ReactMarkdown;

--- a/src/__mocks__/react-monaco-editor.js
+++ b/src/__mocks__/react-monaco-editor.js
@@ -1,0 +1,11 @@
+// Manual mock for `react-monaco-editor` (picked up automatically by CRA jest).
+// The real package ships untranspiled ESM that jest cannot parse, and no test
+// needs an actual code editor — a stub div is enough.
+const React = require('react');
+
+function MonacoEditor () {
+  return React.createElement('div', { 'data-testid': 'monaco-editor-mock' });
+}
+
+module.exports = MonacoEditor;
+module.exports.default = MonacoEditor;

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -3,3 +3,9 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom/extend-expect';
+
+// jsdom does not implement URL.createObjectURL (used by TopBar to offer the
+// notebook download). A stub returning a fake blob URL is enough for tests.
+if (typeof window.URL.createObjectURL !== 'function') {
+  window.URL.createObjectURL = jest.fn(() : string => 'blob:mock-url');
+}


### PR DESCRIPTION
Replaces the stale CRA template test with a real smoke test (always-rendered app shell), mocks for the ESM-only editor/markdown deps, a createObjectURL stub for jsdom, and enables npm test in all four workflows.