### PR TITLE
deps: consume core from git tag instead of npm registry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@lambdulus/frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@lambdulus/core": "^0.0.8",
+        "@lambdulus/core": "git+https://github.com/lambdulus/core.git#v0.0.9",
         "@testing-library/jest-dom": "^5.14.1",
         "@testing-library/react": "^12.1.2",
         "@testing-library/user-event": "^13.5.0",
@@ -2417,8 +2417,8 @@
       }
     },
     "node_modules/@lambdulus/core": {
-      "version": "0.0.8",
-      "resolved": "git+ssh://git@github.com/lambdulus/core.git#aa0a7755b7bba217fe13318fc9615cb7ba2fb886",
+      "version": "0.0.9",
+      "resolved": "git+ssh://git@github.com/lambdulus/core.git#80bbf511adc7b0f9d092ab19e251b5f212b6379f",
       "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -22769,8 +22769,8 @@
       }
     },
     "@lambdulus/core": {
-      "version": "git+ssh://git@github.com/lambdulus/core.git#aa0a7755b7bba217fe13318fc9615cb7ba2fb886",
-      "from": "@lambdulus/core@^0.0.8"
+      "version": "git+ssh://git@github.com/lambdulus/core.git#80bbf511adc7b0f9d092ab19e251b5f212b6379f",
+      "from": "@lambdulus/core@git+https://github.com/lambdulus/core.git#v0.0.9"
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@lambdulus/core": "^0.0.8",
+    "@lambdulus/core": "git+https://github.com/lambdulus/core.git#v0.0.9",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^12.1.2",
     "@testing-library/user-event": "^13.5.0",


### PR DESCRIPTION
core v0.0.9 (parser fixes, built from source via 'prepare') consumed as git+https tag dependency. Lockfile pinned to the tag commit. Verified: frontend tests + production build green on the new core.