### PR TITLE
ci: drop jest-only watchAll flag

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -20,7 +20,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
     - run: npm ci
-    - run: npm test -- --watchAll=false
+    - run: npm test
     - run: npm run build --if-present
 
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
     - run: npm ci
-    - run: npm test -- --watchAll=false
+    - run: npm test
     - run: npm run build --if-present
 
   deploy:

--- a/.github/workflows/dispatch-pr.yml
+++ b/.github/workflows/dispatch-pr.yml
@@ -34,7 +34,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
     - run: npm ci
-    - run: npm test -- --watchAll=false
+    - run: npm test
     - run: npm run build --if-present
 
   deploy:

--- a/.github/workflows/purge-pr-deployment.yml
+++ b/.github/workflows/purge-pr-deployment.yml
@@ -34,7 +34,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
     - run: npm ci
-    - run: npm test -- --watchAll=false
+    - run: npm test
     - run: npm run build --if-present
 
   deploy:


### PR DESCRIPTION
vitest rejects the leftover jest --watchAll flag; plain npm test already runs once.