### PR TITLE
Dark UI tour: zen dwell, cleaning and theme walks, share, recap

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,47 +1,48 @@
 # Audit — `@lambdulus/frontend`
 
-Date: 2026-09-04. Audited from local `develop` HEAD (`8b8129e`, Oct 2022; working tree has uncommitted edits to `src/App.css` and `src/untyped-lambda-integration/Constants.ts`). Verified by reading `package.json`, `tsconfig.json`, `src/`, `public/`, `.github/workflows/`, git log/branches/status.
+Date: 2026-09-07. Audited from `experiment/dark-ui` HEAD (`6876152`). Verified by reading `package.json`, `package-lock.json`, `tsconfig.json`, `vite.config.ts`, `src/`, `.github/workflows/`, `README.md`, git log/branches/status, plus `npm outdated`, `npm audit`, `npx vitest run` (94 passed), `npx tsc --noEmit` (clean).
+
+Supersedes the 2026-09-04 audit, which described the CRA 4 / Node 16 era. Nearly all of its P0–P1 items have since landed (Vite migration, real test suite wired into CI, Node 22, `@monaco-editor/react`, `dist`-free repo, refreshed README, `purge-pr-deployment.yml` filename fixed).
 
 ## 1. What it is
 
-Create-React-App 4 notebook UI for playing with lambda calculus (teaching at FIT CTU). Box system (`components/Box*.tsx`, `CreateBox`, `PickBoxTypeModal`) hosts pluggable integrations: `untyped-lambda-integration/` (expression/exercise boxes, step debugger, macros, settings), `markdown-integration/` (notes), `empty-integration/`, plus `screens/` (Notebook, Settings, Help), `contexts/` (Settings, Theme), `misc/UserGuide.ts`. ~45 TS/TSX files, `react-monaco-editor` editing, `react-markdown` notes. Private package (`"private": true`, v0.1.0).
+Vite 6 + React 18 + TypeScript 5 notebook UI for playing with lambda calculus (teaching at FIT CTU). Box system hosts pluggable integrations: `untyped-lambda-integration/` (expression/exercise boxes, step debugger, macros, settings), `markdown-integration/`, `empty-integration/`, plus `screens/`, `components/`, `contexts/`, `styles/`. Private package (`"private": true`, v0.1.0). The compute engine is `@lambdulus/core`, consumed via git tag (`git+https://github.com/lambdulus/core.git#v0.0.9`) — no npm registry, so Dependabot does not cover it; bumps are manual tag moves. `vite.config.ts` uses relative `base: './'` so one build serves `/`, `/staging`, and `/staging/pr/<branch>`; `outDir` stays `build` for the downstream deploy scripts.
 
-## 2. CI/CD — your recollection is mostly right, with one correction
+## 2. CI/CD
 
-There are 4 workflows, all **dispatch-based** (this repo never publishes to GitHub Pages itself; it builds, then `curl`s a `repository_dispatch` to a *downstream* repo that does the actual deploy):
+Four workflows, all **dispatch-based** (this repo builds, then `curl`s a `repository_dispatch` to a downstream repo that does the actual deploy):
 
-- `deploy.yml` — on `push` to `master`: build, then `POST /repos/lambdulus/lambdulus.github.io/dispatches` with `event_type: deploy`. This is the **production** path (production site repo).
-- `deploy-staging.yml` — on `push` to `develop`: build, then dispatch `deploy-staging` to `lambdulus/staging`. This is the **staging** path.
-- `dispatch-pr.yml` — on `pull_request` to `develop`: posts a comment ("will soon be deployed to `https://lambdulus.github.io/staging/pr/<branch>`…") and dispatches `pr-deploy-staging` (with branch name) to `lambdulus/staging`. Per-PR staging previews.
-- `purge-pr-deployement.yml` (sic, typo in filename) — on PR `closed`: posts a "will shortly be purged" comment and dispatches `pr-purge-staging` to `lambdulus/staging`.
+- `deploy-staging.yml` — push to `develop` → dispatch `deploy-staging` to `lambdulus/staging`.
+- `deploy.yml` — push to `master` → dispatch `deploy` to `lambdulus/lambdulus.github.io` (production site repo; any manual gate lives downstream).
+- `dispatch-pr.yml` — PR to `develop` → comment + dispatch `pr-deploy-staging` (per-PR staging previews).
+- `purge-pr-deployment.yml` — PR `closed` → comment + dispatch `pr-purge-staging`.
 
-So: staging deploys are automatic (push to `develop`, PR open/close); production deploys fire automatically on push to `master` **from this repo's side**. The manual step you remember ("run the production deploy manually from GH website") is not in this repo — it must live in the downstream `lambdulus.github.io` repo (e.g. a manual `workflow_dispatch`/approval gate there). Worth confirming there before touching `deploy.yml`.
+All four run `npm ci` + `npm test` + `npm run build` (which typechecks first) on `actions/checkout@v5` + `actions/setup-node@v5`, Node 22.x, with npm cache — and `deploy` is gated on `build` success. Verified live: the run for the v5/Node-22 modernization itself went green end to end with no deprecation annotations.
 
-Common CI weaknesses across all four: `actions/checkout@v2` + `actions/setup-node@v2` (both EOL), Node `16.x` (EOL since 2023), `npm ci` + `npm run build` with **`npm test` commented out**, deprecated `Accept: application/vnd.github.everest-preview+json` header, auth via `secrets.ACCESS_TOKEN` (a long-lived PAT — check expiry/owner), no verification that the downstream dispatch succeeded beyond curl's exit code.
+Remaining CI wrinkles (all P2 or lower): the `Accept: application/vnd.github.everest-preview+json` header is long obsolete (API is GA — harmless but remove it); auth via long-lived `secrets.ACCESS_TOKEN` PAT (expiry/owner not verifiable from here); no verification of the downstream dispatch beyond curl's exit code.
 
 ## 3. Dependencies / build
 
-- `react-scripts 4.0.3` (CRA 4), `react`/`react-dom 17`, `typescript ^4.4.4`, `@lambdulus/core ^0.0.8` (npm registry — i.e. frontend does **not** consume the sibling `core/` checkout), `react-monaco-editor ^0.45.0`, `react-markdown ^7.1.0`, `pretty-checkbox[-react]`, testing-library stack, `@types/react 17`, `@types/node 16`. `package-lock.json` is 1.5 MB; `npm ls` health not verified here.
-- Everything material is EOL/unmaintained: CRA 4 (no updates since 2021; CRA itself deprecated), React 17 (current is 19; 18+ changes `createRoot`, strict effects), Node 16 types, `react-monaco-editor` (abandoned; monaco + React 18 needs `@monaco-editor/react`), TS 4.4 (`tsconfig` still targets `es5` with `isolatedModules`, `noFallthroughCasesInSwitch` — fine but dated).
-- Scripts inject build metadata via shell interpolation (`REACT_APP_VERSION_INFO=$(date …) REACT_APP_COMMIT=$(git rev-parse HEAD)`) — Unix-only, breaks on Windows, and `git rev-parse` fails on shallow/tagless CI checkouts. `test` is bare `react-scripts test` (watch mode; needs `CI=true` in automation — currently moot since tests are disabled in CI). No `homepage` field and no `gh-pages` dependency, consistent with the dispatch-to-downstream deploy model (§2).
-- Dependabot bump PRs exist on remote (`async`, `eventsource`, `follow-redirects`, `minimist`, `nanoid`, `terser`, `url-parse` — several are **security** fixes) but were never merged; the `update-deps` branch is stale too.
+- `npm audit`: **0 vulnerabilities.** `npm outdated`: every package is at the newest version its pinned range allows. The `dompurify ^3.4.14` override is still load-bearing (`monaco-editor@0.56.0` → `dompurify@3.4.14`) — keep it.
+- Available majors are opt-in migrations, not warnings: React 18→19 (`createRoot`, strict effects — touches the box lifecycle), Vite 6→8, TypeScript 5→7, `react-markdown` 7→10, testing-library 14→16, jsdom 24→29, `@vitejs/plugin-react` 4→6. Each wants a dedicated upgrade pass with the suite green before/after.
+- `package-lock.json` is 174 KB and healthy. Build metadata still injected via shell interpolation (`VITE_COMMIT=$(git rev-parse HEAD)`) — Unix-only, but proven working on CI checkouts, so cosmetic at most.
+- Watch item: `@lambdulus/core` moves only when someone bumps the git tag. Current pin `v0.0.9` matches the sibling `core/` checkout — no drift today.
 
-## 4. Tests — effectively none
+## 4. Tests — real now
 
-- The only test file is `src/App.test.tsx`, still the CRA template: it renders `<App />` and asserts on `/learn react/i`, which does not exist in the real app — i.e. it fails (or would, if it ran). All workflows have `# - run: npm test` commented out, so nothing runs it.
-- 73 `console.log` calls across `src/`, ~40 `TODO/FIXME` comments (dead-code markers, "just for now" F9 shortcuts, Czech notes like `tohle bude chtít přepsat`), commented-out `github-token` in `dispatch-pr.yml`, and uncommitted local edits (`App.css`, `Constants.ts`) sitting in the working tree.
-- No lint gate in CI (only CRA's in-dev eslint), no Prettier/format config, no coverage.
+94 vitest tests across 10 files, all passing; `tsc --noEmit` clean; both enforced in CI (`npm test`, plus typecheck inside `npm run build`). Coverage centers on the areas that actually regress: focus/zen/macro/theme/box-style behaviors, accent preview contract, App shell. No coverage gate and no lint gate — the suite is the gate.
 
 ## 5. Code/structure health
 
-- Clean separation of integrations is a strength; the Box/context refactor series (#52, #55) landed, so state flows through contexts rather than prop-drilling. But many stale remote branches (`tiny-lisp`, `remove-*`, `refactor-*`, `export-types`, …) suggest half-finished migrations still floating around — check whether `develop` vs `master` have diverged meaningfully before deleting.
-- `serviceWorker.ts` is present (CRA default) — confirm whether offline support is actually wanted; an unmaintained SW + teaching tool is a stale-cache footgun.
-- `public/` icons/manifest look fine; `README.md` is the CRA stub plus two deploy sentences (the "open a merge request into master" line predates the current dispatch setup — update it).
+- 3 `console.log` calls left in `src/` (down from ~70), `TODO`/`FIXME` markers in 15 files — background noise, not rot.
+- No `serviceWorker.ts`, no lint/format config (still just the editor defaults) — Prettier/eslint with a committed config remains the cheapest hygiene win.
+- README is current (stack, scripts, git-tag core consumption, branch model). It says "Requires Node 20+"; CI pins 22 — no contradiction, no `engines` field either way.
+- 52 local+remote branches; the `remove-*`/`refactor-*`/`tiny-lisp`/`export-types` series is still floating around. Prune what's merged before the list grows teeth.
 
 ## 6. Prioritized cleanup
 
-1. **Triage deploy config before any upgrade:** confirm the downstream `lambdulus.github.io` / `staging` repos' expected events and the manual production gate; rotate/verify `ACCESS_TOKEN`; fix the `purge-pr-deployement.yml` typo by renaming (keep a compat shim if the downstream matches on filenames — it shouldn't, events matter, but check). (P0 — deploy is the one thing that must keep working.)
-2. **Decide the frontend's future stack, then patch security in the meantime:** merge or re-issue the Dependabot security bumps; then choose stay-on-CRA (upgrade to latest `react-scripts` 5 + React 18, minimal churn) vs. migrate to Vite/Next (bigger win, bigger diff). Either way, replace `react-monaco-editor` with `@monaco-editor/react` and lift Node to 20/22 in CI. (P0 security, P1 stack.)
-3. **Make `npm test` real and run it in CI:** delete or rewrite `App.test.tsx` into a smoke test of the actual App, add integration tests for at least parse→render→step in the untyped-lambda boxes, uncomment/enable `npm test -- --watchAll=false` in all workflows. (P1 — teaching tool with zero tests.)
-4. **Modernize workflows:** `checkout@v4` + `setup-node@v4`, `node-version: [20.x]` (or 22.x), cache `npm`, `CI=true`, fail loudly on dispatch errors (`curl --fail`), replace `everest-preview` header, make build-metadata injection cross-platform (e.g. `REACT_APP_COMMIT=$GITHUB_SHA`). (P1.)
-5. **Hygiene:** commit or stash the two dirty files; remove `serviceWorker.ts` if unused; run Prettier/eslint with a committed config; refresh README (branch model `develop`→staging auto / `master`→production dispatch + downstream manual gate, scripts, Node version); prune merged/stale branches. (P2.)
+1. **PAT hygiene:** confirm `ACCESS_TOKEN` owner/expiry/rotation for both downstream dispatches. (P1 — the one thing that can silently break deploys.)
+2. **Opt-in major upgrades** when there's appetite: React 19 first (biggest API surface), then Vite/TS/testing stack. One migration per pass, suite green throughout. (P1, scheduled — not urgent.)
+3. **Drop the `everest-preview` header** from all four dispatch curls. (P2, trivial.)
+4. **Add Prettier/eslint with committed config** (and keep it out of CI until the tree is clean, or add it — tree is small enough now that day one could be green). (P2.)
+5. **Prune stale branches** after confirming `develop` vs `master` divergence is intentional. (P2.)

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,8 +7,9 @@
     "": {
       "name": "@lambdulus/frontend",
       "version": "0.1.0",
+      "license": "ISC",
       "dependencies": {
-        "@lambdulus/core": "git+https://github.com/lambdulus/core.git#v0.0.9",
+        "@lambdulus/core": "git+https://github.com/lambdulus/core.git#v0.0.10",
         "@monaco-editor/react": "^4.7.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^14.0.0",
@@ -899,8 +900,8 @@
       }
     },
     "node_modules/@lambdulus/core": {
-      "version": "0.0.9",
-      "resolved": "git+ssh://git@github.com/lambdulus/core.git#80bbf511adc7b0f9d092ab19e251b5f212b6379f",
+      "version": "0.0.10",
+      "resolved": "git+ssh://git@github.com/lambdulus/core.git#d4a2d617c1fd650bde26eeed15996c5d19d97cee",
       "license": "MIT"
     },
     "node_modules/@monaco-editor/loader": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@lambdulus/core": "git+https://github.com/lambdulus/core.git#v0.0.9",
+    "@lambdulus/core": "git+https://github.com/lambdulus/core.git#v0.0.10",
     "@monaco-editor/react": "^4.7.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^14.0.0",

--- a/src/App.css
+++ b/src/App.css
@@ -290,6 +290,22 @@ body {
   pointer-events: none;
 }
 
+/* Paging hitbox: an invisible backstop behind the lines, reaching a
+   good way past the short map small notebooks draw, so wheel and
+   swipe gestures find it without hunting for a two-line strip. It
+   sits behind the list content (negative z), so lines and arrows
+   keep their clicks; it only catches the empty strip around them.
+   Always present but harmless outside zen: clicks land on empty
+   margin, and wheel chains on to the page exactly as before. */
+.box-map-hitbox {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: -18vh;
+  bottom: -18vh;
+  z-index: -1;
+}
+
 .box-map-list.mask-top {
   -webkit-mask-image: linear-gradient(to bottom, transparent 0, #000 24px);
   mask-image: linear-gradient(to bottom, transparent 0, #000 24px);

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
-import { test, expect } from 'vitest';
-import { render, fireEvent, waitFor } from '@testing-library/react';
+import { test, expect, afterEach } from 'vitest';
+import { render, fireEvent, waitFor, cleanup } from '@testing-library/react';
 import App from './App';
+
+afterEach(() => cleanup());
 import { createDefaultAppState, preferredTheme, saveTourState, loadTourState } from './Constants';
 import { TOUR_STEPS } from './components/Tour';
 import { defaultSettings, createNewUntypedLambdaExpression } from './untyped-lambda-integration/Constants';
@@ -83,6 +85,20 @@ test('first load opens the guided tour, afterwards only the icon does', () => {
   fireEvent.click(second.container.querySelector('[title="Guided tour"]') as HTMLElement);
   expect(second.container.querySelector('.tour--title')?.textContent).toBe('Macros');
   second.unmount();
+});
+
+test('chauffeur next on the + step opens the real picker', async () => {
+  window.localStorage.clear();
+  const { container } = render(<App />);
+  const nextBtn = () => [...container.querySelectorAll('.tour--actions button')].find((b) => b.textContent === 'Next') as Element;
+
+  fireEvent.click(nextBtn());
+  expect(container.querySelector('.tour--title')?.textContent).toBe('Add a box');
+  fireEvent.click(nextBtn());
+  expect(container.querySelector('.tour--title')?.textContent).toBe('Pick a box type');
+  // The chauffeur worked the clickable control, not its inert wrapper:
+  // the real picker opens (a tick later — native dispatch flushes async).
+  await waitFor(() => expect(container.querySelector('[title="Create new λ box"]')).not.toBeNull());
 });
 
 test('the tour conducts a lambda box from + to evaluated', async () => {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { test, expect } from 'vitest';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 import App from './App';
 import { createDefaultAppState, preferredTheme, saveTourState, loadTourState } from './Constants';
 import { TOUR_STEPS } from './components/Tour';
@@ -63,20 +63,12 @@ test('first load opens the guided tour, afterwards only the icon does', () => {
   window.localStorage.clear();
   const first = render(<App />);
   expect(first.container.querySelector('[role="dialog"]')).not.toBeNull();
-  expect(first.container.querySelector('.tour--title')?.textContent).toBe(TOUR_STEPS[0].title);
-
-  // The tour seeds exactly one evaluated demo box and remembers its key.
-  const demoBoxes = first.container.querySelectorAll('[data-box-key]');
-  expect(demoBoxes.length).toBe(1);
-  const stored = loadTourState();
-  expect(stored?.seeded).toBe(true);
-  expect(stored?.demoBoxKey).toBe(demoBoxes[0].getAttribute('data-box-key'));
-  expect(first.container.querySelector('.untypedLambdaBox')).not.toBeNull();
+  expect(first.container.querySelector('.tour--title')?.textContent).toBe('Welcome to Lambdulus');
   first.unmount();
 
-  // Snoozed mid-tour: no auto-open, and every step target resolves
+  // Snoozed mid-tour: no auto-open, and every step selector resolves
   // in a fresh render so the tour cannot rot silently.
-  saveTourState({ step : 2, done : true, seeded : true, demoBoxKey : stored?.demoBoxKey ?? null });
+  saveTourState({ step : 'macros', done : true });
   const second = render(<App />);
   expect(second.container.querySelector('[role="dialog"]')).toBeNull();
   for (const step of TOUR_STEPS) {
@@ -87,31 +79,70 @@ test('first load opens the guided tour, afterwards only the icon does', () => {
     }
   }
 
-  // The icon resumes where the tour left off — without a second demo box.
+  // The icon resumes where the tour left off.
   fireEvent.click(second.container.querySelector('[title="Guided tour"]') as HTMLElement);
-  expect(second.container.querySelector('.tour--title')?.textContent).toBe(TOUR_STEPS[2].title);
-  expect(second.container.querySelectorAll('[data-box-key]').length).toBe(1);
+  expect(second.container.querySelector('.tour--title')?.textContent).toBe('Macros');
   second.unmount();
 });
 
-test('the + step is live: clicking it advances, next chauffeurs it', () => {
+test('the tour conducts a lambda box from + to evaluated', async () => {
   window.localStorage.clear();
   const { container } = render(<App />);
   const nextBtn = () => [...container.querySelectorAll('.tour--actions button')].find((b) => b.textContent === 'Next') as Element;
+  const title = () => container.querySelector('.tour--title')?.textContent;
 
-  // Walk to the + step, then operate the real control.
+  // Welcome to the + step (empty notebook: the big + panel).
   fireEvent.click(nextBtn());
-  expect(container.querySelector('.tour--title')?.textContent).toBe(TOUR_STEPS[1].title);
-  fireEvent.mouseDown(container.querySelector('.add_box_after') as Element);
-  expect(container.querySelector('.tour--title')?.textContent).toBe(TOUR_STEPS[2].title);
+  expect(title()).toBe('Add a box');
 
-  // Back up: chauffeur mode opens the real picker and walks on exactly once.
-  const backBtn = [...container.querySelectorAll('.tour--actions button')].find((b) => b.textContent === 'Back') as Element;
-  fireEvent.click(backBtn);
-  expect(container.querySelector('.tour--title')?.textContent).toBe(TOUR_STEPS[1].title);
+  // The user clicks + themselves: picker opens, tour walks to box types.
+  fireEvent.click(container.querySelector('.create-box-plus') as Element);
+  expect(title()).toBe('Pick a box type');
+  expect(container.querySelector('[title="Create new λ box"]')).not.toBeNull();
+
+  // They pick λ: a real box appears, the tour watches it happen.
+  fireEvent.click(container.querySelector('[title="Create new λ box"]') as Element);
+  await waitFor(() => expect(title()).toBe('Write and evaluate'));
+  expect(container.querySelectorAll('.box-frame').length).toBe(1);
+
+  // Next does their typing and debugging; the evaluated box walks on.
   fireEvent.click(nextBtn());
-  expect(container.querySelector('.tour--title')?.textContent).toBe(TOUR_STEPS[2].title);
-  expect(container.querySelector('.add-box--group')).not.toBeNull();
+  await waitFor(() => expect(title()).toBe('Step through evaluation'));
+  expect(container.querySelector('.box-history-wrap')).not.toBeNull();
+
+  // To the end: the box stays behind for them to keep.
+  fireEvent.click(nextBtn());
+  expect(title()).toBe('Macros');
+  fireEvent.click(nextBtn());
+  expect(title()).toBe('Make it yours');
+  const done = [...container.querySelectorAll('.tour--actions button')].find((b) => b.textContent === 'Done') as Element;
+  fireEvent.click(done);
+  expect(container.querySelector('[role="dialog"]')).toBeNull();
+  expect(container.querySelectorAll('.box-frame').length).toBe(1);
+  expect(loadTourState()).toEqual({ step : 'welcome', done : true });
+});
+
+test('the markdown detour loops back once its box is deleted', async () => {
+  window.localStorage.clear();
+  const { container } = render(<App />);
+  const nextBtn = () => [...container.querySelectorAll('.tour--actions button')].find((b) => b.textContent === 'Next') as Element;
+  const title = () => container.querySelector('.tour--title')?.textContent;
+
+  fireEvent.click(nextBtn());
+  fireEvent.click(container.querySelector('.create-box-plus') as Element);
+  expect(title()).toBe('Pick a box type');
+
+  // The detour: markdown explains itself, then teaches deletion.
+  fireEvent.click(container.querySelector('[title="Create new MarkDown box"]') as Element);
+  await waitFor(() => expect(title()).toBe('A Markdown box'));
+  fireEvent.click(nextBtn());
+  expect(title()).toBe('Delete a box');
+
+  // Next deletes through state; the watcher loops back to adding, easter
+  // egg intact: the user may circle here for as long as they like.
+  fireEvent.click(nextBtn());
+  await waitFor(() => expect(title()).toBe('Add a box'));
+  expect(container.querySelectorAll('.box-frame').length).toBe(0);
 });
 
 test('accent hover previews site-wide, click commits, popup stays open', () => {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -80,8 +80,10 @@ test('first load opens the guided tour, afterwards only the icon does', () => {
   const second = render(<App />);
   expect(second.container.querySelector('[role="dialog"]')).toBeNull();
   for (const step of TOUR_STEPS) {
-    if (step.target !== undefined) {
-      expect(second.container.querySelector(step.target), step.target).not.toBeNull();
+    for (const selector of [ step.target, step.advanceOn ]) {
+      if (selector !== undefined) {
+        expect(second.container.querySelector(selector), selector).not.toBeNull();
+      }
     }
   }
 
@@ -90,6 +92,26 @@ test('first load opens the guided tour, afterwards only the icon does', () => {
   expect(second.container.querySelector('.tour--title')?.textContent).toBe(TOUR_STEPS[2].title);
   expect(second.container.querySelectorAll('[data-box-key]').length).toBe(1);
   second.unmount();
+});
+
+test('the + step is live: clicking it advances, next chauffeurs it', () => {
+  window.localStorage.clear();
+  const { container } = render(<App />);
+  const nextBtn = () => [...container.querySelectorAll('.tour--actions button')].find((b) => b.textContent === 'Next') as Element;
+
+  // Walk to the + step, then operate the real control.
+  fireEvent.click(nextBtn());
+  expect(container.querySelector('.tour--title')?.textContent).toBe(TOUR_STEPS[1].title);
+  fireEvent.mouseDown(container.querySelector('.add_box_after') as Element);
+  expect(container.querySelector('.tour--title')?.textContent).toBe(TOUR_STEPS[2].title);
+
+  // Back up: chauffeur mode opens the real picker and walks on exactly once.
+  const backBtn = [...container.querySelectorAll('.tour--actions button')].find((b) => b.textContent === 'Back') as Element;
+  fireEvent.click(backBtn);
+  expect(container.querySelector('.tour--title')?.textContent).toBe(TOUR_STEPS[1].title);
+  fireEvent.click(nextBtn());
+  expect(container.querySelector('.tour--title')?.textContent).toBe(TOUR_STEPS[2].title);
+  expect(container.querySelector('.add-box--group')).not.toBeNull();
 });
 
 test('accent hover previews site-wide, click commits, popup stays open', () => {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -74,7 +74,7 @@ test('first load opens the guided tour, afterwards only the icon does', () => {
   const second = render(<App />);
   expect(second.container.querySelector('[role="dialog"]')).toBeNull();
   for (const step of TOUR_STEPS) {
-    if (step.needsBox === true) {
+    if (step.needsBox === true || step.needsPanel === true) {
       continue;
     }
     for (const selector of [ step.target, step.advanceOn ]) {
@@ -131,10 +131,12 @@ test('the tour conducts a lambda box from + to evaluated', async () => {
   await waitFor(() => expect(title()).toBe('Write and evaluate'));
   expect(container.querySelectorAll('.box-frame').length).toBe(1);
 
-  // Next does their typing and debugging; the evaluated box walks on.
+  // Next does their typing and debugging; the evaluated box walks on,
+  // and the ring sits on the Step button alone — never the whole box.
   fireEvent.click(nextBtn());
   await waitFor(() => expect(title()).toBe('Step through evaluation'));
   expect(container.querySelector('.box-history-wrap')).not.toBeNull();
+  expect(container.querySelector('.debug-controls--step')).not.toBeNull();
 
   // The box map rides the right edge: lines jump, arrows page.
   fireEvent.click(nextBtn());
@@ -165,16 +167,88 @@ test('the tour conducts a lambda box from + to evaluated', async () => {
   expect(title()).toBe('Macros');
   await waitFor(() => expect(container.querySelector('.macro-dock--open')).not.toBeNull());
   expect(container.querySelector('.box-settings')).toBeNull();
+
+  // Share one box rides with the box cluster, before the top-bar globals —
+  // and the demonstrated dock collapses on the way out, after its shut
+  // bridge plays out.
+  fireEvent.click(nextBtn());
+  expect(title()).toBe('Share one box');
+  expect(container.querySelector('[title="Copy the link to this Expression."]')).not.toBeNull();
+  await waitFor(() => expect(container.querySelector('.macro-dock--open')).toBeNull());
+
+  // Zen mode, conducted both ways: Next flips the real switch through
+  // state — and the demonstrated dock closes forgetfully with it, never
+  // obstructing the clean box nor springing back afterwards.
+  fireEvent.click(nextBtn());
+  expect(title()).toBe('Zen mode');
+  fireEvent.click(nextBtn());
+  expect(title()).toBe('Settle into zen');
+  fireEvent.click(nextBtn());
+  expect(title()).toBe('A clean slate');
+  expect(container.querySelector('.mainSpace.zen')).not.toBeNull();
+  // The demonstrated dock collapses with it — after its shut bridge
+  // plays out — remembered but never obstructing the clean box.
+  await waitFor(() => expect(container.querySelector('.macro-dock--open')).toBeNull());
+
+  // The middle finale only shows: the clearing options open with both
+  // exits, and nothing is pressed behind the user's back.
+  await waitFor(() => expect(container.querySelector('[title="Erase all notebooks and start over with the defaults"]')).not.toBeNull());
+  expect(container.querySelectorAll('.box-frame').length).toBe(1);
+
+  // The exits walk one by one, settings-cluster style — shown, never pressed.
+  fireEvent.click(nextBtn());
+  expect(title()).toBe('Clear notebook');
+  expect(container.querySelector('.top-bar--clear-btn:not(.btn-danger)')).not.toBeNull();
+  fireEvent.click(nextBtn());
+  expect(title()).toBe('Clean entire workspace');
+
+  // Yours opens themes; the finale then walks take-with-you and meta.
   fireEvent.click(nextBtn());
   expect(title()).toBe('Make it yours');
   await waitFor(() => expect(container.querySelector('.top-bar--accent-pick')).not.toBeNull());
 
-  // To the end: the box stays behind for them to keep.
+  // Themes get their own walks too: accent dots, then box-style tiles.
+  fireEvent.click(nextBtn());
+  expect(title()).toBe('Accent color');
+  fireEvent.click(nextBtn());
+  expect(title()).toBe('Box style');
+  expect(container.querySelector('.top-bar--boxpreview')).not.toBeNull();
+
+  // Export for persistent storage, import for sharing between people —
+  // and the themes panel steps out on the way in.
+  fireEvent.click(nextBtn());
+  expect(title()).toBe('Import and export');
+  expect(container.querySelector('.top-bar--accent-pick')).toBeNull();
+  expect(container.querySelector('[title="Download this Notebook"]')).not.toBeNull();
+
+  // The bug icon reports to the GitHub repo.
+  fireEvent.click(nextBtn());
+  expect(title()).toBe('Report a bug');
+  expect(container.querySelector('[title="Submit a bug or a feature request"]')).not.toBeNull();
+
+  // The walkme icon replays the tour — last step, Done finishes.
+  fireEvent.click(nextBtn());
+  expect(title()).toBe('Walk me again');
+  expect(container.querySelector('[title="Guided tour"]')).not.toBeNull();
+
+  // To the end: the box stays behind for them to keep, and the panels
+  // step out with the tour instead of lingering open.
   const done = [...container.querySelectorAll('.tour--actions button')].find((b) => b.textContent === 'Done') as Element;
   fireEvent.click(done);
   expect(container.querySelector('[role="dialog"]')).toBeNull();
+  expect(container.querySelector('.top-bar--settings-panel')).toBeNull();
   expect(container.querySelectorAll('.box-frame').length).toBe(1);
   expect(loadTourState()).toEqual({ step : 'welcome', done : true });
+
+  // Leaving zen restores nothing: entering forgot the demonstrated dock,
+  // so it stays shut on the way back out — and re-entering keeps it shut.
+  const zenSwitch = container.querySelector('.top-bar--zen') as Element;
+  fireEvent.click(zenSwitch);
+  expect(container.querySelector('.mainSpace.zen')).toBeNull();
+  expect(container.querySelector('.macro-dock--open')).toBeNull();
+  fireEvent.click(zenSwitch);
+  expect(container.querySelector('.mainSpace.zen')).not.toBeNull();
+  await waitFor(() => expect(container.querySelector('.macro-dock--open')).toBeNull());
 });
 
 async function walkToMdDelete (container : HTMLElement) : Promise<() => Element> {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -74,6 +74,9 @@ test('first load opens the guided tour, afterwards only the icon does', () => {
   const second = render(<App />);
   expect(second.container.querySelector('[role="dialog"]')).toBeNull();
   for (const step of TOUR_STEPS) {
+    if (step.needsBox === true) {
+      continue;
+    }
     for (const selector of [ step.target, step.advanceOn ]) {
       if (selector !== undefined) {
         expect(second.container.querySelector(selector), selector).not.toBeNull();
@@ -133,6 +136,11 @@ test('the tour conducts a lambda box from + to evaluated', async () => {
   await waitFor(() => expect(title()).toBe('Step through evaluation'));
   expect(container.querySelector('.box-history-wrap')).not.toBeNull();
 
+  // The box map rides the right edge: lines jump, arrows page.
+  fireEvent.click(nextBtn());
+  expect(title()).toBe('The box map');
+  expect(container.querySelector('.box-map')).not.toBeNull();
+
   // Settings get their own steps: the gear starts closed, Next opens it.
   fireEvent.click(nextBtn());
   expect(title()).toBe('Box settings');
@@ -152,10 +160,11 @@ test('the tour conducts a lambda box from + to evaluated', async () => {
   expect(title()).toBe('Evaluation Strategies');
   expect(container.querySelector('.untyped-lambda-settings-strategies')).not.toBeNull();
 
-  // Macros open themselves on arrival; the themes panel does too.
+  // Macros open themselves on arrival and close the settings behind us.
   fireEvent.click(nextBtn());
   expect(title()).toBe('Macros');
   await waitFor(() => expect(container.querySelector('.macro-dock--open')).not.toBeNull());
+  expect(container.querySelector('.box-settings')).toBeNull();
   fireEvent.click(nextBtn());
   expect(title()).toBe('Make it yours');
   await waitFor(() => expect(container.querySelector('.top-bar--accent-pick')).not.toBeNull());

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { test, expect } from 'vitest';
 import { render, fireEvent } from '@testing-library/react';
 import App from './App';
-import { createDefaultAppState, preferredTheme } from './Constants';
+import { createDefaultAppState, preferredTheme, saveTourState } from './Constants';
+import { TOUR_STEPS } from './components/Tour';
 import { defaultSettings, createNewUntypedLambdaExpression } from './untyped-lambda-integration/Constants';
 import { Theme } from './contexts/Theme';
 
@@ -56,6 +57,30 @@ test('app shell carries the box style hook', () => {
 
 test('new boxes start with settings closed', () => {
   expect(createNewUntypedLambdaExpression(defaultSettings).settingsOpen).toBe(false);
+});
+
+test('first load opens the guided tour, afterwards only the icon does', () => {
+  window.localStorage.clear();
+  const first = render(<App />);
+  expect(first.container.querySelector('[role="dialog"]')).not.toBeNull();
+  expect(first.container.querySelector('.tour--title')?.textContent).toBe(TOUR_STEPS[0].title);
+  first.unmount();
+
+  // Snoozed mid-tour: no auto-open, and every step target resolves
+  // in a fresh render so the tour cannot rot silently.
+  saveTourState({ step : 2, done : true });
+  const second = render(<App />);
+  expect(second.container.querySelector('[role="dialog"]')).toBeNull();
+  for (const step of TOUR_STEPS) {
+    if (step.target !== undefined) {
+      expect(second.container.querySelector(step.target), step.target).not.toBeNull();
+    }
+  }
+
+  // The icon resumes where the tour left off.
+  fireEvent.click(second.container.querySelector('[title="Guided tour"]') as HTMLElement);
+  expect(second.container.querySelector('.tour--title')?.textContent).toBe(TOUR_STEPS[2].title);
+  second.unmount();
 });
 
 test('accent hover previews site-wide, click commits, popup stays open', () => {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -79,6 +79,13 @@ test('first load opens the guided tour, afterwards only the icon does', () => {
         expect(second.container.querySelector(selector), selector).not.toBeNull();
       }
     }
+    // Tracked-box selectors resolve only against a live box (covered by
+    // the conducted walk below); here they must at least exist as hooks.
+    for (const selector of [ step.targetInTracked, step.advanceOnInTracked ]) {
+      if (selector !== undefined) {
+        expect(typeof selector, step.id).toBe('string');
+      }
+    }
   }
 
   // The icon resumes where the tour left off.
@@ -126,16 +133,86 @@ test('the tour conducts a lambda box from + to evaluated', async () => {
   await waitFor(() => expect(title()).toBe('Step through evaluation'));
   expect(container.querySelector('.box-history-wrap')).not.toBeNull();
 
-  // To the end: the box stays behind for them to keep.
+  // Settings get their own steps: the gear starts closed, Next opens it.
+  fireEvent.click(nextBtn());
+  expect(title()).toBe('Box settings');
+  expect(container.querySelector('.box-settings')).toBeNull();
+
+  fireEvent.click(nextBtn());
+  expect(title()).toBe('Single Letter Names');
+  expect(container.querySelector('.box-settings')).not.toBeNull();
+  expect(container.querySelector('.untyped-lambda-settings-SLI')).not.toBeNull();
+  fireEvent.click(nextBtn());
+  expect(title()).toBe('Simplified Evaluation');
+  expect(container.querySelector('.untyped-lambda-settings-SDE')).not.toBeNull();
+  fireEvent.click(nextBtn());
+  expect(title()).toBe('Collapse Old Steps');
+  expect(container.querySelector('.untyped-lambda-settings-collapse')).not.toBeNull();
+  fireEvent.click(nextBtn());
+  expect(title()).toBe('Evaluation Strategies');
+  expect(container.querySelector('.untyped-lambda-settings-strategies')).not.toBeNull();
+
+  // Macros open themselves on arrival; the themes panel does too.
   fireEvent.click(nextBtn());
   expect(title()).toBe('Macros');
+  await waitFor(() => expect(container.querySelector('.macro-dock--open')).not.toBeNull());
   fireEvent.click(nextBtn());
   expect(title()).toBe('Make it yours');
+  await waitFor(() => expect(container.querySelector('.top-bar--accent-pick')).not.toBeNull());
+
+  // To the end: the box stays behind for them to keep.
   const done = [...container.querySelectorAll('.tour--actions button')].find((b) => b.textContent === 'Done') as Element;
   fireEvent.click(done);
   expect(container.querySelector('[role="dialog"]')).toBeNull();
   expect(container.querySelectorAll('.box-frame').length).toBe(1);
   expect(loadTourState()).toEqual({ step : 'welcome', done : true });
+});
+
+async function walkToMdDelete (container : HTMLElement) : Promise<() => Element> {
+  const nextBtn = () => [...container.querySelectorAll('.tour--actions button')].find((b) => b.textContent === 'Next') as Element;
+  const title = () => container.querySelector('.tour--title')?.textContent;
+
+  fireEvent.click(nextBtn());
+  fireEvent.click(container.querySelector('.create-box-plus') as Element);
+  expect(title()).toBe('Pick a box type');
+  fireEvent.click(container.querySelector('[title="Create new MarkDown box"]') as Element);
+  await waitFor(() => expect(title()).toBe('A Markdown box'));
+  fireEvent.click(nextBtn());
+  await waitFor(() => expect(title()).toBe('Delete a box'));
+
+  return nextBtn;
+}
+
+test('deleting the markdown box on the delete step loops back at once', async () => {
+  window.localStorage.clear();
+  const { container } = render(<App />);
+  await walkToMdDelete(container);
+
+  const frame = container.querySelector('.box-frame:has(.markDownBox)') as HTMLElement;
+  expect(frame).not.toBeNull();
+  fireEvent.click(frame.querySelector('[title="Delete this Box from the Notebook"]') as HTMLElement);
+
+  await waitFor(() => expect(container.querySelector('.tour--title')?.textContent).toBe('Add a box'));
+  expect(container.querySelectorAll('.box-frame').length).toBe(0);
+});
+
+test('deleting early on the explainer loops back through next', async () => {
+  window.localStorage.clear();
+  const { container } = render(<App />);
+  const nextBtn = () => [...container.querySelectorAll('.tour--actions button')].find((b) => b.textContent === 'Next') as Element;
+  const title = () => container.querySelector('.tour--title')?.textContent;
+
+  fireEvent.click(nextBtn());
+  fireEvent.click(container.querySelector('.create-box-plus') as Element);
+  fireEvent.click(container.querySelector('[title="Create new MarkDown box"]') as Element);
+  await waitFor(() => expect(title()).toBe('A Markdown box'));
+
+  const frame = container.querySelector('.box-frame:has(.markDownBox)') as HTMLElement;
+  fireEvent.click(frame.querySelector('[title="Delete this Box from the Notebook"]') as HTMLElement);
+  fireEvent.click(nextBtn());
+
+  await waitFor(() => expect(title()).toBe('Add a box'));
+  expect(container.querySelectorAll('.box-frame').length).toBe(0);
 });
 
 test('the markdown detour loops back once its box is deleted', async () => {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { test, expect } from 'vitest';
 import { render, fireEvent } from '@testing-library/react';
 import App from './App';
-import { createDefaultAppState, preferredTheme, saveTourState } from './Constants';
+import { createDefaultAppState, preferredTheme, saveTourState, loadTourState } from './Constants';
 import { TOUR_STEPS } from './components/Tour';
 import { defaultSettings, createNewUntypedLambdaExpression } from './untyped-lambda-integration/Constants';
 import { Theme } from './contexts/Theme';
@@ -64,11 +64,19 @@ test('first load opens the guided tour, afterwards only the icon does', () => {
   const first = render(<App />);
   expect(first.container.querySelector('[role="dialog"]')).not.toBeNull();
   expect(first.container.querySelector('.tour--title')?.textContent).toBe(TOUR_STEPS[0].title);
+
+  // The tour seeds exactly one evaluated demo box and remembers its key.
+  const demoBoxes = first.container.querySelectorAll('[data-box-key]');
+  expect(demoBoxes.length).toBe(1);
+  const stored = loadTourState();
+  expect(stored?.seeded).toBe(true);
+  expect(stored?.demoBoxKey).toBe(demoBoxes[0].getAttribute('data-box-key'));
+  expect(first.container.querySelector('.untypedLambdaBox')).not.toBeNull();
   first.unmount();
 
   // Snoozed mid-tour: no auto-open, and every step target resolves
   // in a fresh render so the tour cannot rot silently.
-  saveTourState({ step : 2, done : true });
+  saveTourState({ step : 2, done : true, seeded : true, demoBoxKey : stored?.demoBoxKey ?? null });
   const second = render(<App />);
   expect(second.container.querySelector('[role="dialog"]')).toBeNull();
   for (const step of TOUR_STEPS) {
@@ -77,9 +85,10 @@ test('first load opens the guided tour, afterwards only the icon does', () => {
     }
   }
 
-  // The icon resumes where the tour left off.
+  // The icon resumes where the tour left off — without a second demo box.
   fireEvent.click(second.container.querySelector('[title="Guided tour"]') as HTMLElement);
   expect(second.container.querySelector('.tour--title')?.textContent).toBe(TOUR_STEPS[2].title);
+  expect(second.container.querySelectorAll('[data-box-key]').length).toBe(1);
   second.unmount();
 });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import  { loadAppStateFromStorage
         , updateAppStateToStorage
         , updateNotebookStateToStorage
         , loadTourState
+        , saveTourState
         , CLEAR_NOTEBOOK_CONFIRMATION
         , RESET_WORKSPACE_CONFIRMATION
         , createEmptyNotebook
@@ -59,10 +60,46 @@ export default class App extends Component<{}, AppState> {
   }
 
   private tourOpen : boolean
+  private demoBoxKey : string | null = null
 
   openTour () : void {
+    this.seedDemoBox()
     this.tourOpen = true
     this.forceUpdate()
+  }
+
+  // The tour shows, not just tells: opening it seeds one evaluated demo box
+  // into the active notebook (once ever — relaunches never duplicate it,
+  // and deleting it is respected). Locked notebooks take no new boxes, so
+  // a Manual-active tour simply opens ringless.
+  seedDemoBox () : void {
+    const stored = loadTourState()
+    this.demoBoxKey = stored?.demoBoxKey ?? null
+
+    if (stored?.seeded === true) {
+      return
+    }
+
+    const { notebooks, activeNotebookIndex } = this.state
+    const notebook : NotebookState | undefined = notebooks[activeNotebookIndex]
+
+    if (notebook === undefined || notebook.locked === true) {
+      return
+    }
+
+    try {
+      const settings = notebook.settings[UNTYPED_LAMBDA_CODE_NAME] as UntypedLambdaSettings | undefined
+      const demo = createNewUntypedLambdaBoxFromSource('(λ x . x y) a', settings ?? defaultSettings, UntypedLambdaType.ORDINARY, {})
+      this.demoBoxKey = demo.__key
+      this.updateNotebook({
+        boxList : [ ...notebook.boxList, demo ],
+        activeBoxIndex : notebook.boxList.length,
+      })
+      saveTourState({ step : stored?.step ?? 0, done : false, seeded : true, demoBoxKey : demo.__key })
+    }
+    catch (e) {
+      console.error(`Demo box seeding failed, opening the tour anyway.\n\n${e}`)
+    }
   }
 
   closeTour () : void {
@@ -71,7 +108,15 @@ export default class App extends Component<{}, AppState> {
   }
 
   componentDidMount () : void {
-    this.createNotebookFromURL()
+    const shared : boolean = this.createNotebookFromURL()
+
+    // First-run auto-open seeds the demo box too (the icon path seeds
+    // inside openTour; the constructor cannot setState for it). A shared
+    // link already delivers its own box — and its setState is still queued,
+    // so seeding here would read stale state and clobber it.
+    if (this.tourOpen && !shared) {
+      this.seedDemoBox()
+    }
   }
 
   // TODO: all of this needs to be moved to more apropriate component
@@ -79,12 +124,13 @@ export default class App extends Component<{}, AppState> {
   // I don't think it should get moved to the component, standalone helper function would be OK
   // OR -> split it --> there will be very simple top level abstraction implementation
   // and according the type of the BOX - specific Integration Module will handle the actual deserialization
-  createNotebookFromURL () {
+  // true when a shared-link notebook was installed (and its setState queued).
+  createNotebookFromURL () : boolean {
     const urlSearchParams : URLSearchParams = new URL(window.location.toString()).searchParams
     const type : string | null = urlSearchParams.get('type')
 
     if (type === null) {
-      return
+      return false
     }
 
     switch (type) {
@@ -97,7 +143,7 @@ export default class App extends Component<{}, AppState> {
         const SLI : string | null = urlSearchParams.get('SLI')
         
         if (source === null || macros == null || subtype === null || strategy === null || SDE === null || SLI === null) {
-          return
+          return false
         }
 
         const strat : EvaluationStrategy = EvaluationStrategy.NORMAL === strategy ? EvaluationStrategy.NORMAL : EvaluationStrategy.APPLICATIVE
@@ -136,9 +182,12 @@ export default class App extends Component<{}, AppState> {
             notebooks,
             activeNotebookIndex : notebooks.length - 1,
           })
+
+          return true
         }
         catch (ex) {
           window.history.replaceState(null, '', '/') // TODO: decide if remove or leave
+          return false
         }
       }
       break
@@ -146,6 +195,8 @@ export default class App extends Component<{}, AppState> {
       default:
         break;
     }
+
+    return false
   }
 
   // Hover previews of accent theme and box style: transient pointer state,
@@ -207,7 +258,11 @@ export default class App extends Component<{}, AppState> {
 
             {
               this.tourOpen ?
-                <Tour initialStep={ loadTourState()?.step ?? 0 } onClose={ this.closeTour } />
+                <Tour
+                  initialStep={ loadTourState()?.step ?? 0 }
+                  demoBoxKey={ this.demoBoxKey }
+                  onClose={ this.closeTour }
+                />
               :
                 null
             }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,6 @@ import  { loadAppStateFromStorage
         , updateAppStateToStorage
         , updateNotebookStateToStorage
         , loadTourState
-        , saveTourState
         , CLEAR_NOTEBOOK_CONFIRMATION
         , RESET_WORKSPACE_CONFIRMATION
         , createEmptyNotebook
@@ -18,7 +17,7 @@ import TopBar from './components/TopBar'
 import Tour from './components/Tour'
 import Notebook from './screens/Notebook'
 import { Accent, BoxStyle, AppState, NotebookState, GlobalSettings, BoxType, BoxState } from './Types'
-import { CODE_NAME as UNTYPED_LAMBDA_CODE_NAME, createNewUntypedLambdaBoxFromSource, defaultSettings } from './untyped-lambda-integration/Constants'
+import { CODE_NAME as UNTYPED_LAMBDA_CODE_NAME, createNewUntypedLambdaBoxFromSource, createNewUntypedLambdaExpression, defaultSettings } from './untyped-lambda-integration/Constants'
 import { UntypedLambdaState, UntypedLambdaSettings, EvaluationStrategy, UntypedLambdaType } from './untyped-lambda-integration/Types'
 import { MacroTable } from '@lambdulus/core'
 import { Theme, ThemeContext } from './contexts/Theme'
@@ -52,6 +51,9 @@ export default class App extends Component<{}, AppState> {
     this.createNotebookFromURL = this.createNotebookFromURL.bind(this)
     this.openTour = this.openTour.bind(this)
     this.closeTour = this.closeTour.bind(this)
+    this.addTourLambdaBox = this.addTourLambdaBox.bind(this)
+    this.fillTourBoxEditor = this.fillTourBoxEditor.bind(this)
+    this.deleteTourBox = this.deleteTourBox.bind(this)
 
     // First load ever opens the guided tour; afterwards only the top-bar
     // icon opens it, resuming the saved step. Transient UI state, same as
@@ -60,46 +62,10 @@ export default class App extends Component<{}, AppState> {
   }
 
   private tourOpen : boolean
-  private demoBoxKey : string | null = null
 
   openTour () : void {
-    this.seedDemoBox()
     this.tourOpen = true
     this.forceUpdate()
-  }
-
-  // The tour shows, not just tells: opening it seeds one evaluated demo box
-  // into the active notebook (once ever — relaunches never duplicate it,
-  // and deleting it is respected). Locked notebooks take no new boxes, so
-  // a Manual-active tour simply opens ringless.
-  seedDemoBox () : void {
-    const stored = loadTourState()
-    this.demoBoxKey = stored?.demoBoxKey ?? null
-
-    if (stored?.seeded === true) {
-      return
-    }
-
-    const { notebooks, activeNotebookIndex } = this.state
-    const notebook : NotebookState | undefined = notebooks[activeNotebookIndex]
-
-    if (notebook === undefined || notebook.locked === true) {
-      return
-    }
-
-    try {
-      const settings = notebook.settings[UNTYPED_LAMBDA_CODE_NAME] as UntypedLambdaSettings | undefined
-      const demo = createNewUntypedLambdaBoxFromSource('(λ x . x y) a', settings ?? defaultSettings, UntypedLambdaType.ORDINARY, {})
-      this.demoBoxKey = demo.__key
-      this.updateNotebook({
-        boxList : [ ...notebook.boxList, demo ],
-        activeBoxIndex : notebook.boxList.length,
-      })
-      saveTourState({ step : stored?.step ?? 0, done : false, seeded : true, demoBoxKey : demo.__key })
-    }
-    catch (e) {
-      console.error(`Demo box seeding failed, opening the tour anyway.\n\n${e}`)
-    }
   }
 
   closeTour () : void {
@@ -107,16 +73,72 @@ export default class App extends Component<{}, AppState> {
     this.forceUpdate()
   }
 
-  componentDidMount () : void {
-    const shared : boolean = this.createNotebookFromURL()
+  // Tour chauffeur callbacks: the tour conducts box creation, filling and
+  // deletion through the same state path as the real UI, so chauffeured
+  // boxes are indistinguishable from hand-made ones.
+  tourSettings () : UntypedLambdaSettings | null {
+    const notebook : NotebookState | undefined = this.state.notebooks[this.state.activeNotebookIndex]
 
-    // First-run auto-open seeds the demo box too (the icon path seeds
-    // inside openTour; the constructor cannot setState for it). A shared
-    // link already delivers its own box — and its setState is still queued,
-    // so seeding here would read stale state and clobber it.
-    if (this.tourOpen && !shared) {
-      this.seedDemoBox()
+    if (notebook === undefined || notebook.locked === true) {
+      return null
     }
+
+    return (notebook.settings[UNTYPED_LAMBDA_CODE_NAME] as UntypedLambdaSettings | undefined) ?? defaultSettings
+  }
+
+  // An empty λ box in the active notebook; null when locked or missing.
+  addTourLambdaBox () : string | null {
+    const settings : UntypedLambdaSettings | null = this.tourSettings()
+
+    if (settings === null) {
+      return null
+    }
+
+    const { notebooks, activeNotebookIndex } = this.state
+    const box : UntypedLambdaState = createNewUntypedLambdaExpression(settings)
+    const boxList : Array<BoxState> = [ ...notebooks[activeNotebookIndex].boxList, box ]
+    this.updateNotebook({ boxList, activeBoxIndex : boxList.length - 1 })
+
+    return box.__key
+  }
+
+  fillTourBoxEditor (boxKey : string, content : string) : void {
+    const { notebooks, activeNotebookIndex } = this.state
+    const boxList : Array<BoxState> = notebooks[activeNotebookIndex].boxList.map((box : BoxState) =>
+      box.__key === boxKey && box.type === BoxType.UNTYPED_LAMBDA ?
+        { ...(box as UntypedLambdaState), editor : { ...(box as UntypedLambdaState).editor, content, syntaxError : null } }
+      :
+        box
+    )
+    this.updateNotebook({ boxList })
+  }
+
+  // Same nearest-valid-index rule as the notebook's own removeBox.
+  deleteTourBox (boxKey : string) : void {
+    const { notebooks, activeNotebookIndex } = this.state
+    const boxList : Array<BoxState> = notebooks[activeNotebookIndex].boxList
+    const index : number = boxList.findIndex((box : BoxState) => box.__key === boxKey)
+
+    if (index === -1) {
+      return
+    }
+
+    const nearestValidIndex = (i : number) => {
+      if (i < activeNotebookIndex) return activeNotebookIndex - 1
+      if (i > activeNotebookIndex) return activeNotebookIndex
+      if (boxList.length === 1) return NaN
+      if (i === 0) return i
+      return i - 1
+    }
+
+    this.updateNotebook({
+      boxList : boxList.filter((box : BoxState) => box.__key !== boxKey),
+      activeBoxIndex : nearestValidIndex(index),
+    })
+  }
+
+  componentDidMount () : void {
+    this.createNotebookFromURL()
   }
 
   // TODO: all of this needs to be moved to more apropriate component
@@ -259,9 +281,11 @@ export default class App extends Component<{}, AppState> {
             {
               this.tourOpen ?
                 <Tour
-                  initialStep={ loadTourState()?.step ?? 0 }
-                  demoBoxKey={ this.demoBoxKey }
+                  initialStep={ loadTourState()?.step ?? 'welcome' }
                   onClose={ this.closeTour }
+                  onAddLambdaBox={ this.addTourLambdaBox }
+                  onFillBoxEditor={ this.fillTourBoxEditor }
+                  onDeleteBox={ this.deleteTourBox }
                 />
               :
                 null

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,7 @@ import { uniqueKey } from './uniqueKey'
 
 import TopBar from './components/TopBar'
 import Tour from './components/Tour'
-import Notebook from './screens/Notebook'
+import Notebook, { syncDocksToFocus } from './screens/Notebook'
 import { Accent, BoxStyle, AppState, NotebookState, GlobalSettings, BoxType, BoxState } from './Types'
 import { CODE_NAME as UNTYPED_LAMBDA_CODE_NAME, createNewUntypedLambdaBoxFromSource, createNewUntypedLambdaExpression, defaultSettings } from './untyped-lambda-integration/Constants'
 import { UntypedLambdaState, UntypedLambdaSettings, EvaluationStrategy, UntypedLambdaType } from './untyped-lambda-integration/Types'
@@ -55,7 +55,10 @@ export default class App extends Component<{}, AppState> {
     this.fillTourBoxEditor = this.fillTourBoxEditor.bind(this)
     this.setTourBoxSettings = this.setTourBoxSettings.bind(this)
     this.showTourBoxMacros = this.showTourBoxMacros.bind(this)
+    this.hideTourBoxMacros = this.hideTourBoxMacros.bind(this)
     this.deleteTourBox = this.deleteTourBox.bind(this)
+    this.setZenMode = this.setZenMode.bind(this)
+    this.setTourZenMode = this.setTourZenMode.bind(this)
 
     // First load ever opens the guided tour; afterwards only the top-bar
     // icon opens it, resuming the saved step. Transient UI state, same as
@@ -129,6 +132,21 @@ export default class App extends Component<{}, AppState> {
     this.updateNotebook({ boxList })
   }
 
+  // The macros step demonstrates the dock, then steps out of the way:
+  // leaving for share collapses the display while the want survives —
+  // Back re-opens it on arrival, zen entry forgets it right after — so
+  // the next step never starts obstructed.
+  hideTourBoxMacros (boxKey : string) : void {
+    const { notebooks, activeNotebookIndex } = this.state
+    const boxList : Array<BoxState> = notebooks[activeNotebookIndex].boxList.map((box : BoxState) =>
+      box.__key === boxKey && box.type === BoxType.UNTYPED_LAMBDA ?
+        { ...(box as UntypedLambdaState), macrolistOpen : false }
+      :
+        box
+    )
+    this.updateNotebook({ boxList })
+  }
+
   // Atomic panel handoff for the macros step: one commit closes settings
   // and opens the dock, so two toggles can never resurrect each other's
   // stale key through the box replace. Setting values, not toggling, so
@@ -137,11 +155,37 @@ export default class App extends Component<{}, AppState> {
     const { notebooks, activeNotebookIndex } = this.state
     const boxList : Array<BoxState> = notebooks[activeNotebookIndex].boxList.map((box : BoxState) =>
       box.__key === boxKey && box.type === BoxType.UNTYPED_LAMBDA ?
-        { ...(box as UntypedLambdaState), settingsOpen : false, macrolistOpen : true }
+        { ...(box as UntypedLambdaState), settingsOpen : false, macrolistOpen : true, macrolistWanted : true }
       :
         box
     )
     this.updateNotebook({ boxList })
+  }
+
+  // One zen road for the switch and the tour: entering closes every macro
+  // table FORGETFULLY — the want is cleared, not just collapsed — so
+  // nothing springs back open on the way back out. A dock demonstrated
+  // mid-tour stays shut after the finale; a dock opened mid-zen still
+  // restores on leaving, and focus memory across box switches (which
+  // never passes through here) is untouched.
+  setZenMode (zenMode : boolean) : void {
+    const { boxList, focusedBoxIndex, activeBoxIndex } = this.state.notebooks[this.state.activeNotebookIndex]
+    const entered : Array<BoxState> = zenMode ? boxList.map((box : BoxState) =>
+      box.type === BoxType.UNTYPED_LAMBDA ?
+        { ...(box as UntypedLambdaState), macrolistOpen : false, macrolistWanted : false }
+      :
+        box
+    ) : boxList
+    this.updateNotebook({
+      zenMode,
+      boxList : syncDocksToFocus(entered, zenMode ? null : (focusedBoxIndex ?? activeBoxIndex), zenMode),
+    })
+  }
+
+  // Explicit zen value for the finale steps: setting, never toggling,
+  // so an already-zen notebook simply stays zen.
+  setTourZenMode (zenMode : boolean) : void {
+    this.setZenMode(zenMode)
   }
 
   // Same nearest-valid-index rule as the notebook's own removeBox.
@@ -303,7 +347,7 @@ export default class App extends Component<{}, AppState> {
               onResetWorkspace={ this.resetWorkspace }
               onDarkModeChange={ this.toggleTheme }
               onSettingsChange={ this.updateSettings }
-              onZenModeChange={ (zenMode : boolean) => this.updateNotebook({ zenMode }) }
+              onZenModeChange={ this.setZenMode }
               onTourOpen={ this.openTour }
             />
 
@@ -318,7 +362,9 @@ export default class App extends Component<{}, AppState> {
                   onFillBoxEditor={ this.fillTourBoxEditor }
                   onSetBoxSettings={ this.setTourBoxSettings }
                   onShowBoxMacros={ this.showTourBoxMacros }
+                  onHideBoxMacros={ this.hideTourBoxMacros }
                   onDeleteBox={ this.deleteTourBox }
+                  onSetZenMode={ this.setTourZenMode }
                 />
               :
                 null

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import './App.css'
 import  { loadAppStateFromStorage
         , updateAppStateToStorage
         , updateNotebookStateToStorage
+        , loadTourState
         , CLEAR_NOTEBOOK_CONFIRMATION
         , RESET_WORKSPACE_CONFIRMATION
         , createEmptyNotebook
@@ -13,6 +14,7 @@ import  { loadAppStateFromStorage
 import { uniqueKey } from './uniqueKey'
 
 import TopBar from './components/TopBar'
+import Tour from './components/Tour'
 import Notebook from './screens/Notebook'
 import { Accent, BoxStyle, AppState, NotebookState, GlobalSettings, BoxType, BoxState } from './Types'
 import { CODE_NAME as UNTYPED_LAMBDA_CODE_NAME, createNewUntypedLambdaBoxFromSource, defaultSettings } from './untyped-lambda-integration/Constants'
@@ -47,6 +49,25 @@ export default class App extends Component<{}, AppState> {
     this.removeNotebook = this.removeNotebook.bind(this)
 
     this.createNotebookFromURL = this.createNotebookFromURL.bind(this)
+    this.openTour = this.openTour.bind(this)
+    this.closeTour = this.closeTour.bind(this)
+
+    // First load ever opens the guided tour; afterwards only the top-bar
+    // icon opens it, resuming the saved step. Transient UI state, same as
+    // the accent previews below — never part of AppState.
+    this.tourOpen = loadTourState() === null
+  }
+
+  private tourOpen : boolean
+
+  openTour () : void {
+    this.tourOpen = true
+    this.forceUpdate()
+  }
+
+  closeTour () : void {
+    this.tourOpen = false
+    this.forceUpdate()
   }
 
   componentDidMount () : void {
@@ -179,9 +200,17 @@ export default class App extends Component<{}, AppState> {
               onDarkModeChange={ this.toggleTheme }
               onSettingsChange={ this.updateSettings }
               onZenModeChange={ (zenMode : boolean) => this.updateNotebook({ zenMode }) }
+              onTourOpen={ this.openTour }
             />
 
             <Notebook state={ notebook } updateNotebook={ this.updateNotebook } />
+
+            {
+              this.tourOpen ?
+                <Tour initialStep={ loadTourState()?.step ?? 0 } onClose={ this.closeTour } />
+              :
+                null
+            }
           </div>
 
         </SettingsContext.Provider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -53,6 +53,8 @@ export default class App extends Component<{}, AppState> {
     this.closeTour = this.closeTour.bind(this)
     this.addTourLambdaBox = this.addTourLambdaBox.bind(this)
     this.fillTourBoxEditor = this.fillTourBoxEditor.bind(this)
+    this.setTourBoxSettings = this.setTourBoxSettings.bind(this)
+    this.showTourBoxMacros = this.showTourBoxMacros.bind(this)
     this.deleteTourBox = this.deleteTourBox.bind(this)
 
     // First load ever opens the guided tour; afterwards only the top-bar
@@ -107,6 +109,35 @@ export default class App extends Component<{}, AppState> {
     const boxList : Array<BoxState> = notebooks[activeNotebookIndex].boxList.map((box : BoxState) =>
       box.__key === boxKey && box.type === BoxType.UNTYPED_LAMBDA ?
         { ...(box as UntypedLambdaState), editor : { ...(box as UntypedLambdaState).editor, content, syntaxError : null } }
+      :
+        box
+    )
+    this.updateNotebook({ boxList })
+  }
+
+  // Explicit settings value through fresh store state: the title-bar gear
+  // is a render-closure toggle, so working it programmatically would read
+  // stale props whenever the bar skipped a render.
+  setTourBoxSettings (boxKey : string, open : boolean) : void {
+    const { notebooks, activeNotebookIndex } = this.state
+    const boxList : Array<BoxState> = notebooks[activeNotebookIndex].boxList.map((box : BoxState) =>
+      box.__key === boxKey && box.type === BoxType.UNTYPED_LAMBDA ?
+        { ...(box as UntypedLambdaState), settingsOpen : open }
+      :
+        box
+    )
+    this.updateNotebook({ boxList })
+  }
+
+  // Atomic panel handoff for the macros step: one commit closes settings
+  // and opens the dock, so two toggles can never resurrect each other's
+  // stale key through the box replace. Setting values, not toggling, so
+  // an already-open dock simply stays open.
+  showTourBoxMacros (boxKey : string) : void {
+    const { notebooks, activeNotebookIndex } = this.state
+    const boxList : Array<BoxState> = notebooks[activeNotebookIndex].boxList.map((box : BoxState) =>
+      box.__key === boxKey && box.type === BoxType.UNTYPED_LAMBDA ?
+        { ...(box as UntypedLambdaState), settingsOpen : false, macrolistOpen : true }
       :
         box
     )
@@ -285,6 +316,8 @@ export default class App extends Component<{}, AppState> {
                   onClose={ this.closeTour }
                   onAddLambdaBox={ this.addTourLambdaBox }
                   onFillBoxEditor={ this.fillTourBoxEditor }
+                  onSetBoxSettings={ this.setTourBoxSettings }
+                  onShowBoxMacros={ this.showTourBoxMacros }
                   onDeleteBox={ this.deleteTourBox }
                 />
               :

--- a/src/Constants.test.ts
+++ b/src/Constants.test.ts
@@ -35,13 +35,20 @@ beforeEach(() => window.localStorage.removeItem('LambdulusTour'));
 
 test('tour storage starts empty, round-trips, rejects garbage', () => {
   expect(loadTourState()).toBeNull();
-  expect(defaultTourState()).toEqual({ step : 0, done : false });
+  expect(defaultTourState()).toEqual({ step : 0, done : false, seeded : false, demoBoxKey : null });
 
-  saveTourState({ step : 3, done : false });
-  expect(loadTourState()).toEqual({ step : 3, done : false });
+  saveTourState({ step : 3, done : false, seeded : true, demoBoxKey : 'k1' });
+  expect(loadTourState()).toEqual({ step : 3, done : false, seeded : true, demoBoxKey : 'k1' });
 
-  saveTourState({ step : 0, done : true });
-  expect(loadTourState()).toEqual({ step : 0, done : true });
+  saveTourState({ step : 0, done : true, seeded : false, demoBoxKey : null });
+  expect(loadTourState()).toEqual({ step : 0, done : true, seeded : false, demoBoxKey : null });
+
+  // Pre-seeded-flag keys (none in the wild yet, but be tolerant).
+  window.localStorage.setItem('LambdulusTour', JSON.stringify({ step : 2, done : true }));
+  expect(loadTourState()).toEqual({ step : 2, done : true, seeded : false, demoBoxKey : null });
+
+  window.localStorage.setItem('LambdulusTour', JSON.stringify({ step : 2, done : true, seeded : true, demoBoxKey : 7 }));
+  expect(loadTourState()).toEqual({ step : 2, done : true, seeded : true, demoBoxKey : null });
 
   window.localStorage.setItem('LambdulusTour', 'not-json{');
   expect(loadTourState()).toBeNull();

--- a/src/Constants.test.ts
+++ b/src/Constants.test.ts
@@ -1,0 +1,32 @@
+import { test, expect } from 'vitest';
+import { decodeNotebook } from './Constants';
+import { CODE_NAME as UNTYPED_CODE_NAME } from './untyped-lambda-integration/Constants';
+import { EvaluationStrategy } from './untyped-lambda-integration/Types';
+import { NotebookState } from './Types';
+
+function legacyNotebook (settings : unknown) : NotebookState {
+  return { name : 'Old', boxList : [], settings } as unknown as NotebookState;
+}
+
+function untypedOf (notebook : NotebookState) : { strategy : unknown; SLI : unknown; SDE : unknown } {
+  return notebook.settings[UNTYPED_CODE_NAME] as unknown as { strategy : unknown; SLI : unknown; SDE : unknown };
+}
+
+test('decode backfills settings for pre-settings notebooks', () => {
+  // Regression: years-old stored notebooks carry no settings key, so every
+  // box created from them got strategy/SLI/SDE undefined and no submitted
+  // expression would ever evaluate ("Something is wrong...").
+  const untyped = untypedOf(decodeNotebook(legacyNotebook(undefined)));
+  expect(untyped.strategy).toBe(EvaluationStrategy.NORMAL);
+  expect(untyped.SLI).toBe(true);
+  expect(untyped.SDE).toBe(true);
+});
+
+test('decode keeps stored settings, filling only the gaps', () => {
+  const untyped = untypedOf(decodeNotebook(legacyNotebook({
+    [UNTYPED_CODE_NAME] : { strategy : EvaluationStrategy.APPLICATIVE },
+  })));
+  expect(untyped.strategy).toBe(EvaluationStrategy.APPLICATIVE);
+  expect(untyped.SLI).toBe(true);
+  expect(untyped.SDE).toBe(true);
+});

--- a/src/Constants.test.ts
+++ b/src/Constants.test.ts
@@ -35,27 +35,23 @@ beforeEach(() => window.localStorage.removeItem('LambdulusTour'));
 
 test('tour storage starts empty, round-trips, rejects garbage', () => {
   expect(loadTourState()).toBeNull();
-  expect(defaultTourState()).toEqual({ step : 0, done : false, seeded : false, demoBoxKey : null });
+  expect(defaultTourState()).toEqual({ step : 'welcome', done : false });
 
-  saveTourState({ step : 3, done : false, seeded : true, demoBoxKey : 'k1' });
-  expect(loadTourState()).toEqual({ step : 3, done : false, seeded : true, demoBoxKey : 'k1' });
+  saveTourState({ step : 'type', done : false });
+  expect(loadTourState()).toEqual({ step : 'type', done : false });
 
-  saveTourState({ step : 0, done : true, seeded : false, demoBoxKey : null });
-  expect(loadTourState()).toEqual({ step : 0, done : true, seeded : false, demoBoxKey : null });
-
-  // Pre-seeded-flag keys (none in the wild yet, but be tolerant).
-  window.localStorage.setItem('LambdulusTour', JSON.stringify({ step : 2, done : true }));
-  expect(loadTourState()).toEqual({ step : 2, done : true, seeded : false, demoBoxKey : null });
-
-  window.localStorage.setItem('LambdulusTour', JSON.stringify({ step : 2, done : true, seeded : true, demoBoxKey : 7 }));
-  expect(loadTourState()).toEqual({ step : 2, done : true, seeded : true, demoBoxKey : null });
+  saveTourState({ step : 'welcome', done : true });
+  expect(loadTourState()).toEqual({ step : 'welcome', done : true });
 
   window.localStorage.setItem('LambdulusTour', 'not-json{');
   expect(loadTourState()).toBeNull();
 
-  window.localStorage.setItem('LambdulusTour', JSON.stringify({ step : 'two', done : 'yes' }));
+  window.localStorage.setItem('LambdulusTour', 'not-json{');
   expect(loadTourState()).toBeNull();
 
-  window.localStorage.setItem('LambdulusTour', JSON.stringify({ step : -1, done : false }));
+  window.localStorage.setItem('LambdulusTour', JSON.stringify({ step : 2, done : false }));
+  expect(loadTourState()).toBeNull();
+
+  window.localStorage.setItem('LambdulusTour', JSON.stringify({ step : '', done : true }));
   expect(loadTourState()).toBeNull();
 });

--- a/src/Constants.test.ts
+++ b/src/Constants.test.ts
@@ -1,5 +1,5 @@
-import { test, expect } from 'vitest';
-import { decodeNotebook } from './Constants';
+import { test, expect, beforeEach } from 'vitest';
+import { decodeNotebook, loadTourState, saveTourState, defaultTourState } from './Constants';
 import { CODE_NAME as UNTYPED_CODE_NAME } from './untyped-lambda-integration/Constants';
 import { EvaluationStrategy } from './untyped-lambda-integration/Types';
 import { NotebookState } from './Types';
@@ -29,4 +29,26 @@ test('decode keeps stored settings, filling only the gaps', () => {
   expect(untyped.strategy).toBe(EvaluationStrategy.APPLICATIVE);
   expect(untyped.SLI).toBe(true);
   expect(untyped.SDE).toBe(true);
+});
+
+beforeEach(() => window.localStorage.removeItem('LambdulusTour'));
+
+test('tour storage starts empty, round-trips, rejects garbage', () => {
+  expect(loadTourState()).toBeNull();
+  expect(defaultTourState()).toEqual({ step : 0, done : false });
+
+  saveTourState({ step : 3, done : false });
+  expect(loadTourState()).toEqual({ step : 3, done : false });
+
+  saveTourState({ step : 0, done : true });
+  expect(loadTourState()).toEqual({ step : 0, done : true });
+
+  window.localStorage.setItem('LambdulusTour', 'not-json{');
+  expect(loadTourState()).toBeNull();
+
+  window.localStorage.setItem('LambdulusTour', JSON.stringify({ step : 'two', done : 'yes' }));
+  expect(loadTourState()).toBeNull();
+
+  window.localStorage.setItem('LambdulusTour', JSON.stringify({ step : -1, done : false }));
+  expect(loadTourState()).toBeNull();
 });

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -216,10 +216,35 @@ export function decodeNotebook (notebook : NotebookState) : NotebookState | neve
     readOnly : box.readOnly === true,
   }))
 
+  // Notebooks persisted before per-notebook settings existed (or with a
+  // partial settings object) would otherwise hand undefined strategy/SLI/SDE
+  // to every box created from them, and no submitted expression would ever
+  // evaluate — strategyToEvaluator would get undefined and `new undefined()`
+  // throws. Backfill so old notebooks behave like fresh ones.
+  const storedSettings : GlobalSettings =
+    typeof notebook.settings === 'object' && notebook.settings !== null ?
+      notebook.settings
+    :
+      {}
+  const storedUntyped : object =
+    typeof storedSettings[UNTYPED_CODE_NAME] === 'object' && storedSettings[UNTYPED_CODE_NAME] !== null ?
+      storedSettings[UNTYPED_CODE_NAME] as unknown as object
+    :
+      {}
+  const settings : GlobalSettings = {
+    ...createDefaultSettings(),
+    ...storedSettings,
+    [UNTYPED_CODE_NAME] : {
+      ...UntypedLambdaDefaultSettings,
+      ...storedUntyped,
+    },
+  }
+
   return {
     ...notebook,
     name : typeof notebook.name === 'string' && notebook.name.length > 0 ? notebook.name : 'Notebook',
     locked,
     boxList : normalizedBoxes,
+    settings,
   }
 }

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -148,12 +148,18 @@ export function updateNotebookStateToStorage (index : number, notebook : Noteboo
 export interface TourState {
   step : number
   done : boolean
+  // Whether the tour already seeded its demo box. One box ever: relaunching
+  // never duplicates it, and deleting it is respected (no resurrection).
+  seeded : boolean
+  // __key of the demo box, so relaunches (even after a reload) can still
+  // ring it. A deleted box simply leaves step two ringless.
+  demoBoxKey : string | null
 }
 
 const TOUR_KEY = 'LambdulusTour'
 
 export function defaultTourState () : TourState {
-  return { step : 0, done : false }
+  return { step : 0, done : false, seeded : false, demoBoxKey : null }
 }
 
 // null means never started (or unreadable): first load opens the tour.
@@ -171,7 +177,13 @@ export function loadTourState () : TourState | null {
         && typeof (parsed as TourState).step === 'number'
         && (parsed as TourState).step >= 0
         && typeof (parsed as TourState).done === 'boolean') {
-      return { step : Math.floor((parsed as TourState).step), done : (parsed as TourState).done }
+      const demoBoxKey : unknown = (parsed as TourState).demoBoxKey
+      return {
+        step : Math.floor((parsed as TourState).step),
+        done : (parsed as TourState).done,
+        seeded : (parsed as TourState).seeded === true,
+        demoBoxKey : typeof demoBoxKey === 'string' ? demoBoxKey : null,
+      }
     }
   }
   catch (e) {

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -142,6 +142,49 @@ export function updateNotebookStateToStorage (index : number, notebook : Noteboo
   updateAppStateToStorage(state)
 }
 
+// Guided-tour progress, kept outside AppState on purpose: the tour is
+// transient UI onboarding, not workspace data, and must survive workspace
+// resets (clearing notebooks must not resurrect the tour).
+export interface TourState {
+  step : number
+  done : boolean
+}
+
+const TOUR_KEY = 'LambdulusTour'
+
+export function defaultTourState () : TourState {
+  return { step : 0, done : false }
+}
+
+// null means never started (or unreadable): first load opens the tour.
+export function loadTourState () : TourState | null {
+  const raw : string | null = localStorage.getItem(TOUR_KEY)
+
+  if (raw === null) {
+    return null
+  }
+
+  try {
+    const parsed : unknown = JSON.parse(raw)
+
+    if (typeof parsed === 'object' && parsed !== null
+        && typeof (parsed as TourState).step === 'number'
+        && (parsed as TourState).step >= 0
+        && typeof (parsed as TourState).done === 'boolean') {
+      return { step : Math.floor((parsed as TourState).step), done : (parsed as TourState).done }
+    }
+  }
+  catch (e) {
+    console.error(`Error while loading tour state from the storage.\n\n${e}`)
+  }
+
+  return null
+}
+
+export function saveTourState (state : TourState) : void {
+  localStorage.setItem(TOUR_KEY, JSON.stringify(state))
+}
+
 // TODO: This function is going to be replaced with correct implementation of decoding
 // this slowly becomes better and better base for the final implementation
 /**

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -144,22 +144,18 @@ export function updateNotebookStateToStorage (index : number, notebook : Noteboo
 
 // Guided-tour progress, kept outside AppState on purpose: the tour is
 // transient UI onboarding, not workspace data, and must survive workspace
-// resets (clearing notebooks must not resurrect the tour).
+// resets (clearing notebooks must not resurrect the tour). Steps are string
+// ids — the tour branches (markdown detour loops back), so numbers cannot
+// address them.
 export interface TourState {
-  step : number
+  step : string
   done : boolean
-  // Whether the tour already seeded its demo box. One box ever: relaunching
-  // never duplicates it, and deleting it is respected (no resurrection).
-  seeded : boolean
-  // __key of the demo box, so relaunches (even after a reload) can still
-  // ring it. A deleted box simply leaves step two ringless.
-  demoBoxKey : string | null
 }
 
 const TOUR_KEY = 'LambdulusTour'
 
 export function defaultTourState () : TourState {
-  return { step : 0, done : false, seeded : false, demoBoxKey : null }
+  return { step : 'welcome', done : false }
 }
 
 // null means never started (or unreadable): first load opens the tour.
@@ -174,16 +170,10 @@ export function loadTourState () : TourState | null {
     const parsed : unknown = JSON.parse(raw)
 
     if (typeof parsed === 'object' && parsed !== null
-        && typeof (parsed as TourState).step === 'number'
-        && (parsed as TourState).step >= 0
+        && typeof (parsed as TourState).step === 'string'
+        && (parsed as TourState).step.length > 0
         && typeof (parsed as TourState).done === 'boolean') {
-      const demoBoxKey : unknown = (parsed as TourState).demoBoxKey
-      return {
-        step : Math.floor((parsed as TourState).step),
-        done : (parsed as TourState).done,
-        seeded : (parsed as TourState).seeded === true,
-        demoBoxKey : typeof demoBoxKey === 'string' ? demoBoxKey : null,
-      }
+      return { step : (parsed as TourState).step, done : (parsed as TourState).done }
     }
   }
   catch (e) {

--- a/src/components/BoxContainer.tsx
+++ b/src/components/BoxContainer.tsx
@@ -105,7 +105,10 @@ export class BoxContainer extends Component<Props, State> {
   
     return (
       <div ref={ this.rootRef }>
-        <div className={ `box-frame${ isFocusedBox ? ' box-frame--focused' : '' }${ isAnchorBox ? ' box-frame--anchor' : '' }` }>
+        <div
+          className={ `box-frame${ isFocusedBox ? ' box-frame--focused' : '' }${ isAnchorBox ? ' box-frame--anchor' : '' }` }
+          data-box-key={ box.__key }
+        >
           <div
             className="box-rail"
             title="Focus this box"

--- a/src/components/TopBar.test.tsx
+++ b/src/components/TopBar.test.tsx
@@ -180,6 +180,16 @@ test('dismissing the popup drops any preview with it', () => {
   expect(container.querySelector('.top-bar--accent-pick')).toBeNull();
 });
 
+test('the global settings panel closes on outside click too', () => {
+  const { container } = render(<TopBar { ...baseProps(() => void 0) } />);
+
+  fireEvent.click(container.querySelector('[title="Notebook settings"]') as HTMLElement);
+  expect(container.querySelector('.top-bar--settings-panel')).not.toBeNull();
+
+  fireEvent.click(container.querySelector('.top-bar--backdrop') as HTMLElement);
+  expect(container.querySelector('.top-bar--settings-panel')).toBeNull();
+});
+
 test('hovering a box tile previews it, leaving the row falls back', () => {
   const onBoxStylePreview = vi.fn();
   const { container } = render(

--- a/src/components/TopBar.test.tsx
+++ b/src/components/TopBar.test.tsx
@@ -42,6 +42,7 @@ function baseProps (onZenModeChange : (zenMode : boolean) => void) {
     onDarkModeChange : () => void 0,
     onSettingsChange : () => void 0,
     onZenModeChange,
+    onTourOpen : () => void 0,
   };
 }
 
@@ -217,6 +218,18 @@ test('keyboard focus previews the box tile, tabbing out falls back', () => {
   fireEvent.focus(radios[0]);
   fireEvent.blur(radios[0], { relatedTarget : document.body });
   expect(onBoxStylePreview).toHaveBeenLastCalledWith(null);
+});
+
+test('tour icon opens the tour and parks any open panel', () => {
+  const onTourOpen = vi.fn();
+  const { container } = render(<TopBar { ...baseProps(() => void 0) } onTourOpen={ onTourOpen } />);
+
+  fireEvent.click(container.querySelector('[title="Accent theme"]') as HTMLElement);
+  expect(container.querySelector('.top-bar--accent-pick')).not.toBeNull();
+
+  fireEvent.click(container.querySelector('[title="Guided tour"]') as HTMLElement);
+  expect(onTourOpen).toHaveBeenCalledTimes(1);
+  expect(container.querySelector('.top-bar--accent-pick')).toBeNull();
 });
 
 test('box style is picked by preview tiles acting as radios', () => {

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,5 +1,5 @@
 import React, { ChangeEvent, useEffect, useMemo, useRef, useState } from 'react'
-import { Bug, Download, Eraser, Focus, Lock, Moon, Palette, Plus, Settings as SettingsIcon, Sun, Upload, X } from 'lucide-react'
+import { Bug, Download, Eraser, Focus, Footprints, Lock, Moon, Palette, Plus, Settings as SettingsIcon, Sun, Upload, X } from 'lucide-react'
 
 import { Accent, BoxStyle, GlobalSettings, NotebookState } from '../Types'
 
@@ -34,6 +34,7 @@ interface Props {
   onDarkModeChange () : void
   onSettingsChange (settings : GlobalSettings) : void
   onZenModeChange (zenMode : boolean) : void
+  onTourOpen () : void
 }
 
 export default function TopBar (props : Props) : JSX.Element {
@@ -57,6 +58,7 @@ export default function TopBar (props : Props) : JSX.Element {
     onDarkModeChange,
     onSettingsChange,
     onZenModeChange,
+    onTourOpen,
   } : Props = props
 
   // A single open panel: switching icons swaps popovers in one click
@@ -209,6 +211,17 @@ export default function TopBar (props : Props) : JSX.Element {
             onClick={ () => togglePanel('themes') }
           >
             <Palette size={ 17 } strokeWidth={ 1.75 } />
+          </button>
+
+          <button
+            className='top-bar--action'
+            title='Guided tour'
+            onClick={ () => {
+              setOpenPanel(null)
+              onTourOpen()
+            } }
+          >
+            <Footprints size={ 17 } strokeWidth={ 1.75 } />
           </button>
 
           <a

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -10,6 +10,7 @@ import UntypedLambdaCalculusSet from '../untyped-lambda-integration/Settings'
 import {
   CODE_NAME as UNTYPED_CODE_NAME,
   GLOBAL_SETTINGS_ENABLER as UNTYPED_GLOBAL_SETTINGS_ENABLER,
+  defaultSettings as UNTYPED_DEFAULT_SETTINGS,
 } from '../untyped-lambda-integration/Constants'
 import { UntypedLambdaSettings } from '../untyped-lambda-integration/Types'
 
@@ -99,7 +100,9 @@ export default function TopBar (props : Props) : JSX.Element {
   const link : string = useMemo(() => createURL(serialized), [ serialized ])
   const fileName : string = `${ notebook.name.replace(/[^\w\- ]+/g, '').trim() || 'notebook' }.lus`
 
-  const untypedSettings : UntypedLambdaSettings = settings[UNTYPED_CODE_NAME] as UntypedLambdaSettings
+  // Settings-less notebooks (years-old storage) fall back to the defaults
+  // instead of crashing the panel open, same as the box picker modal.
+  const untypedSettings : UntypedLambdaSettings = (settings[UNTYPED_CODE_NAME] as UntypedLambdaSettings | undefined) ?? UNTYPED_DEFAULT_SETTINGS
 
   return (
     <div className='top-bar'>

--- a/src/components/Tour.test.tsx
+++ b/src/components/Tour.test.tsx
@@ -210,6 +210,26 @@ test('the markdown detour loops back once the box is gone', async () => {
   await waitFor(() => expect(titleOf(container)).toBe('Add a box'));
 });
 
+test('the delete step rings the trash button, not the whole box', async () => {
+  const { container } = render(<Tour { ...props({ initialStep : 'pick' }) } />);
+  const frame = plantFrame(container, 'markDownBox', 'k-md');
+  const trash = document.createElement('div');
+  trash.setAttribute('title', 'Delete this Box from the Notebook');
+  trash.getBoundingClientRect = () => ({ x : 20, y : 10, top : 10, left : 20, right : 36, bottom : 26, width : 16, height : 16, toJSON : () => ({}) }) as DOMRect;
+  frame.appendChild(trash);
+  await waitFor(() => expect(titleOf(container)).toBe('A Markdown box'));
+
+  fireEvent.click(nextBtn(container));
+  expect(titleOf(container)).toBe('Delete a box');
+
+  // The ring seats on the 16px trash button with a 6px margin, not the frame.
+  const ring = container.querySelector('.tour--ring') as HTMLElement;
+  expect(ring).not.toBeNull();
+  expect(ring.style.top).toBe('4px');
+  expect(ring.style.left).toBe('14px');
+  expect(ring.style.width).toBe('28px');
+});
+
 test('pick next prefers the open picker, falling back to state', () => {
   const onPick = vi.fn();
   const onAddLambdaBox = vi.fn(() => 'k-fallback');

--- a/src/components/Tour.test.tsx
+++ b/src/components/Tour.test.tsx
@@ -1,71 +1,103 @@
 import { test, expect, vi, afterEach, beforeEach } from 'vitest';
-import { render, fireEvent, cleanup } from '@testing-library/react';
+import { render, fireEvent, cleanup, waitFor } from '@testing-library/react';
 import Tour, { TOUR_STEPS } from './Tour';
 import { loadTourState } from '../Constants';
 
 afterEach(() => cleanup());
 beforeEach(() => window.localStorage.removeItem('LambdulusTour'));
 
-function buttons (container : Element) : Record<string, Element | null> {
-  const all = [...container.querySelectorAll('.tour--actions button')];
-  const byText = (text : string) => all.find((b) => b.textContent === text) ?? null;
-  return { back : byText('Back'), skip : byText('Skip'), next : byText('Next'), done : byText('Done') };
+interface TourCallbacks {
+  onClose : () => void
+  onAddLambdaBox : () => string | null
+  onFillBoxEditor : (boxKey : string, content : string) => void
+  onDeleteBox : (boxKey : string) => void
 }
 
-test('tour walks forward and back, persisting each step', () => {
+function props (over : Partial<{ initialStep : string } & TourCallbacks> = {}) {
+  return {
+    initialStep : 'welcome',
+    onClose : () => void 0,
+    onAddLambdaBox : () => null,
+    onFillBoxEditor : () => void 0,
+    onDeleteBox : () => void 0,
+    ...over,
+  };
+}
+
+function titleOf (container : HTMLElement) : string | null | undefined {
+  return container.querySelector('.tour--title')?.textContent;
+}
+
+function nextBtn (container : HTMLElement) : Element {
+  return [...container.querySelectorAll('.tour--actions button')].find((b) => b.textContent === 'Next') as Element;
+}
+
+function plantFrame (container : HTMLElement, boxClass : string, key : string) : Element {
+  const frame = document.createElement('div');
+  frame.className = 'box-frame';
+  frame.setAttribute('data-box-key', key);
+  const inner = document.createElement('div');
+  inner.className = boxClass;
+  frame.appendChild(inner);
+  container.appendChild(frame);
+
+  return frame;
+}
+
+test('tour walks the main path, persisting each step id', () => {
   const onClose = vi.fn();
-  const { container } = render(<Tour initialStep={ 0 } demoBoxKey={ null } onClose={ onClose } />);
+  const { container } = render(<Tour { ...props({ onClose }) } />);
 
-  expect(container.querySelector('.tour--title')?.textContent).toBe(TOUR_STEPS[0].title);
-  expect(container.querySelector('.tour--kicker')?.textContent).toContain('1 of 6');
+  expect(titleOf(container)).toBe('Welcome to Lambdulus');
 
-  fireEvent.click(buttons(container).next as HTMLElement);
-  expect(container.querySelector('.tour--title')?.textContent).toBe(TOUR_STEPS[1].title);
-  expect(loadTourState()).toEqual({ step : 1, done : false, seeded : false, demoBoxKey : null });
-
-  fireEvent.click(buttons(container).back as HTMLElement);
-  expect(container.querySelector('.tour--title')?.textContent).toBe(TOUR_STEPS[0].title);
-  expect(loadTourState()).toEqual({ step : 0, done : false, seeded : false, demoBoxKey : null });
+  fireEvent.click(nextBtn(container));
+  expect(titleOf(container)).toBe('Add a box');
+  expect(loadTourState()).toEqual({ step : 'add', done : false });
   expect(onClose).not.toHaveBeenCalled();
 });
 
-test('skip snoozes at the current step, done restarts from zero', () => {
-  const onClose = vi.fn();
-  const { container, unmount } = render(<Tour initialStep={ 2 } demoBoxKey={ null } onClose={ onClose } />);
-  expect(container.querySelector('.tour--kicker')?.textContent).toContain('3 of 6');
+test('back follows the branch map', () => {
+  const { container } = render(<Tour { ...props({ initialStep : 'macros' }) } />);
+  const back = [...container.querySelectorAll('.tour--actions button')].find((b) => b.textContent === 'Back') as Element;
+  fireEvent.click(back);
+  expect(titleOf(container)).toBe('Step through evaluation');
+});
 
-  fireEvent.click(buttons(container).skip as HTMLElement);
+test('unknown initial step lands on welcome', () => {
+  const { container } = render(<Tour { ...props({ initialStep : 'bogus' }) } />);
+  expect(titleOf(container)).toBe('Welcome to Lambdulus');
+});
+
+test('a type step without its box loops back to adding', async () => {
+  // Reloads forget the tracked element by design: never touch a stranger.
+  const { container } = render(<Tour { ...props({ initialStep : 'type' }) } />);
+  await waitFor(() => expect(titleOf(container)).toBe('Add a box'));
+  expect(loadTourState()).toEqual({ step : 'add', done : false });
+});
+
+test('skip snoozes with the id, done restarts from welcome', () => {
+  const onClose = vi.fn();
+  const { container, unmount } = render(<Tour { ...props({ initialStep : 'macros', onClose }) } />);
+  const skip = [...container.querySelectorAll('.tour--actions button')].find((b) => b.textContent === 'Skip') as Element;
+  fireEvent.click(skip);
   expect(onClose).toHaveBeenCalledTimes(1);
-  expect(loadTourState()).toEqual({ step : 2, done : true, seeded : false, demoBoxKey : null });
+  expect(loadTourState()).toEqual({ step : 'macros', done : true });
   unmount();
 
   const onClose2 = vi.fn();
-  const second = render(<Tour initialStep={ 5 } demoBoxKey={ null } onClose={ onClose2 } />);
-  expect(second.container.querySelector('.tour--kicker')?.textContent).toContain('6 of 6');
-  expect(buttons(second.container).next).toBeNull();
-  fireEvent.click(buttons(second.container).done as HTMLElement);
+  const second = render(<Tour { ...props({ initialStep : 'yours', onClose : onClose2 }) } />);
+  const done = [...second.container.querySelectorAll('.tour--actions button')].find((b) => b.textContent === 'Done') as Element;
+  fireEvent.click(done);
   expect(onClose2).toHaveBeenCalledTimes(1);
-  expect(loadTourState()).toEqual({ step : 0, done : true, seeded : false, demoBoxKey : null });
+  expect(loadTourState()).toEqual({ step : 'welcome', done : true });
 });
 
 test('backdrop click snoozes like skip', () => {
   const onClose = vi.fn();
-  const { container } = render(<Tour initialStep={ 1 } demoBoxKey={ null } onClose={ onClose } />);
-  fireEvent.click(container.querySelector('.tour--backdrop') as HTMLElement);
+  const { container } = render(<Tour { ...props({ initialStep : 'add', onClose }) } />);
+  fireEvent.click(container.querySelector('.tour--backdrop') as Element);
   expect(onClose).toHaveBeenCalledTimes(1);
-  expect(loadTourState()).toEqual({ step : 1, done : true, seeded : false, demoBoxKey : null });
-});
-
-test('out-of-range initial step clamps into the tour', () => {
-  const { container } = render(<Tour initialStep={ 99 } demoBoxKey={ null } onClose={ () => void 0 } />);
-  expect(container.querySelector('.tour--kicker')?.textContent).toContain('6 of 6');
-});
-
-test('missing targets never break the card', () => {
-  // jsdom rects are zero-sized, so no ring — but the card stands alone.
-  const { container } = render(<Tour initialStep={ 0 } demoBoxKey={ null } onClose={ () => void 0 } />);
-  expect(container.querySelector('.tour--ring')).toBeNull();
-  expect(container.querySelector('[role="dialog"]')).not.toBeNull();
+  expect(loadTourState()).toEqual({ step : 'add', done : true });
 });
 
 test('operating the + control advances just like next', () => {
@@ -73,15 +105,15 @@ test('operating the + control advances just like next', () => {
   const { container } = render(
     <div>
       <div className='add_box_after' onMouseDown={ onPlus } />
-      <Tour initialStep={ 1 } demoBoxKey={ null } onClose={ () => void 0 } />
+      <Tour { ...props({ initialStep : 'add' }) } />
     </div>
   );
 
   expect(container.querySelector('.tour')?.classList.contains('tour--interactive')).toBe(true);
   fireEvent.mouseDown(container.querySelector('.add_box_after') as Element);
   expect(onPlus).toHaveBeenCalledTimes(1);
-  expect(container.querySelector('.tour--title')?.textContent).toBe(TOUR_STEPS[2].title);
-  expect(loadTourState()).toEqual({ step : 2, done : false, seeded : false, demoBoxKey : null });
+  expect(titleOf(container)).toBe('Pick a box type');
+  expect(loadTourState()).toEqual({ step : 'pick', done : false });
   expect(container.querySelector('.tour')?.classList.contains('tour--interactive')).toBe(false);
 });
 
@@ -90,28 +122,118 @@ test('next on the + step works the control, advancing exactly once', () => {
   const { container } = render(
     <div>
       <div className='add_box_after' onMouseDown={ onPlus } />
-      <Tour initialStep={ 1 } demoBoxKey={ null } onClose={ () => void 0 } />
+      <Tour { ...props({ initialStep : 'add' }) } />
     </div>
   );
 
-  const next = [...container.querySelectorAll('.tour--actions button')].find((b) => b.textContent === 'Next') as Element;
-  fireEvent.click(next);
+  fireEvent.click(nextBtn(container));
   // Chauffeur mode: the control got its mousedown, the flagged events did
   // not re-advance, and we walked on exactly once.
   expect(onPlus).toHaveBeenCalledTimes(1);
-  expect(container.querySelector('.tour--title')?.textContent).toBe(TOUR_STEPS[2].title);
-  expect(loadTourState()).toEqual({ step : 2, done : false, seeded : false, demoBoxKey : null });
+  expect(titleOf(container)).toBe('Pick a box type');
+  expect(loadTourState()).toEqual({ step : 'pick', done : false });
 });
 
-test('the stepping step points at the demo box when its key is known', () => {
+test('a new lambda box routes pick to the typing step', async () => {
+  const { container } = render(<Tour { ...props({ initialStep : 'pick' }) } />);
+  expect(titleOf(container)).toBe('Pick a box type');
+
+  plantFrame(container, 'untypedLambdaBox', 'k-lambda');
+  await waitFor(() => expect(titleOf(container)).toBe('Write and evaluate'));
+  expect(loadTourState()).toEqual({ step : 'type', done : false });
+});
+
+test('a new markdown box routes pick to the detour', async () => {
+  const { container } = render(<Tour { ...props({ initialStep : 'pick' }) } />);
+
+  plantFrame(container, 'markDownBox', 'k-md');
+  await waitFor(() => expect(titleOf(container)).toBe('A Markdown box'));
+  expect(loadTourState()).toEqual({ step : 'md-explain', done : false });
+});
+
+test('an evaluated box advances typing to stepping', async () => {
+  const { container } = render(<Tour { ...props({ initialStep : 'pick' }) } />);
+  const frame = plantFrame(container, 'untypedLambdaBox', 'k-lambda');
+  await waitFor(() => expect(titleOf(container)).toBe('Write and evaluate'));
+
+  const evaluated = document.createElement('div');
+  evaluated.className = 'box-history-wrap';
+  frame.appendChild(evaluated);
+  await waitFor(() => expect(titleOf(container)).toBe('Step through evaluation'));
+  expect(loadTourState()).toEqual({ step : 'stepping', done : false });
+});
+
+test('a deleted box loops back to adding', async () => {
+  const { container } = render(<Tour { ...props({ initialStep : 'pick' }) } />);
+  const frame = plantFrame(container, 'untypedLambdaBox', 'k-lambda');
+  await waitFor(() => expect(titleOf(container)).toBe('Write and evaluate'));
+
+  frame.remove();
+  await waitFor(() => expect(titleOf(container)).toBe('Add a box'));
+  expect(loadTourState()).toEqual({ step : 'add', done : false });
+});
+
+test('the markdown detour loops back once the box is gone', async () => {
+  const onDeleteBox = vi.fn();
+  const { container } = render(<Tour { ...props({ initialStep : 'pick', onDeleteBox }) } />);
+  const frame = plantFrame(container, 'markDownBox', 'k-md');
+  await waitFor(() => expect(titleOf(container)).toBe('A Markdown box'));
+
+  // Through the explainer to the delete step, then chauffeur the deletion.
+  fireEvent.click(nextBtn(container));
+  expect(titleOf(container)).toBe('Delete a box');
+  fireEvent.click(nextBtn(container));
+  expect(onDeleteBox).toHaveBeenCalledWith('k-md');
+
+  // The watcher sees the real removal and loops back to adding.
+  frame.remove();
+  await waitFor(() => expect(titleOf(container)).toBe('Add a box'));
+});
+
+test('pick next prefers the open picker, falling back to state', () => {
+  const onPick = vi.fn();
+  const onAddLambdaBox = vi.fn(() => 'k-fallback');
   const { container } = render(
     <div>
-      <div data-box-key='demo-1' />
-      <Tour initialStep={ 3 } demoBoxKey='demo-1' onClose={ () => void 0 } />
+      <div title='Create new λ box' onClick={ onPick } />
+      <Tour { ...props({ initialStep : 'pick', onAddLambdaBox }) } />
     </div>
   );
-  // The ring itself needs real layout, but the step resolved its target:
-  // with an unknown key the same step stays ringless by construction.
-  expect(container.querySelector('[data-box-key="demo-1"]')).not.toBeNull();
-  expect(container.querySelector('.tour--title')?.textContent).toBe(TOUR_STEPS[3].title);
+
+  fireEvent.click(nextBtn(container));
+  expect(onPick).toHaveBeenCalledTimes(1);
+  expect(onAddLambdaBox).not.toHaveBeenCalled();
+  // No box appeared, so the tour correctly stays put.
+  expect(titleOf(container)).toBe('Pick a box type');
+});
+
+test('pick next without a modal creates the box through state', () => {
+  const onAddLambdaBox = vi.fn(() => 'k-fallback');
+  const { container } = render(<Tour { ...props({ initialStep : 'pick', onAddLambdaBox }) } />);
+
+  fireEvent.click(nextBtn(container));
+  expect(onAddLambdaBox).toHaveBeenCalledTimes(1);
+});
+
+test('type next fills the editor and submits for them', () => {
+  const onFillBoxEditor = vi.fn();
+  const { container } = render(<Tour { ...props({ initialStep : 'pick', onFillBoxEditor }) } />);
+  const frame = plantFrame(container, 'untypedLambdaBox', 'k-lambda');
+  const debug = document.createElement('button');
+  debug.className = 'open-as-debug';
+  const submitted : Array<string> = [];
+  debug.addEventListener('click', () => submitted.push('debug'));
+  frame.appendChild(debug);
+
+  return waitFor(() => expect(titleOf(container)).toBe('Write and evaluate')).then(() => {
+    fireEvent.click(nextBtn(container));
+    expect(onFillBoxEditor).toHaveBeenCalledWith('k-lambda', '(λ x . x y) a');
+    expect(submitted).toEqual([ 'debug' ]);
+  });
+});
+
+test('the tour ids stay addressable', () => {
+  expect(TOUR_STEPS.map((s) => s.id)).toEqual([
+    'welcome', 'add', 'pick', 'type', 'stepping', 'macros', 'yours', 'md-explain', 'md-delete',
+  ]);
 });

--- a/src/components/Tour.test.tsx
+++ b/src/components/Tour.test.tsx
@@ -68,15 +68,50 @@ test('missing targets never break the card', () => {
   expect(container.querySelector('[role="dialog"]')).not.toBeNull();
 });
 
-test('step two points at the demo box when its key is known', () => {
+test('operating the + control advances just like next', () => {
+  const onPlus = vi.fn();
+  const { container } = render(
+    <div>
+      <div className='add_box_after' onMouseDown={ onPlus } />
+      <Tour initialStep={ 1 } demoBoxKey={ null } onClose={ () => void 0 } />
+    </div>
+  );
+
+  expect(container.querySelector('.tour')?.classList.contains('tour--interactive')).toBe(true);
+  fireEvent.mouseDown(container.querySelector('.add_box_after') as Element);
+  expect(onPlus).toHaveBeenCalledTimes(1);
+  expect(container.querySelector('.tour--title')?.textContent).toBe(TOUR_STEPS[2].title);
+  expect(loadTourState()).toEqual({ step : 2, done : false, seeded : false, demoBoxKey : null });
+  expect(container.querySelector('.tour')?.classList.contains('tour--interactive')).toBe(false);
+});
+
+test('next on the + step works the control, advancing exactly once', () => {
+  const onPlus = vi.fn();
+  const { container } = render(
+    <div>
+      <div className='add_box_after' onMouseDown={ onPlus } />
+      <Tour initialStep={ 1 } demoBoxKey={ null } onClose={ () => void 0 } />
+    </div>
+  );
+
+  const next = [...container.querySelectorAll('.tour--actions button')].find((b) => b.textContent === 'Next') as Element;
+  fireEvent.click(next);
+  // Chauffeur mode: the control got its mousedown, the flagged events did
+  // not re-advance, and we walked on exactly once.
+  expect(onPlus).toHaveBeenCalledTimes(1);
+  expect(container.querySelector('.tour--title')?.textContent).toBe(TOUR_STEPS[2].title);
+  expect(loadTourState()).toEqual({ step : 2, done : false, seeded : false, demoBoxKey : null });
+});
+
+test('the stepping step points at the demo box when its key is known', () => {
   const { container } = render(
     <div>
       <div data-box-key='demo-1' />
-      <Tour initialStep={ 1 } demoBoxKey='demo-1' onClose={ () => void 0 } />
+      <Tour initialStep={ 3 } demoBoxKey='demo-1' onClose={ () => void 0 } />
     </div>
   );
   // The ring itself needs real layout, but the step resolved its target:
   // with an unknown key the same step stays ringless by construction.
   expect(container.querySelector('[data-box-key="demo-1"]')).not.toBeNull();
-  expect(container.querySelector('.tour--title')?.textContent).toBe(TOUR_STEPS[1].title);
+  expect(container.querySelector('.tour--title')?.textContent).toBe(TOUR_STEPS[3].title);
 });

--- a/src/components/Tour.test.tsx
+++ b/src/components/Tour.test.tsx
@@ -92,12 +92,22 @@ test('skip snoozes with the id, done restarts from welcome', () => {
   expect(loadTourState()).toEqual({ step : 'welcome', done : true });
 });
 
-test('backdrop click snoozes like skip', () => {
+test('backdrop click snoozes like skip on blocking steps', () => {
   const onClose = vi.fn();
-  const { container } = render(<Tour { ...props({ initialStep : 'add', onClose }) } />);
+  const { container } = render(<Tour { ...props({ initialStep : 'welcome', onClose }) } />);
   fireEvent.click(container.querySelector('.tour--backdrop') as Element);
   expect(onClose).toHaveBeenCalledTimes(1);
-  expect(loadTourState()).toEqual({ step : 'add', done : true });
+  expect(loadTourState()).toEqual({ step : 'welcome', done : true });
+});
+
+test('working steps go click-through, reading steps stay blocking', () => {
+  const live = render(<Tour { ...props({ initialStep : 'type' }) } />);
+  expect(live.container.querySelector('.tour')?.classList.contains('tour--live')).toBe(true);
+  live.unmount();
+
+  const blocking = render(<Tour { ...props({ initialStep : 'yours' }) } />);
+  expect(blocking.container.querySelector('.tour')?.classList.contains('tour--live')).toBe(false);
+  blocking.unmount();
 });
 
 test('operating the + control advances just like next', () => {
@@ -109,12 +119,13 @@ test('operating the + control advances just like next', () => {
     </div>
   );
 
-  expect(container.querySelector('.tour')?.classList.contains('tour--interactive')).toBe(true);
+  expect(container.querySelector('.tour')?.classList.contains('tour--live')).toBe(true);
   fireEvent.mouseDown(container.querySelector('.add_box_after') as Element);
   expect(onPlus).toHaveBeenCalledTimes(1);
   expect(titleOf(container)).toBe('Pick a box type');
   expect(loadTourState()).toEqual({ step : 'pick', done : false });
-  expect(container.querySelector('.tour')?.classList.contains('tour--interactive')).toBe(false);
+  // The pick step stays live: its modal must remain operable.
+  expect(container.querySelector('.tour')?.classList.contains('tour--live')).toBe(true);
 });
 
 test('next on the + step works the control, advancing exactly once', () => {

--- a/src/components/Tour.test.tsx
+++ b/src/components/Tour.test.tsx
@@ -10,6 +10,8 @@ interface TourCallbacks {
   onClose : () => void
   onAddLambdaBox : () => string | null
   onFillBoxEditor : (boxKey : string, content : string) => void
+  onSetBoxSettings : (boxKey : string, open : boolean) => void
+  onShowBoxMacros : (boxKey : string) => void
   onDeleteBox : (boxKey : string) => void
 }
 
@@ -19,6 +21,8 @@ function props (over : Partial<{ initialStep : string } & TourCallbacks> = {}) {
     onClose : () => void 0,
     onAddLambdaBox : () => null,
     onFillBoxEditor : () => void 0,
+    onSetBoxSettings : () => void 0,
+    onShowBoxMacros : () => void 0,
     onDeleteBox : () => void 0,
     ...over,
   };
@@ -241,7 +245,7 @@ test('type next fills the editor and submits for them', () => {
 
 test('the tour ids stay addressable', () => {
   expect(TOUR_STEPS.map((s) => s.id)).toEqual([
-    'welcome', 'add', 'pick', 'type', 'stepping',
+    'welcome', 'add', 'pick', 'type', 'stepping', 'boxmap',
     'settings', 'set-sli', 'set-sde', 'set-collapse', 'set-strategy',
     'macros', 'yours', 'md-explain', 'md-delete',
   ]);
@@ -257,26 +261,27 @@ test('deleting early on the explainer loops back at once', async () => {
   expect(loadTourState()).toEqual({ step : 'add', done : false });
 });
 
-test('settings next opens the real gear and walks each switch', async () => {
-  const { container } = render(<Tour { ...props({ initialStep : 'pick' }) } />);
-  const frame = plantFrame(container, 'untypedLambdaBox', 'k-lambda');
-  const gear = document.createElement('div');
-  gear.setAttribute('title', 'Open this Boxs\' settings');
-  const opened : Array<string> = [];
-  gear.addEventListener('click', () => opened.push('gear'));
-  frame.appendChild(gear);
+test('settings next opens the panel through state and walks each switch', async () => {
+  const onSetBoxSettings = vi.fn();
+  const onShowBoxMacros = vi.fn();
+  const { container } = render(<Tour { ...props({ initialStep : 'pick', onSetBoxSettings, onShowBoxMacros }) } />);
+  plantFrame(container, 'untypedLambdaBox', 'k-lambda');
   await waitFor(() => expect(titleOf(container)).toBe('Write and evaluate'));
 
   const evaluated = document.createElement('div');
   evaluated.className = 'box-history-wrap';
-  frame.appendChild(evaluated);
+  container.querySelector('.box-frame')?.appendChild(evaluated);
   await waitFor(() => expect(titleOf(container)).toBe('Step through evaluation'));
+
+  fireEvent.click(nextBtn(container));
+  expect(titleOf(container)).toBe('The box map');
 
   fireEvent.click(nextBtn(container));
   expect(titleOf(container)).toBe('Box settings');
 
+  // Explicit value through state, never the render-closure toggle.
   fireEvent.click(nextBtn(container));
-  expect(opened).toEqual([ 'gear' ]);
+  expect(onSetBoxSettings).toHaveBeenCalledWith('k-lambda', true);
   expect(titleOf(container)).toBe('Single Letter Names');
 
   for (const title of [ 'Simplified Evaluation', 'Collapse Old Steps', 'Evaluation Strategies' ]) {
@@ -284,8 +289,10 @@ test('settings next opens the real gear and walks each switch', async () => {
     expect(titleOf(container)).toBe(title);
   }
 
+  // Macros arrival hands the panels over atomically, never toggling.
   fireEvent.click(nextBtn(container));
   expect(titleOf(container)).toBe('Macros');
+  expect(onShowBoxMacros).toHaveBeenCalledWith('k-lambda');
 });
 
 test('dictated expressions render as delimited code', async () => {
@@ -294,5 +301,5 @@ test('dictated expressions render as delimited code', async () => {
   await waitFor(() => expect(titleOf(container)).toBe('Write and evaluate'));
 
   const code = container.querySelector('.tour--code');
-  expect(code?.textContent).toBe('(λ x . x y) a');
+  expect(code?.textContent).toBe('(\\ x . x y) a');
 });

--- a/src/components/Tour.test.tsx
+++ b/src/components/Tour.test.tsx
@@ -1,3 +1,4 @@
+import { readFileSync } from 'fs';
 import { test, expect, vi, afterEach, beforeEach } from 'vitest';
 import { render, fireEvent, cleanup, waitFor } from '@testing-library/react';
 import Tour, { TOUR_STEPS } from './Tour';
@@ -102,6 +103,14 @@ test('the tour never dims: no step renders a backdrop', () => {
     expect(container.querySelector('.tour--backdrop'), step.id).toBeNull();
     unmount();
   }
+});
+
+test('the tour tops the fixed top bar, whose backdrop ate DONE', () => {
+  // The top bar paints at 888 with a viewport-wide backdrop per panel;
+  // below it the backdrop swallows tour clicks to close itself instead.
+  const css = readFileSync('src/styles/Tour.css', 'utf8');
+  const root = css.match(/\.tour\s*\{[^}]*\}/)?.[0] ?? '';
+  expect(root).toMatch(/z-index\s*:\s*1000/);
 });
 
 test('every step leaves the app clickable', () => {

--- a/src/components/Tour.test.tsx
+++ b/src/components/Tour.test.tsx
@@ -13,7 +13,9 @@ interface TourCallbacks {
   onFillBoxEditor : (boxKey : string, content : string) => void
   onSetBoxSettings : (boxKey : string, open : boolean) => void
   onShowBoxMacros : (boxKey : string) => void
+  onHideBoxMacros : (boxKey : string) => void
   onDeleteBox : (boxKey : string) => void
+  onSetZenMode : (zenMode : boolean) => void
 }
 
 function props (over : Partial<{ initialStep : string } & TourCallbacks> = {}) {
@@ -24,7 +26,9 @@ function props (over : Partial<{ initialStep : string } & TourCallbacks> = {}) {
     onFillBoxEditor : () => void 0,
     onSetBoxSettings : () => void 0,
     onShowBoxMacros : () => void 0,
+    onHideBoxMacros : () => void 0,
     onDeleteBox : () => void 0,
+    onSetZenMode : () => void 0,
     ...over,
   };
 }
@@ -90,7 +94,7 @@ test('skip snoozes with the id, done restarts from welcome', () => {
   unmount();
 
   const onClose2 = vi.fn();
-  const second = render(<Tour { ...props({ initialStep : 'yours', onClose : onClose2 }) } />);
+  const second = render(<Tour { ...props({ initialStep : 'recap', onClose : onClose2 }) } />);
   const done = [...second.container.querySelectorAll('.tour--actions button')].find((b) => b.textContent === 'Done') as Element;
   fireEvent.click(done);
   expect(onClose2).toHaveBeenCalledTimes(1);
@@ -272,12 +276,86 @@ test('type next fills the editor and submits for them', () => {
   });
 });
 
+test('the tour card rides low instead of covering centered dialogs', () => {
+  const css = readFileSync('src/styles/Tour.css', 'utf8');
+  const card = css.match(/\.tour--card\s*\{[^}]*\}/)?.[0] ?? '';
+  expect(card).toMatch(/bottom\s*:\s*24px/);
+  expect(card).not.toMatch(/top\s*:\s*50%/);
+});
+
 test('the tour ids stay addressable', () => {
   expect(TOUR_STEPS.map((s) => s.id)).toEqual([
     'welcome', 'add', 'pick', 'type', 'stepping', 'boxmap',
     'settings', 'set-sli', 'set-sde', 'set-collapse', 'set-strategy',
-    'macros', 'yours', 'md-explain', 'md-delete',
+    'macros', 'share', 'zen', 'zen-dwell', 'cleaning', 'clean-notebook', 'clean-workspace',
+    'yours', 'theme-accent', 'theme-style', 'transfer', 'report', 'recap',
+    'md-explain', 'md-delete',
   ]);
+});
+
+test('zen next enables zen mode through state and dwells before the finale', () => {
+  const onSetZenMode = vi.fn();
+  const { container } = render(<Tour { ...props({ initialStep : 'zen', onSetZenMode }) } />);
+  expect(titleOf(container)).toBe('Zen mode');
+
+  fireEvent.click(nextBtn(container));
+  expect(onSetZenMode).toHaveBeenCalledWith(true);
+  expect(titleOf(container)).toBe('Settle into zen');
+
+  fireEvent.click(nextBtn(container));
+  expect(titleOf(container)).toBe('A clean slate');
+});
+
+test('the zen switch click walks on like next', () => {
+  const { container } = render(
+    <div>
+      <button className='top-bar--zen' />
+      <Tour { ...props({ initialStep : 'zen' }) } />
+    </div>
+  );
+
+  fireEvent.click(container.querySelector('.top-bar--zen') as Element);
+  expect(titleOf(container)).toBe('Settle into zen');
+});
+
+test('zen arrival steps open panels out of the way', () => {
+  const onBackdrop = vi.fn();
+  const { unmount } = render(
+    <div>
+      <div className='top-bar--backdrop' onClick={ onBackdrop } />
+      <Tour { ...props({ initialStep : 'zen' }) } />
+    </div>
+  );
+  expect(onBackdrop).toHaveBeenCalledTimes(1);
+  unmount();
+});
+
+test('cleaning arrival opens the clearing options but presses nothing', () => {
+  const onEraser = vi.fn();
+  const { container, unmount } = render(
+    <div>
+      <button title='Clearing options' onClick={ onEraser } />
+      <Tour { ...props({ initialStep : 'cleaning' }) } />
+    </div>
+  );
+  // Shown, not done: the panel opens, and the step carries no clear
+  // callback to fire through.
+  expect(onEraser).toHaveBeenCalledTimes(1);
+  expect(titleOf(container)).toBe('A clean slate');
+  unmount();
+});
+
+test('cleaning arrival leaves an open clearing panel alone', () => {
+  const onEraser = vi.fn();
+  const { unmount } = render(
+    <div>
+      <button title='Clearing options' onClick={ onEraser } />
+      <button title='Erase all notebooks and start over with the defaults' />
+      <Tour { ...props({ initialStep : 'cleaning' }) } />
+    </div>
+  );
+  expect(onEraser).not.toHaveBeenCalled();
+  unmount();
 });
 
 test('deleting early on the explainer loops back at once', async () => {
@@ -331,4 +409,62 @@ test('dictated expressions render as delimited code', async () => {
 
   const code = container.querySelector('.tour--code');
   expect(code?.textContent).toBe('(\\ x . x y) a');
+});
+
+test('starting or resuming seats the step subject below the top bar', () => {
+  // A scrolled page (or boxes above the tour's own) must not leave the
+  // card pointing off-screen: init seats the step's own target, else the
+  // first box frame, below the fixed bar — the notebook's own 60px seat.
+  // (jsdom has no layout, so the subjects below carry stubbed rects.)
+  const rectAt = (top : number) => () => ({ top, left : 0, bottom : top + 50, right : 10, width : 10, height : 50, x : 0, y : top, toJSON : () => ({}) }) as unknown as DOMRect;
+  const original : typeof window.scrollTo = window.scrollTo;
+  const scrollTo = vi.fn();
+  window.scrollTo = scrollTo as unknown as typeof window.scrollTo;
+
+  try {
+    const tabs = document.createElement('div');
+    tabs.className = 'top-bar--tabs';
+    tabs.getBoundingClientRect = rectAt(900);
+    document.body.appendChild(tabs);
+    const started = render(<Tour { ...props({ initialStep : 'welcome' }) } />);
+    expect(scrollTo).toHaveBeenCalledTimes(1);
+    expect(scrollTo).toHaveBeenLastCalledWith({ top : 840, behavior : 'auto' });
+    started.unmount();
+    tabs.remove();
+
+    const shell = document.createElement('div');
+    document.body.appendChild(shell);
+    const frame = document.createElement('div');
+    frame.className = 'box-frame';
+    frame.getBoundingClientRect = rectAt(-200);
+    shell.appendChild(frame);
+    const resumed = render(<Tour { ...props({ initialStep : 'macros' }) } />);
+    expect(scrollTo).toHaveBeenCalledTimes(2);
+    expect(scrollTo).toHaveBeenLastCalledWith({ top : 0, behavior : 'auto' });
+    resumed.unmount();
+    shell.remove();
+  } finally {
+    window.scrollTo = original;
+  }
+});
+
+test('a visible subject stays exactly where the user put it', () => {
+  // Only subjects actually out of view move: a step landing on visible
+  // UI must never yank the page.
+  const original : typeof window.scrollTo = window.scrollTo;
+  const scrollTo = vi.fn();
+  window.scrollTo = scrollTo as unknown as typeof window.scrollTo;
+
+  try {
+    const tabs = document.createElement('div');
+    tabs.className = 'top-bar--tabs';
+    tabs.getBoundingClientRect = () => ({ top : 100, left : 0, bottom : 150, right : 10, width : 10, height : 50, x : 0, y : 100, toJSON : () => ({}) }) as unknown as DOMRect;
+    document.body.appendChild(tabs);
+    const { unmount } = render(<Tour { ...props({ initialStep : 'welcome' }) } />);
+    expect(scrollTo).not.toHaveBeenCalled();
+    unmount();
+    tabs.remove();
+  } finally {
+    window.scrollTo = original;
+  }
 });

--- a/src/components/Tour.test.tsx
+++ b/src/components/Tour.test.tsx
@@ -60,7 +60,7 @@ test('back follows the branch map', () => {
   const { container } = render(<Tour { ...props({ initialStep : 'macros' }) } />);
   const back = [...container.querySelectorAll('.tour--actions button')].find((b) => b.textContent === 'Back') as Element;
   fireEvent.click(back);
-  expect(titleOf(container)).toBe('Step through evaluation');
+  expect(titleOf(container)).toBe('Evaluation Strategies');
 });
 
 test('unknown initial step lands on welcome', () => {
@@ -92,22 +92,21 @@ test('skip snoozes with the id, done restarts from welcome', () => {
   expect(loadTourState()).toEqual({ step : 'welcome', done : true });
 });
 
-test('backdrop click snoozes like skip on blocking steps', () => {
-  const onClose = vi.fn();
-  const { container } = render(<Tour { ...props({ initialStep : 'welcome', onClose }) } />);
-  fireEvent.click(container.querySelector('.tour--backdrop') as Element);
-  expect(onClose).toHaveBeenCalledTimes(1);
-  expect(loadTourState()).toEqual({ step : 'welcome', done : true });
+test('the tour never dims: no step renders a backdrop', () => {
+  for (const step of TOUR_STEPS) {
+    const { container, unmount } = render(<Tour { ...props({ initialStep : step.id }) } />);
+    expect(container.querySelector('.tour--backdrop'), step.id).toBeNull();
+    unmount();
+  }
 });
 
-test('working steps go click-through, reading steps stay blocking', () => {
-  const live = render(<Tour { ...props({ initialStep : 'type' }) } />);
-  expect(live.container.querySelector('.tour')?.classList.contains('tour--live')).toBe(true);
-  live.unmount();
-
-  const blocking = render(<Tour { ...props({ initialStep : 'yours' }) } />);
-  expect(blocking.container.querySelector('.tour')?.classList.contains('tour--live')).toBe(false);
-  blocking.unmount();
+test('every step leaves the app clickable', () => {
+  for (const step of TOUR_STEPS) {
+    const { container, unmount } = render(<Tour { ...props({ initialStep : step.id }) } />);
+    expect(container.querySelector('.tour')?.classList.contains('tour--live'), step.id).toBe(false);
+    expect(container.querySelector('.tour > .tour--card'), step.id).not.toBeNull();
+    unmount();
+  }
 });
 
 test('operating the + control advances just like next', () => {
@@ -119,13 +118,10 @@ test('operating the + control advances just like next', () => {
     </div>
   );
 
-  expect(container.querySelector('.tour')?.classList.contains('tour--live')).toBe(true);
   fireEvent.mouseDown(container.querySelector('.add_box_after') as Element);
   expect(onPlus).toHaveBeenCalledTimes(1);
   expect(titleOf(container)).toBe('Pick a box type');
   expect(loadTourState()).toEqual({ step : 'pick', done : false });
-  // The pick step stays live: its modal must remain operable.
-  expect(container.querySelector('.tour')?.classList.contains('tour--live')).toBe(true);
 });
 
 test('next on the + step works the control, advancing exactly once', () => {
@@ -245,6 +241,58 @@ test('type next fills the editor and submits for them', () => {
 
 test('the tour ids stay addressable', () => {
   expect(TOUR_STEPS.map((s) => s.id)).toEqual([
-    'welcome', 'add', 'pick', 'type', 'stepping', 'macros', 'yours', 'md-explain', 'md-delete',
+    'welcome', 'add', 'pick', 'type', 'stepping',
+    'settings', 'set-sli', 'set-sde', 'set-collapse', 'set-strategy',
+    'macros', 'yours', 'md-explain', 'md-delete',
   ]);
+});
+
+test('deleting early on the explainer loops back at once', async () => {
+  const { container } = render(<Tour { ...props({ initialStep : 'pick' }) } />);
+  const frame = plantFrame(container, 'markDownBox', 'k-md');
+  await waitFor(() => expect(titleOf(container)).toBe('A Markdown box'));
+
+  frame.remove();
+  await waitFor(() => expect(titleOf(container)).toBe('Add a box'));
+  expect(loadTourState()).toEqual({ step : 'add', done : false });
+});
+
+test('settings next opens the real gear and walks each switch', async () => {
+  const { container } = render(<Tour { ...props({ initialStep : 'pick' }) } />);
+  const frame = plantFrame(container, 'untypedLambdaBox', 'k-lambda');
+  const gear = document.createElement('div');
+  gear.setAttribute('title', 'Open this Boxs\' settings');
+  const opened : Array<string> = [];
+  gear.addEventListener('click', () => opened.push('gear'));
+  frame.appendChild(gear);
+  await waitFor(() => expect(titleOf(container)).toBe('Write and evaluate'));
+
+  const evaluated = document.createElement('div');
+  evaluated.className = 'box-history-wrap';
+  frame.appendChild(evaluated);
+  await waitFor(() => expect(titleOf(container)).toBe('Step through evaluation'));
+
+  fireEvent.click(nextBtn(container));
+  expect(titleOf(container)).toBe('Box settings');
+
+  fireEvent.click(nextBtn(container));
+  expect(opened).toEqual([ 'gear' ]);
+  expect(titleOf(container)).toBe('Single Letter Names');
+
+  for (const title of [ 'Simplified Evaluation', 'Collapse Old Steps', 'Evaluation Strategies' ]) {
+    fireEvent.click(nextBtn(container));
+    expect(titleOf(container)).toBe(title);
+  }
+
+  fireEvent.click(nextBtn(container));
+  expect(titleOf(container)).toBe('Macros');
+});
+
+test('dictated expressions render as delimited code', async () => {
+  const { container } = render(<Tour { ...props({ initialStep : 'pick' }) } />);
+  plantFrame(container, 'untypedLambdaBox', 'k-lambda');
+  await waitFor(() => expect(titleOf(container)).toBe('Write and evaluate'));
+
+  const code = container.querySelector('.tour--code');
+  expect(code?.textContent).toBe('(λ x . x y) a');
 });

--- a/src/components/Tour.test.tsx
+++ b/src/components/Tour.test.tsx
@@ -14,56 +14,69 @@ function buttons (container : Element) : Record<string, Element | null> {
 
 test('tour walks forward and back, persisting each step', () => {
   const onClose = vi.fn();
-  const { container } = render(<Tour initialStep={ 0 } onClose={ onClose } />);
+  const { container } = render(<Tour initialStep={ 0 } demoBoxKey={ null } onClose={ onClose } />);
 
   expect(container.querySelector('.tour--title')?.textContent).toBe(TOUR_STEPS[0].title);
   expect(container.querySelector('.tour--kicker')?.textContent).toContain('1 of 6');
 
   fireEvent.click(buttons(container).next as HTMLElement);
   expect(container.querySelector('.tour--title')?.textContent).toBe(TOUR_STEPS[1].title);
-  expect(loadTourState()).toEqual({ step : 1, done : false });
+  expect(loadTourState()).toEqual({ step : 1, done : false, seeded : false, demoBoxKey : null });
 
   fireEvent.click(buttons(container).back as HTMLElement);
   expect(container.querySelector('.tour--title')?.textContent).toBe(TOUR_STEPS[0].title);
-  expect(loadTourState()).toEqual({ step : 0, done : false });
+  expect(loadTourState()).toEqual({ step : 0, done : false, seeded : false, demoBoxKey : null });
   expect(onClose).not.toHaveBeenCalled();
 });
 
 test('skip snoozes at the current step, done restarts from zero', () => {
   const onClose = vi.fn();
-  const { container, unmount } = render(<Tour initialStep={ 2 } onClose={ onClose } />);
+  const { container, unmount } = render(<Tour initialStep={ 2 } demoBoxKey={ null } onClose={ onClose } />);
   expect(container.querySelector('.tour--kicker')?.textContent).toContain('3 of 6');
 
   fireEvent.click(buttons(container).skip as HTMLElement);
   expect(onClose).toHaveBeenCalledTimes(1);
-  expect(loadTourState()).toEqual({ step : 2, done : true });
+  expect(loadTourState()).toEqual({ step : 2, done : true, seeded : false, demoBoxKey : null });
   unmount();
 
   const onClose2 = vi.fn();
-  const second = render(<Tour initialStep={ 5 } onClose={ onClose2 } />);
+  const second = render(<Tour initialStep={ 5 } demoBoxKey={ null } onClose={ onClose2 } />);
   expect(second.container.querySelector('.tour--kicker')?.textContent).toContain('6 of 6');
   expect(buttons(second.container).next).toBeNull();
   fireEvent.click(buttons(second.container).done as HTMLElement);
   expect(onClose2).toHaveBeenCalledTimes(1);
-  expect(loadTourState()).toEqual({ step : 0, done : true });
+  expect(loadTourState()).toEqual({ step : 0, done : true, seeded : false, demoBoxKey : null });
 });
 
 test('backdrop click snoozes like skip', () => {
   const onClose = vi.fn();
-  const { container } = render(<Tour initialStep={ 1 } onClose={ onClose } />);
+  const { container } = render(<Tour initialStep={ 1 } demoBoxKey={ null } onClose={ onClose } />);
   fireEvent.click(container.querySelector('.tour--backdrop') as HTMLElement);
   expect(onClose).toHaveBeenCalledTimes(1);
-  expect(loadTourState()).toEqual({ step : 1, done : true });
+  expect(loadTourState()).toEqual({ step : 1, done : true, seeded : false, demoBoxKey : null });
 });
 
 test('out-of-range initial step clamps into the tour', () => {
-  const { container } = render(<Tour initialStep={ 99 } onClose={ () => void 0 } />);
+  const { container } = render(<Tour initialStep={ 99 } demoBoxKey={ null } onClose={ () => void 0 } />);
   expect(container.querySelector('.tour--kicker')?.textContent).toContain('6 of 6');
 });
 
 test('missing targets never break the card', () => {
   // jsdom rects are zero-sized, so no ring — but the card stands alone.
-  const { container } = render(<Tour initialStep={ 0 } onClose={ () => void 0 } />);
+  const { container } = render(<Tour initialStep={ 0 } demoBoxKey={ null } onClose={ () => void 0 } />);
   expect(container.querySelector('.tour--ring')).toBeNull();
   expect(container.querySelector('[role="dialog"]')).not.toBeNull();
+});
+
+test('step two points at the demo box when its key is known', () => {
+  const { container } = render(
+    <div>
+      <div data-box-key='demo-1' />
+      <Tour initialStep={ 1 } demoBoxKey='demo-1' onClose={ () => void 0 } />
+    </div>
+  );
+  // The ring itself needs real layout, but the step resolved its target:
+  // with an unknown key the same step stays ringless by construction.
+  expect(container.querySelector('[data-box-key="demo-1"]')).not.toBeNull();
+  expect(container.querySelector('.tour--title')?.textContent).toBe(TOUR_STEPS[1].title);
 });

--- a/src/components/Tour.test.tsx
+++ b/src/components/Tour.test.tsx
@@ -1,0 +1,69 @@
+import { test, expect, vi, afterEach, beforeEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/react';
+import Tour, { TOUR_STEPS } from './Tour';
+import { loadTourState } from '../Constants';
+
+afterEach(() => cleanup());
+beforeEach(() => window.localStorage.removeItem('LambdulusTour'));
+
+function buttons (container : Element) : Record<string, Element | null> {
+  const all = [...container.querySelectorAll('.tour--actions button')];
+  const byText = (text : string) => all.find((b) => b.textContent === text) ?? null;
+  return { back : byText('Back'), skip : byText('Skip'), next : byText('Next'), done : byText('Done') };
+}
+
+test('tour walks forward and back, persisting each step', () => {
+  const onClose = vi.fn();
+  const { container } = render(<Tour initialStep={ 0 } onClose={ onClose } />);
+
+  expect(container.querySelector('.tour--title')?.textContent).toBe(TOUR_STEPS[0].title);
+  expect(container.querySelector('.tour--kicker')?.textContent).toContain('1 of 6');
+
+  fireEvent.click(buttons(container).next as HTMLElement);
+  expect(container.querySelector('.tour--title')?.textContent).toBe(TOUR_STEPS[1].title);
+  expect(loadTourState()).toEqual({ step : 1, done : false });
+
+  fireEvent.click(buttons(container).back as HTMLElement);
+  expect(container.querySelector('.tour--title')?.textContent).toBe(TOUR_STEPS[0].title);
+  expect(loadTourState()).toEqual({ step : 0, done : false });
+  expect(onClose).not.toHaveBeenCalled();
+});
+
+test('skip snoozes at the current step, done restarts from zero', () => {
+  const onClose = vi.fn();
+  const { container, unmount } = render(<Tour initialStep={ 2 } onClose={ onClose } />);
+  expect(container.querySelector('.tour--kicker')?.textContent).toContain('3 of 6');
+
+  fireEvent.click(buttons(container).skip as HTMLElement);
+  expect(onClose).toHaveBeenCalledTimes(1);
+  expect(loadTourState()).toEqual({ step : 2, done : true });
+  unmount();
+
+  const onClose2 = vi.fn();
+  const second = render(<Tour initialStep={ 5 } onClose={ onClose2 } />);
+  expect(second.container.querySelector('.tour--kicker')?.textContent).toContain('6 of 6');
+  expect(buttons(second.container).next).toBeNull();
+  fireEvent.click(buttons(second.container).done as HTMLElement);
+  expect(onClose2).toHaveBeenCalledTimes(1);
+  expect(loadTourState()).toEqual({ step : 0, done : true });
+});
+
+test('backdrop click snoozes like skip', () => {
+  const onClose = vi.fn();
+  const { container } = render(<Tour initialStep={ 1 } onClose={ onClose } />);
+  fireEvent.click(container.querySelector('.tour--backdrop') as HTMLElement);
+  expect(onClose).toHaveBeenCalledTimes(1);
+  expect(loadTourState()).toEqual({ step : 1, done : true });
+});
+
+test('out-of-range initial step clamps into the tour', () => {
+  const { container } = render(<Tour initialStep={ 99 } onClose={ () => void 0 } />);
+  expect(container.querySelector('.tour--kicker')?.textContent).toContain('6 of 6');
+});
+
+test('missing targets never break the card', () => {
+  // jsdom rects are zero-sized, so no ring — but the card stands alone.
+  const { container } = render(<Tour initialStep={ 0 } onClose={ () => void 0 } />);
+  expect(container.querySelector('.tour--ring')).toBeNull();
+  expect(container.querySelector('[role="dialog"]')).not.toBeNull();
+});

--- a/src/components/Tour.tsx
+++ b/src/components/Tour.tsx
@@ -50,6 +50,7 @@ const TYPE_EXPRESSION = '(λ x . x y) a'
 // Per-box controls the tour conducts: the settings gear and its panel,
 // the macros dock, and one row hook per box setting.
 const GEAR_SELECTOR = '[title="Open this Boxs\' settings"]'
+const DELETE_SELECTOR = '[title="Delete this Box from the Notebook"]'
 const MACRO_DOCK = '.macro-dock'
 const SLI_ROW = '.untyped-lambda-settings-SLI'
 const SDE_ROW = '.untyped-lambda-settings-SDE'
@@ -149,7 +150,7 @@ export const TOUR_STEPS : Array<TourStep> = [
   {
     id : 'md-explain',
     title : 'A Markdown box',
-    body : 'Notes, docs, headings — Markdown boxes hold text, not calculus. Since we came for lambda, let’s remove this one next — deleting boxes is worth knowing anyway.',
+    body : 'Notes, docs, headings — Markdown boxes hold text, not calculus. Since we came for lambda-calculus, let’s remove this one next — deleting boxes is worth knowing anyway.',
     branch : true,
     dot : 'add',
   },
@@ -159,7 +160,7 @@ export const TOUR_STEPS : Array<TourStep> = [
     body : 'Every box deletes from its title-bar controls. Delete this Markdown box now — or press Next and I will do it for you.',
     branch : true,
     dot : 'add',
-    ringTracked : true,
+    targetInTracked : DELETE_SELECTOR,
   },
 ]
 

--- a/src/components/Tour.tsx
+++ b/src/components/Tour.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 
-import { saveTourState } from '../Constants'
+import { loadTourState, saveTourState } from '../Constants'
 
 import '../styles/Tour.css'
 
@@ -21,11 +21,8 @@ export const TOUR_STEPS : Array<TourStep> = [
     target : '.top-bar--tabs',
   },
   {
-    title : 'Add a box',
-    body : 'Boxes are the cells of a notebook. Hit the + affordance to add a λ Expression box for evaluating, or a Markdown box for notes.',
-    // Empty notebooks offer the big + panel, occupied ones a + row after
-    // each box — whichever is on screen gets the ring.
-    target : '.top-level--create-box, .add_box_after',
+    title : 'Here\u2019s your first box',
+    body : 'We added an evaluated expression — (λ x . x y) applied to a, waiting at its first step below. Hit the + affordance to add more boxes anytime; this one deletes like any other.',
   },
   {
     title : 'Write and evaluate',
@@ -49,6 +46,9 @@ export const TOUR_STEPS : Array<TourStep> = [
 
 interface Props {
   initialStep : number
+  // __key of the demo box seeded for this tour, if any. Step two rings it;
+  // a missing or deleted box simply leaves that step ringless.
+  demoBoxKey : string | null
   onClose () : void
 }
 
@@ -68,27 +68,40 @@ function clampStep (step : number) : number {
 }
 
 export default function Tour (props : Props) : JSX.Element {
-  const { initialStep, onClose } : Props = props
+  const { initialStep, demoBoxKey, onClose } : Props = props
+  const steps : Array<TourStep> = TOUR_STEPS.map((step, i) =>
+    i === 1 && demoBoxKey !== null ?
+      { ...step, target : `[data-box-key="${demoBoxKey}"]` }
+    :
+      step
+  )
   const [ step, setStep ] = useState(() => clampStep(initialStep))
   const [ ring, setRing ] = useState<Ring | null>(null)
-  const current : TourStep = TOUR_STEPS[step]
-  const last : boolean = step === TOUR_STEPS.length - 1
+  const current : TourStep = steps[step]
+  const last : boolean = step === steps.length - 1
+
+  // Step and done move; seeded and the demo key belong to the box,
+  // never to the walk.
+  const persist = (nextStep : number, done : boolean) => {
+    const stored = loadTourState()
+    saveTourState({ step : nextStep, done, seeded : stored?.seeded ?? false, demoBoxKey : stored?.demoBoxKey ?? null })
+  }
 
   const go = (next : number) => {
     const clamped : number = clampStep(next)
     setStep(clamped)
-    saveTourState({ step : clamped, done : false })
+    persist(clamped, false)
   }
 
   // Skip (or backdrop): done for now, resume where left off via the icon.
   const snooze = () => {
-    saveTourState({ step, done : true })
+    persist(step, true)
     onClose()
   }
 
   // Done on the last step: restart from the beginning next time.
   const finish = () => {
-    saveTourState({ step : 0, done : true })
+    persist(0, true)
     onClose()
   }
 

--- a/src/components/Tour.tsx
+++ b/src/components/Tour.tsx
@@ -1,0 +1,164 @@
+import React, { useEffect, useState } from 'react'
+
+import { saveTourState } from '../Constants'
+
+import '../styles/Tour.css'
+
+
+export interface TourStep {
+  title : string
+  body : string
+  // CSS selector of the UI the step points at. When it matches a visible
+  // element a ring highlights it; otherwise the card simply stands alone,
+  // so steps never break on screens where the target is absent.
+  target ?: string
+}
+
+export const TOUR_STEPS : Array<TourStep> = [
+  {
+    title : 'Welcome to Lambdulus',
+    body : 'A notebook for playing with lambda calculus. Your work lives in notebooks — switch them in the tabs above. This tour takes a minute; skip anytime.',
+    target : '.top-bar--tabs',
+  },
+  {
+    title : 'Add a box',
+    body : 'Boxes are the cells of a notebook. Hit the + affordance to add a λ Expression box for evaluating, or a Markdown box for notes.',
+    // Empty notebooks offer the big + panel, occupied ones a + row after
+    // each box — whichever is on screen gets the ring.
+    target : '.top-level--create-box, .add_box_after',
+  },
+  {
+    title : 'Write and evaluate',
+    body : 'Type an expression, then Debug (Ctrl + Enter) to evaluate it step by step, or Exercise (Shift + Enter) to take the steps yourself. Lines above the expression define macros — NAME := definition, each ending with a semicolon.',
+  },
+  {
+    title : 'Step through evaluation',
+    body : 'Run walks all the way, Step advances once. A box\u2019s settings switch the strategy (normal, applicative…), toggle single-letter variables, and expand standalones.',
+  },
+  {
+    title : 'Macros',
+    body : 'Church numerals, booleans and arithmetic (Y, ZERO, SUC, +, *) are builtin. Your own definitions unfold in the Macros dock beside each box.',
+  },
+  {
+    title : 'Make it yours',
+    body : 'Hover the accent dots or box-style tiles to preview them live across the whole page — click to keep. The top bar also holds notebook settings, zen mode, and export.',
+    target : '[title="Accent theme"]',
+  },
+]
+
+
+interface Props {
+  initialStep : number
+  onClose () : void
+}
+
+interface Ring {
+  top : number
+  left : number
+  width : number
+  height : number
+}
+
+function clampStep (step : number) : number {
+  if (Number.isNaN(step)) {
+    return 0
+  }
+
+  return Math.max(0, Math.min(TOUR_STEPS.length - 1, Math.floor(step)))
+}
+
+export default function Tour (props : Props) : JSX.Element {
+  const { initialStep, onClose } : Props = props
+  const [ step, setStep ] = useState(() => clampStep(initialStep))
+  const [ ring, setRing ] = useState<Ring | null>(null)
+  const current : TourStep = TOUR_STEPS[step]
+  const last : boolean = step === TOUR_STEPS.length - 1
+
+  const go = (next : number) => {
+    const clamped : number = clampStep(next)
+    setStep(clamped)
+    saveTourState({ step : clamped, done : false })
+  }
+
+  // Skip (or backdrop): done for now, resume where left off via the icon.
+  const snooze = () => {
+    saveTourState({ step, done : true })
+    onClose()
+  }
+
+  // Done on the last step: restart from the beginning next time.
+  const finish = () => {
+    saveTourState({ step : 0, done : true })
+    onClose()
+  }
+
+  useEffect(() => {
+    setRing(null)
+
+    if (!current.target) {
+      return
+    }
+
+    const element : Element | null = document.querySelector(current.target)
+
+    if (element === null) {
+      return
+    }
+
+    const rect : DOMRect = element.getBoundingClientRect()
+
+    if (rect.width === 0 && rect.height === 0) {
+      return
+    }
+
+    setRing({ top : rect.top, left : rect.left, width : rect.width, height : rect.height })
+  }, [ step, current.target ])
+
+  return (
+    <div className='tour'>
+      <div className='tour--backdrop' onClick={ snooze } />
+      {
+        ring !== null ?
+          <div
+            className='tour--ring'
+            aria-hidden='true'
+            style={ {
+              top : ring.top - 6,
+              left : ring.left - 6,
+              width : ring.width + 12,
+              height : ring.height + 12,
+            } }
+          />
+        :
+          null
+      }
+      <div className='tour--card' role='dialog' aria-label={ `Guided tour: ${current.title}` }>
+        <p className='tour--kicker'>Guided tour · { step + 1 } of { TOUR_STEPS.length }</p>
+        <p className='tour--title'>{ current.title }</p>
+        <p className='tour--body'>{ current.body }</p>
+        <div className='tour--dots' aria-hidden='true'>
+          {
+            TOUR_STEPS.map((_, i : number) =>
+              <span key={ i } className={ i === step ? 'tour--dot tour--dot--active' : 'tour--dot' } />
+            )
+          }
+        </div>
+        <div className='tour--actions'>
+          {
+            step > 0 ?
+              <button className='tour--btn' onClick={ () => go(step - 1) }>Back</button>
+            :
+              <span />
+          }
+          <button className='tour--btn' onClick={ snooze }>Skip</button>
+          {
+            last ?
+              <button className='tour--btn tour--btn--primary' onClick={ finish }>Done</button>
+            :
+              <button className='tour--btn tour--btn--primary' onClick={ () => go(step + 1) }>Next</button>
+          }
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/Tour.tsx
+++ b/src/components/Tour.tsx
@@ -29,6 +29,10 @@ export interface TourStep {
   advanceTo ?: string
   // Ring the box this tour run is working with instead of a selector.
   ringTracked ?: boolean
+  // The target only resolves once a box exists (the box map hides on an
+  // empty notebook): the fresh-render selector sweep skips these, and the
+  // conducted walk asserts them against its live box instead.
+  needsBox ?: boolean
   // Detour steps render the main-path dots parked at the + step.
   branch ?: boolean
   // Park this step's dot on another step (settings cluster, detour).
@@ -46,10 +50,7 @@ const TYPE_EXPRESSION = '(λ x . x y) a'
 // Per-box controls the tour conducts: the settings gear and its panel,
 // the macros dock, and one row hook per box setting.
 const GEAR_SELECTOR = '[title="Open this Boxs\' settings"]'
-const SETTINGS_PANEL = '.box-settings'
 const MACRO_DOCK = '.macro-dock'
-const MACRO_HEAD = '.macro-dock--head'
-const MACRO_OPEN = 'macro-dock--open'
 const SLI_ROW = '.untyped-lambda-settings-SLI'
 const SDE_ROW = '.untyped-lambda-settings-SDE'
 const COLLAPSE_ROW = '.untyped-lambda-settings-collapse'
@@ -82,13 +83,20 @@ export const TOUR_STEPS : Array<TourStep> = [
   {
     id : 'type',
     title : 'Write and evaluate',
-    body : 'Type `(λ x . x y) a` into the editor — the backslash becomes λ as you type — then press Debug (Ctrl + Enter). Press Next and I will do it for you.',
+    body : 'Type `(\\ x . x y) a` into the editor — the backslash becomes λ as you type — then press Debug (Ctrl + Enter). Press Next and I will do it for you.',
   },
   {
     id : 'stepping',
     title : 'Step through evaluation',
-    body : 'Evaluated, waiting at its first step. Run walks all the way to the normal form; Step advances once. Try it now.',
+    body : 'Evaluated, waiting at its first step. Run walks all the way to the normal form; Step advances once. Try it now — or press `F8` to step, `F9` to run.',
     ringTracked : true,
+  },
+  {
+    id : 'boxmap',
+    title : 'The box map',
+    body : 'The strip on the right edge maps every box — click a line to jump to it, or page with `ArrowUp` and `ArrowDown`. The accent bar marks where you are.',
+    target : '.box-map',
+    needsBox : true,
   },
   {
     id : 'settings',
@@ -155,7 +163,7 @@ export const TOUR_STEPS : Array<TourStep> = [
   },
 ]
 
-const MAIN_DOTS = [ 'welcome', 'add', 'pick', 'type', 'stepping', 'settings', 'macros', 'yours' ]
+const MAIN_DOTS = [ 'welcome', 'add', 'pick', 'type', 'stepping', 'boxmap', 'settings', 'macros', 'yours' ]
 
 const BACK : Record<string, string | null> = {
   welcome : null,
@@ -163,7 +171,8 @@ const BACK : Record<string, string | null> = {
   pick : 'add',
   type : 'pick',
   stepping : 'type',
-  settings : 'stepping',
+  boxmap : 'stepping',
+  settings : 'boxmap',
   'set-sli' : 'settings',
   'set-sde' : 'set-sli',
   'set-collapse' : 'set-sde',
@@ -177,7 +186,8 @@ const BACK : Record<string, string | null> = {
 const NEXT_MAIN : Record<string, string> = {
   welcome : 'add',
   add : 'pick',
-  stepping : 'settings',
+  stepping : 'boxmap',
+  boxmap : 'settings',
   settings : 'set-sli',
   'set-sli' : 'set-sde',
   'set-sde' : 'set-collapse',
@@ -212,6 +222,8 @@ interface Props {
   onClose () : void
   onAddLambdaBox () : string | null
   onFillBoxEditor (boxKey : string, content : string) : void
+  onSetBoxSettings (boxKey : string, open : boolean) : void
+  onShowBoxMacros (boxKey : string) : void
   onDeleteBox (boxKey : string) : void
 }
 
@@ -223,7 +235,7 @@ interface Ring {
 }
 
 export default function Tour (props : Props) : JSX.Element {
-  const { initialStep, onClose, onAddLambdaBox, onFillBoxEditor, onDeleteBox } : Props = props
+  const { initialStep, onClose, onAddLambdaBox, onFillBoxEditor, onSetBoxSettings, onShowBoxMacros, onDeleteBox } : Props = props
   const [ id, setId ] = useState(() => stepById(initialStep).id)
   // The box frame this tour run is working with. Session-only: a reload
   // forgets it, and the wait steps below loop back to 'add' instead of
@@ -400,14 +412,17 @@ export default function Tour (props : Props) : JSX.Element {
   }, [ id ])
 
   // Show, don't tell: the macros and themes steps open the real panels on
-  // arrival — never toggling one that is already open — so the tour points
-  // at living UI instead of describing it.
+  // arrival, so the tour points at living UI instead of describing it.
+  // The macros arrival is one atomic handoff — settings closed, dock
+  // open — because two programmatic toggles would read stale props and
+  // resurrect each other through the box replace. Setting values, never
+  // toggling, so an already-open dock simply stays open.
   useEffect(() => {
     if (id === 'macros' && tracked !== null && tracked.isConnected) {
-      const dock : Element | null = tracked.querySelector(MACRO_DOCK)
+      const boxKey : string | null = boxKeyOf(tracked)
 
-      if (dock !== null && !dock.classList.contains(MACRO_OPEN)) {
-        (dock.querySelector(MACRO_HEAD) as HTMLElement | null)?.click()
+      if (boxKey !== null) {
+        onShowBoxMacros(boxKey)
       }
     }
 
@@ -457,11 +472,18 @@ export default function Tour (props : Props) : JSX.Element {
       return
     }
 
-    // Same road as the hand: open the real panel unless it already is.
-    if (tracked.querySelector(SETTINGS_PANEL) === null) {
-      (tracked.querySelector(GEAR_SELECTOR) as HTMLElement | null)?.click()
+    const boxKey : string | null = boxKeyOf(tracked)
+
+    if (boxKey === null) {
+      goId('add')
+      return
     }
 
+    // Explicit value through state, not the gear toggle: the title bar only
+    // re-renders on box commits, so a programmatic toggle would read stale
+    // props whenever the bar skipped a render. The user's own hand still
+    // works the real gear (it commits, then re-renders, then is fresh).
+    onSetBoxSettings(boxKey, true)
     goId('set-sli')
   }
 

--- a/src/components/Tour.tsx
+++ b/src/components/Tour.tsx
@@ -9,25 +9,30 @@ import '../styles/Tour.css'
 export interface TourStep {
   id : string
   title : string
+  // Backtick spans render as inline code, so expressions read as
+  // expressions instead of dissolving into the sentence.
   body : string
   // CSS selector of the UI the step points at. When it matches a visible
   // element a ring highlights it; otherwise the card simply stands alone,
   // so steps never break on screens where the target is absent.
   target ?: string
+  // Same, scoped to the box this run is working with: the ring follows
+  // tracked.querySelector(selector), so per-box controls stay addressable.
+  targetInTracked ?: string
   // CSS selector of a live control the user may operate mid-step. Clicking
   // it advances the tour to advanceTo just like Next does; pressing Next
   // activates ("clicks") it first, so both paths walk the same road.
   advanceOn ?: string
+  // Same, scoped to the tracked box.
+  advanceOnInTracked ?: string
   // Where operating advanceOn (or chauffeuring it through Next) walks to.
   advanceTo ?: string
-  // Click-through step: the overlay dims but never intercepts, so the user
-  // can operate the app the step talks about. Every step that asks for a
-  // real click must be live, or the backdrop traps the user out.
-  live ?: boolean
   // Ring the box this tour run is working with instead of a selector.
   ringTracked ?: boolean
   // Detour steps render the main-path dots parked at the + step.
   branch ?: boolean
+  // Park this step's dot on another step (settings cluster, detour).
+  dot ?: string
 }
 
 // The clickable add-box controls: the big + panel's button on empty
@@ -37,6 +42,22 @@ const ADD_BOX_SELECTOR = '.create-box-plus, .add_box_after'
 
 const LAMBDA_PICK_TITLE = 'Create new λ box'
 const TYPE_EXPRESSION = '(λ x . x y) a'
+
+// Per-box controls the tour conducts: the settings gear and its panel,
+// the macros dock, and one row hook per box setting.
+const GEAR_SELECTOR = '[title="Open this Boxs\' settings"]'
+const SETTINGS_PANEL = '.box-settings'
+const MACRO_DOCK = '.macro-dock'
+const MACRO_HEAD = '.macro-dock--head'
+const MACRO_OPEN = 'macro-dock--open'
+const SLI_ROW = '.untyped-lambda-settings-SLI'
+const SDE_ROW = '.untyped-lambda-settings-SDE'
+const COLLAPSE_ROW = '.untyped-lambda-settings-collapse'
+const STRATEGY_ROW = '.untyped-lambda-settings-strategies'
+
+// The top-bar themes control and its panel.
+const THEMES_ICON = '[title="Accent theme"]'
+const THEMES_PANEL = '.top-bar--accent-pick'
 
 export const TOUR_STEPS : Array<TourStep> = [
   {
@@ -52,57 +73,89 @@ export const TOUR_STEPS : Array<TourStep> = [
     target : ADD_BOX_SELECTOR,
     advanceOn : ADD_BOX_SELECTOR,
     advanceTo : 'pick',
-    live : true,
   },
   {
     id : 'pick',
     title : 'Pick a box type',
     body : 'A λ Expression box evaluates lambda calculus step by step. A Markdown box holds notes and docs. Pick λ Expression to keep walking with me.',
-    live : true,
   },
   {
     id : 'type',
     title : 'Write and evaluate',
-    body : 'Type (\\ x . x y) a into the editor — the backslash becomes λ as you type — then press Debug (Ctrl + Enter). Press Next and I will do it for you.',
-    live : true,
+    body : 'Type `(λ x . x y) a` into the editor — the backslash becomes λ as you type — then press Debug (Ctrl + Enter). Press Next and I will do it for you.',
   },
   {
     id : 'stepping',
     title : 'Step through evaluation',
-    body : 'There it is — evaluated and waiting at its first step. Run walks all the way to the normal form, Step advances once — try it now. A box\u2019s settings switch the strategy (normal, applicative…), toggle single-letter variables, and expand standalones.',
+    body : 'Evaluated, waiting at its first step. Run walks all the way to the normal form; Step advances once. Try it now.',
     ringTracked : true,
-    live : true,
+  },
+  {
+    id : 'settings',
+    title : 'Box settings',
+    body : 'Every box carries its own settings, behind this gear. Click it — or press Next and I will — and we will walk each switch.',
+    targetInTracked : GEAR_SELECTOR,
+    advanceOnInTracked : GEAR_SELECTOR,
+    advanceTo : 'set-sli',
+  },
+  {
+    id : 'set-sli',
+    title : 'Single Letter Names',
+    body : 'Lone letters count as variables, no spaces needed. Flip it and Step again to feel it.',
+    targetInTracked : SLI_ROW,
+    dot : 'settings',
+  },
+  {
+    id : 'set-sde',
+    title : 'Simplified Evaluation',
+    body : 'This steers stepping by a different strategy — try the same expression with it on and off.',
+    targetInTracked : SDE_ROW,
+    dot : 'settings',
+  },
+  {
+    id : 'set-collapse',
+    title : 'Collapse Old Steps',
+    body : 'This shortens older steps — click any shortened step to expand it again.',
+    targetInTracked : COLLAPSE_ROW,
+    dot : 'settings',
+  },
+  {
+    id : 'set-strategy',
+    title : 'Evaluation Strategies',
+    body : 'Normal and Applicative reduce in a different order — run the same expression under each.',
+    targetInTracked : STRATEGY_ROW,
+    dot : 'settings',
   },
   {
     id : 'macros',
     title : 'Macros',
-    body : 'Church numerals, booleans and arithmetic (Y, ZERO, SUC, +, *) are builtin. Your own definitions unfold in the Macros dock beside each box.',
-    live : true,
+    body : 'Builtins live here — Y, ZERO, SUC and arithmetic — and `name := …` above the expression defines your own.',
+    targetInTracked : MACRO_DOCK,
   },
   {
     id : 'yours',
     title : 'Make it yours',
-    body : 'Hover the accent dots or box-style tiles to preview them live across the whole page — click to keep. The top bar also holds notebook settings, zen mode, and export.',
-    target : '[title="Accent theme"]',
+    body : 'The themes panel is open — hover the accent dots or box-style tiles to preview them live, click to keep. Notebook settings, zen mode and export live up here too.',
+    target : THEMES_ICON,
   },
   {
     id : 'md-explain',
     title : 'A Markdown box',
-    body : 'Notes, docs, headings — Markdown boxes hold text, not calculus. Since we came for lambda, let\u2019s remove this one next — deleting boxes is worth knowing anyway.',
+    body : 'Notes, docs, headings — Markdown boxes hold text, not calculus. Since we came for lambda, let’s remove this one next — deleting boxes is worth knowing anyway.',
     branch : true,
-    live : true,
+    dot : 'add',
   },
   {
     id : 'md-delete',
     title : 'Delete a box',
     body : 'Every box deletes from its title-bar controls. Delete this Markdown box now — or press Next and I will do it for you.',
     branch : true,
+    dot : 'add',
     ringTracked : true,
-    live : true,
   },
 ]
 
-const MAIN_DOTS = [ 'welcome', 'add', 'pick', 'type', 'stepping', 'macros', 'yours' ]
+const MAIN_DOTS = [ 'welcome', 'add', 'pick', 'type', 'stepping', 'settings', 'macros', 'yours' ]
 
 const BACK : Record<string, string | null> = {
   welcome : null,
@@ -110,7 +163,12 @@ const BACK : Record<string, string | null> = {
   pick : 'add',
   type : 'pick',
   stepping : 'type',
-  macros : 'stepping',
+  settings : 'stepping',
+  'set-sli' : 'settings',
+  'set-sde' : 'set-sli',
+  'set-collapse' : 'set-sde',
+  'set-strategy' : 'set-collapse',
+  macros : 'set-strategy',
   yours : 'macros',
   'md-explain' : 'pick',
   'md-delete' : 'md-explain',
@@ -119,7 +177,12 @@ const BACK : Record<string, string | null> = {
 const NEXT_MAIN : Record<string, string> = {
   welcome : 'add',
   add : 'pick',
-  stepping : 'macros',
+  stepping : 'settings',
+  settings : 'set-sli',
+  'set-sli' : 'set-sde',
+  'set-sde' : 'set-collapse',
+  'set-collapse' : 'set-strategy',
+  'set-strategy' : 'macros',
   macros : 'yours',
   'md-explain' : 'md-delete',
 }
@@ -130,6 +193,17 @@ function stepById (id : string) : TourStep {
 
 function boxKeyOf (element : Element) : string | null {
   return element.closest('[data-box-key]')?.getAttribute('data-box-key') ?? null
+}
+
+// Backtick spans become inline code, so the expression a step dictates
+// reads as one delimited unit instead of dissolving into the sentence.
+function renderBody (body : string) : React.ReactNode {
+  return body.split(/(`[^`]+`)/g).map((part : string, index : number) =>
+    part.length > 2 && part.startsWith('`') && part.endsWith('`') ?
+      <code key={ index } className='tour--code'>{ part.slice(1, -1) }</code>
+    :
+      part
+  )
 }
 
 
@@ -159,7 +233,7 @@ export default function Tour (props : Props) : JSX.Element {
   const known = useRef<Set<Element>>(new Set())
   const current : TourStep = stepById(id)
   const last : boolean = id === 'yours'
-  const dotIndex : number = current.branch === true ? MAIN_DOTS.indexOf('add') : MAIN_DOTS.indexOf(id)
+  const dotIndex : number = MAIN_DOTS.indexOf(current.dot ?? id)
 
   const goId = (next : string) => {
     if (next === 'add') {
@@ -170,7 +244,7 @@ export default function Tour (props : Props) : JSX.Element {
     saveTourState({ step : stepById(next).id, done : false })
   }
 
-  // Skip (or backdrop): done for now, resume where left off via the icon.
+  // Skip: done for now, resume where left off via the icon.
   const snooze = () => {
     saveTourState({ step : id, done : true })
     onClose()
@@ -213,20 +287,39 @@ export default function Tour (props : Props) : JSX.Element {
 
   // Interactive step: operating the control advances just like Next.
   // Capture phase, so no stopPropagation inside the app can swallow it.
+  // There is no dim and no blocking step anymore — the whole page stays
+  // visibly clickable, so "live" is not a step property but the default.
   useEffect(() => {
-    if (current.advanceOn === undefined) {
+    const docSel : string | undefined = current.advanceOn
+    const scopedSel : string | undefined = current.advanceOnInTracked
+
+    if (docSel === undefined && scopedSel === undefined) {
       return
     }
 
-    const selector : string = current.advanceOn
     const target : string = current.advanceTo ?? id
     const onActivate = (e : Event) => {
       if ((e as Event & Record<string, boolean>)[CHAUFFEUR] === true) {
         return
       }
 
-      if ((e.target as Element | null)?.closest?.(selector) != null) {
+      const el : Element | null = e.target as Element | null
+
+      if (el === null || el.closest === undefined) {
+        return
+      }
+
+      if (docSel !== undefined && el.closest(docSel) !== null) {
         goId(target)
+        return
+      }
+
+      if (scopedSel !== undefined && tracked !== null && tracked.isConnected) {
+        const hit : Element | null = el.closest(scopedSel)
+
+        if (hit !== null && tracked.contains(hit)) {
+          goId(target)
+        }
       }
     }
 
@@ -237,10 +330,12 @@ export default function Tour (props : Props) : JSX.Element {
       document.removeEventListener('mousedown', onActivate, true)
       document.removeEventListener('click', onActivate, true)
     }
-  }, [ id, current.advanceOn ])
+  }, [ id, current.advanceOn, current.advanceOnInTracked, tracked ])
 
   // Branch routing: watch the app for the boxes this run creates, evaluates
-  // or deletes, and walk on when the real thing happens.
+  // or deletes, and walk on when the real thing happens. The detour watches
+  // from its explainer already, so deleting early advances at once instead
+  // of stranding the user on a step about a box that is gone.
   useEffect(() => {
     if (id === 'pick') {
       known.current = new Set([ ...document.querySelectorAll('.box-frame') ])
@@ -276,7 +371,7 @@ export default function Tour (props : Props) : JSX.Element {
       return () => observer.disconnect()
     }
 
-    if (id === 'type' || id === 'md-delete') {
+    if (id === 'type' || id === 'md-delete' || id === 'md-explain') {
       if (tracked === null || !tracked.isConnected) {
         goId('add')
         return
@@ -302,6 +397,23 @@ export default function Tour (props : Props) : JSX.Element {
     }
 
     return undefined
+  }, [ id ])
+
+  // Show, don't tell: the macros and themes steps open the real panels on
+  // arrival — never toggling one that is already open — so the tour points
+  // at living UI instead of describing it.
+  useEffect(() => {
+    if (id === 'macros' && tracked !== null && tracked.isConnected) {
+      const dock : Element | null = tracked.querySelector(MACRO_DOCK)
+
+      if (dock !== null && !dock.classList.contains(MACRO_OPEN)) {
+        (dock.querySelector(MACRO_HEAD) as HTMLElement | null)?.click()
+      }
+    }
+
+    if (id === 'yours' && document.querySelector(THEMES_PANEL) === null) {
+      (document.querySelector(THEMES_ICON) as HTMLElement | null)?.click()
+    }
   }, [ id ])
 
   const chauffeurPickLambda = () => {
@@ -339,6 +451,20 @@ export default function Tour (props : Props) : JSX.Element {
     )
   }
 
+  const chauffeurGear = () => {
+    if (tracked === null || !tracked.isConnected) {
+      goId('add')
+      return
+    }
+
+    // Same road as the hand: open the real panel unless it already is.
+    if (tracked.querySelector(SETTINGS_PANEL) === null) {
+      (tracked.querySelector(GEAR_SELECTOR) as HTMLElement | null)?.click()
+    }
+
+    goId('set-sli')
+  }
+
   const chauffeurDelete = () => {
     if (tracked === null || !tracked.isConnected) {
       goId('add')
@@ -371,6 +497,9 @@ export default function Tour (props : Props) : JSX.Element {
       case 'type':
         chauffeurTypeAndDebug()
         return
+      case 'settings':
+        chauffeurGear()
+        return
       case 'md-delete':
         chauffeurDelete()
         return
@@ -388,6 +517,8 @@ export default function Tour (props : Props) : JSX.Element {
     const element : Element | null =
       current.ringTracked === true ?
         (tracked !== null && tracked.isConnected ? tracked : null)
+      : current.targetInTracked !== undefined ?
+        (tracked !== null && tracked.isConnected ? tracked.querySelector(current.targetInTracked) : null)
       : current.target !== undefined ?
         document.querySelector(current.target)
       :
@@ -397,21 +528,37 @@ export default function Tour (props : Props) : JSX.Element {
       return
     }
 
-    const rect : DOMRect = element.getBoundingClientRect()
+    // The ring re-seats on resize, scroll and the element's own growth —
+    // a stepping box grows under it — so the highlight never lags behind.
+    const place = () => {
+      const rect : DOMRect = element.getBoundingClientRect()
 
-    if (rect.width === 0 && rect.height === 0) {
-      return
+      if (rect.width === 0 && rect.height === 0) {
+        setRing(null)
+        return
+      }
+
+      setRing({ top : rect.top, left : rect.left, width : rect.width, height : rect.height })
     }
 
-    setRing({ top : rect.top, left : rect.left, width : rect.width, height : rect.height })
+    place()
+
+    const ro : ResizeObserver | null =
+      typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(place)
+
+    ro?.observe(element)
+    window.addEventListener('resize', place)
+    document.addEventListener('scroll', place, true)
+
+    return () => {
+      ro?.disconnect()
+      window.removeEventListener('resize', place)
+      document.removeEventListener('scroll', place, true)
+    }
   }, [ id, tracked ])
 
   return (
-    <div className={ current.live === true ? 'tour tour--live' : 'tour' }>
-      { /* Live steps dim without intercepting, so the user can operate the
-           app the step talks about. Snoozing stays one click away on the
-           blocking steps; Skip is always there, so nothing can trap. */ }
-      <div className='tour--backdrop' onClick={ snooze } />
+    <div className='tour'>
       {
         ring !== null ?
           <div
@@ -437,7 +584,7 @@ export default function Tour (props : Props) : JSX.Element {
           }
         </p>
         <p className='tour--title'>{ current.title }</p>
-        <p className='tour--body'>{ current.body }</p>
+        <p className='tour--body'>{ renderBody(current.body) }</p>
         <div className='tour--dots' aria-hidden='true'>
           {
             MAIN_DOTS.map((dot : string) =>

--- a/src/components/Tour.tsx
+++ b/src/components/Tour.tsx
@@ -12,7 +12,15 @@ export interface TourStep {
   // element a ring highlights it; otherwise the card simply stands alone,
   // so steps never break on screens where the target is absent.
   target ?: string
+  // CSS selector of a live control the user may operate mid-step. Clicking
+  // it advances the tour just like Next does; pressing Next activates
+  // ("clicks") it first, so both paths walk the same road.
+  advanceOn ?: string
 }
+
+// The add-box affordance differs by notebook state: an empty notebook shows
+// the big + panel, an occupied one a + row after each box.
+const ADD_BOX_SELECTOR = '.top-level--create-box, .add_box_after, .create-box-plus'
 
 export const TOUR_STEPS : Array<TourStep> = [
   {
@@ -21,8 +29,10 @@ export const TOUR_STEPS : Array<TourStep> = [
     target : '.top-bar--tabs',
   },
   {
-    title : 'Here\u2019s your first box',
-    body : 'We added an evaluated expression — (λ x . x y) applied to a, waiting at its first step below. Hit the + affordance to add more boxes anytime; this one deletes like any other.',
+    title : 'Add a box',
+    body : 'Boxes are the cells of a notebook — your evaluated sample below is one already. Add your own: click the + affordance yourself, or press Next and I will click it for you.',
+    target : ADD_BOX_SELECTOR,
+    advanceOn : ADD_BOX_SELECTOR,
   },
   {
     title : 'Write and evaluate',
@@ -30,7 +40,7 @@ export const TOUR_STEPS : Array<TourStep> = [
   },
   {
     title : 'Step through evaluation',
-    body : 'Run walks all the way, Step advances once. A box\u2019s settings switch the strategy (normal, applicative…), toggle single-letter variables, and expand standalones.',
+    body : 'Run walks all the way to the normal form, Step advances once — try it on your sample box below. A box\u2019s settings switch the strategy (normal, applicative…), toggle single-letter variables, and expand standalones.',
   },
   {
     title : 'Macros',
@@ -70,7 +80,7 @@ function clampStep (step : number) : number {
 export default function Tour (props : Props) : JSX.Element {
   const { initialStep, demoBoxKey, onClose } : Props = props
   const steps : Array<TourStep> = TOUR_STEPS.map((step, i) =>
-    i === 1 && demoBoxKey !== null ?
+    i === 3 && demoBoxKey !== null ?
       { ...step, target : `[data-box-key="${demoBoxKey}"]` }
     :
       step
@@ -91,6 +101,64 @@ export default function Tour (props : Props) : JSX.Element {
     const clamped : number = clampStep(next)
     setStep(clamped)
     persist(clamped, false)
+  }
+
+  // Flag marking events the tour dispatches itself, so the document
+  // listener below can tell chauffeur mode apart from the user's own hand.
+  const CHAUFFEUR = '__tourChauffeur'
+
+  // "Click" a target the way the + affordances listen: the rows open on
+  // mousedown, the empty-notebook panel on click. Flagged so the listener
+  // opens the control's UI without advancing the tour a second time.
+  const activateTarget = (selector : string) : void => {
+    const element : Element | null = document.querySelector(selector)
+
+    if (element === null) {
+      return
+    }
+
+    for (const kind of [ 'mousedown', 'click' ]) {
+      const event : MouseEvent & Record<string, boolean> = new MouseEvent(kind, { bubbles : true, cancelable : true }) as MouseEvent & Record<string, boolean>
+      event[CHAUFFEUR] = true
+      element.dispatchEvent(event)
+    }
+  }
+
+  // Interactive step: operating the control advances just like Next.
+  // Capture phase, so no stopPropagation inside the app can swallow it.
+  useEffect(() => {
+    if (current.advanceOn === undefined) {
+      return
+    }
+
+    const selector : string = current.advanceOn
+    const onActivate = (e : Event) => {
+      if ((e as Event & Record<string, boolean>)[CHAUFFEUR] === true) {
+        return
+      }
+
+      if ((e.target as Element | null)?.closest?.(selector) != null) {
+        go(step + 1)
+      }
+    }
+
+    document.addEventListener('mousedown', onActivate, true)
+    document.addEventListener('click', onActivate, true)
+
+    return () => {
+      document.removeEventListener('mousedown', onActivate, true)
+      document.removeEventListener('click', onActivate, true)
+    }
+  }, [ step, current.advanceOn ])
+
+  const next = () => {
+    // Chauffeur mode: work the control ourselves (its flagged events open
+    // the control's UI but never advance), then walk on exactly once.
+    if (current.advanceOn !== undefined) {
+      activateTarget(current.advanceOn)
+    }
+
+    go(step + 1)
   }
 
   // Skip (or backdrop): done for now, resume where left off via the icon.
@@ -128,7 +196,9 @@ export default function Tour (props : Props) : JSX.Element {
   }, [ step, current.target ])
 
   return (
-    <div className='tour'>
+    <div className={ current.advanceOn !== undefined ? 'tour tour--interactive' : 'tour' }>
+      { /* Interactive steps let clicks through to the live control below;
+           Skip stays the way out, so nothing can trap the user. */ }
       <div className='tour--backdrop' onClick={ snooze } />
       {
         ring !== null ?
@@ -168,7 +238,7 @@ export default function Tour (props : Props) : JSX.Element {
             last ?
               <button className='tour--btn tour--btn--primary' onClick={ finish }>Done</button>
             :
-              <button className='tour--btn tour--btn--primary' onClick={ () => go(step + 1) }>Next</button>
+              <button className='tour--btn tour--btn--primary' onClick={ next }>Next</button>
           }
         </div>
       </div>

--- a/src/components/Tour.tsx
+++ b/src/components/Tour.tsx
@@ -1,11 +1,13 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
+import { flushSync } from 'react-dom'
 
-import { loadTourState, saveTourState } from '../Constants'
+import { saveTourState } from '../Constants'
 
 import '../styles/Tour.css'
 
 
 export interface TourStep {
+  id : string
   title : string
   body : string
   // CSS selector of the UI the step points at. When it matches a visible
@@ -16,50 +18,112 @@ export interface TourStep {
   // it advances the tour just like Next does; pressing Next activates
   // ("clicks") it first, so both paths walk the same road.
   advanceOn ?: string
+  // Ring the box this tour run is working with instead of a selector.
+  ringTracked ?: boolean
+  // Detour steps render the main-path dots parked at the + step.
+  branch ?: boolean
 }
 
 // The add-box affordance differs by notebook state: an empty notebook shows
 // the big + panel, an occupied one a + row after each box.
 const ADD_BOX_SELECTOR = '.top-level--create-box, .add_box_after, .create-box-plus'
 
+const LAMBDA_PICK_TITLE = 'Create new λ box'
+const TYPE_EXPRESSION = '(λ x . x y) a'
+
 export const TOUR_STEPS : Array<TourStep> = [
   {
+    id : 'welcome',
     title : 'Welcome to Lambdulus',
     body : 'A notebook for playing with lambda calculus. Your work lives in notebooks — switch them in the tabs above. This tour takes a minute; skip anytime.',
     target : '.top-bar--tabs',
   },
   {
+    id : 'add',
     title : 'Add a box',
-    body : 'Boxes are the cells of a notebook — your evaluated sample below is one already. Add your own: click the + affordance yourself, or press Next and I will click it for you.',
+    body : 'Boxes are the cells of a notebook. Add one now: click the + affordance — or press Next and I will click it for you.',
     target : ADD_BOX_SELECTOR,
     advanceOn : ADD_BOX_SELECTOR,
   },
   {
+    id : 'pick',
+    title : 'Pick a box type',
+    body : 'A λ Expression box evaluates lambda calculus step by step. A Markdown box holds notes and docs. Pick λ Expression to keep walking with me.',
+  },
+  {
+    id : 'type',
     title : 'Write and evaluate',
-    body : 'Type an expression, then Debug (Ctrl + Enter) to evaluate it step by step, or Exercise (Shift + Enter) to take the steps yourself. Lines above the expression define macros — NAME := definition, each ending with a semicolon.',
+    body : 'Type (\\ x . x y) a into the editor — the backslash becomes λ as you type — then press Debug (Ctrl + Enter). Press Next and I will do it for you.',
   },
   {
+    id : 'stepping',
     title : 'Step through evaluation',
-    body : 'Run walks all the way to the normal form, Step advances once — try it on your sample box below. A box\u2019s settings switch the strategy (normal, applicative…), toggle single-letter variables, and expand standalones.',
+    body : 'There it is — evaluated and waiting at its first step. Run walks all the way to the normal form, Step advances once — try it now. A box\u2019s settings switch the strategy (normal, applicative…), toggle single-letter variables, and expand standalones.',
+    ringTracked : true,
   },
   {
+    id : 'macros',
     title : 'Macros',
     body : 'Church numerals, booleans and arithmetic (Y, ZERO, SUC, +, *) are builtin. Your own definitions unfold in the Macros dock beside each box.',
   },
   {
+    id : 'yours',
     title : 'Make it yours',
     body : 'Hover the accent dots or box-style tiles to preview them live across the whole page — click to keep. The top bar also holds notebook settings, zen mode, and export.',
     target : '[title="Accent theme"]',
   },
+  {
+    id : 'md-explain',
+    title : 'A Markdown box',
+    body : 'Notes, docs, headings — Markdown boxes hold text, not calculus. Since we came for lambda, let\u2019s remove this one next — deleting boxes is worth knowing anyway.',
+    branch : true,
+  },
+  {
+    id : 'md-delete',
+    title : 'Delete a box',
+    body : 'Every box deletes from its title-bar controls. Delete this Markdown box now — or press Next and I will do it for you.',
+    branch : true,
+    ringTracked : true,
+  },
 ]
+
+const MAIN_DOTS = [ 'welcome', 'add', 'pick', 'type', 'stepping', 'macros', 'yours' ]
+
+const BACK : Record<string, string | null> = {
+  welcome : null,
+  add : 'welcome',
+  pick : 'add',
+  type : 'pick',
+  stepping : 'type',
+  macros : 'stepping',
+  yours : 'macros',
+  'md-explain' : 'pick',
+  'md-delete' : 'md-explain',
+}
+
+const NEXT_MAIN : Record<string, string> = {
+  welcome : 'add',
+  add : 'pick',
+  stepping : 'macros',
+  macros : 'yours',
+  'md-explain' : 'md-delete',
+}
+
+function stepById (id : string) : TourStep {
+  return TOUR_STEPS.find((step) => step.id === id) ?? TOUR_STEPS[0]
+}
+
+function boxKeyOf (element : Element) : string | null {
+  return element.closest('[data-box-key]')?.getAttribute('data-box-key') ?? null
+}
 
 
 interface Props {
-  initialStep : number
-  // __key of the demo box seeded for this tour, if any. Step two rings it;
-  // a missing or deleted box simply leaves that step ringless.
-  demoBoxKey : string | null
+  initialStep : string
   onClose () : void
+  onAddLambdaBox () : string | null
+  onFillBoxEditor (boxKey : string, content : string) : void
+  onDeleteBox (boxKey : string) : void
 }
 
 interface Ring {
@@ -69,38 +133,46 @@ interface Ring {
   height : number
 }
 
-function clampStep (step : number) : number {
-  if (Number.isNaN(step)) {
-    return 0
-  }
-
-  return Math.max(0, Math.min(TOUR_STEPS.length - 1, Math.floor(step)))
-}
-
 export default function Tour (props : Props) : JSX.Element {
-  const { initialStep, demoBoxKey, onClose } : Props = props
-  const steps : Array<TourStep> = TOUR_STEPS.map((step, i) =>
-    i === 3 && demoBoxKey !== null ?
-      { ...step, target : `[data-box-key="${demoBoxKey}"]` }
-    :
-      step
-  )
-  const [ step, setStep ] = useState(() => clampStep(initialStep))
+  const { initialStep, onClose, onAddLambdaBox, onFillBoxEditor, onDeleteBox } : Props = props
+  const [ id, setId ] = useState(() => stepById(initialStep).id)
+  // The box frame this tour run is working with. Session-only: a reload
+  // forgets it, and the wait steps below loop back to 'add' instead of
+  // ever touching a stranger's box.
+  const [ tracked, setTracked ] = useState<Element | null>(null)
   const [ ring, setRing ] = useState<Ring | null>(null)
-  const current : TourStep = steps[step]
-  const last : boolean = step === steps.length - 1
+  const known = useRef<Set<Element>>(new Set())
+  const current : TourStep = stepById(id)
+  const last : boolean = id === 'yours'
+  const dotIndex : number = current.branch === true ? MAIN_DOTS.indexOf('add') : MAIN_DOTS.indexOf(id)
 
-  // Step and done move; seeded and the demo key belong to the box,
-  // never to the walk.
-  const persist = (nextStep : number, done : boolean) => {
-    const stored = loadTourState()
-    saveTourState({ step : nextStep, done, seeded : stored?.seeded ?? false, demoBoxKey : stored?.demoBoxKey ?? null })
+  const goId = (next : string) => {
+    if (next === 'add') {
+      setTracked(null)
+    }
+
+    setId(stepById(next).id)
+    saveTourState({ step : stepById(next).id, done : false })
   }
 
-  const go = (next : number) => {
-    const clamped : number = clampStep(next)
-    setStep(clamped)
-    persist(clamped, false)
+  // Skip (or backdrop): done for now, resume where left off via the icon.
+  const snooze = () => {
+    saveTourState({ step : id, done : true })
+    onClose()
+  }
+
+  // Done on the last step: restart from the beginning next time.
+  const finish = () => {
+    saveTourState({ step : 'welcome', done : true })
+    onClose()
+  }
+
+  const back = () => {
+    const prev : string | null = BACK[id]
+
+    if (prev !== null) {
+      goId(prev)
+    }
   }
 
   // Flag marking events the tour dispatches itself, so the document
@@ -138,7 +210,7 @@ export default function Tour (props : Props) : JSX.Element {
       }
 
       if ((e.target as Element | null)?.closest?.(selector) != null) {
-        go(step + 1)
+        goId(MAIN_DOTS[MAIN_DOTS.indexOf(id) + 1] ?? id)
       }
     }
 
@@ -149,38 +221,161 @@ export default function Tour (props : Props) : JSX.Element {
       document.removeEventListener('mousedown', onActivate, true)
       document.removeEventListener('click', onActivate, true)
     }
-  }, [ step, current.advanceOn ])
+  }, [ id, current.advanceOn ])
 
-  const next = () => {
-    // Chauffeur mode: work the control ourselves (its flagged events open
-    // the control's UI but never advance), then walk on exactly once.
-    if (current.advanceOn !== undefined) {
-      activateTarget(current.advanceOn)
+  // Branch routing: watch the app for the boxes this run creates, evaluates
+  // or deletes, and walk on when the real thing happens.
+  useEffect(() => {
+    if (id === 'pick') {
+      known.current = new Set([ ...document.querySelectorAll('.box-frame') ])
+
+      const check = () => {
+        for (const frame of document.querySelectorAll('.box-frame')) {
+          if (known.current.has(frame)) {
+            continue
+          }
+
+          known.current.add(frame)
+
+          if (frame.querySelector('.untypedLambdaBox') !== null) {
+            setTracked(frame)
+            goId('type')
+            return
+          }
+
+          if (frame.querySelector('.markDownBox') !== null) {
+            setTracked(frame)
+            goId('md-explain')
+            return
+          }
+
+          // Unknown box type: watched, but never routed on.
+        }
+      }
+
+      check()
+      const observer = new MutationObserver(check)
+      observer.observe(document.body, { childList : true, subtree : true })
+
+      return () => observer.disconnect()
     }
 
-    go(step + 1)
+    if (id === 'type' || id === 'md-delete') {
+      if (tracked === null || !tracked.isConnected) {
+        goId('add')
+        return
+      }
+
+      const check = () => {
+        if (!tracked.isConnected) {
+          goId('add')
+          return
+        }
+
+        // A submitted box renders its history; an empty one only the editor.
+        if (id === 'type' && tracked.querySelector('.box-history-wrap') !== null) {
+          goId('stepping')
+        }
+      }
+
+      check()
+      const observer = new MutationObserver(check)
+      observer.observe(document.body, { childList : true, subtree : true })
+
+      return () => observer.disconnect()
+    }
+
+    return undefined
+  }, [ id ])
+
+  const chauffeurPickLambda = () => {
+    // Prefer the open picker (same road as the hand); fall back to state
+    // when the modal is nowhere to be found. Either way the pick watcher
+    // above routes on the new box.
+    const option : Element | null = document.querySelector(`[title="${LAMBDA_PICK_TITLE}"]`)
+
+    if (option !== null) {
+      (option as HTMLElement).click()
+      return
+    }
+
+    onAddLambdaBox()
   }
 
-  // Skip (or backdrop): done for now, resume where left off via the icon.
-  const snooze = () => {
-    persist(step, true)
-    onClose()
+  const chauffeurTypeAndDebug = () => {
+    if (tracked === null || !tracked.isConnected) {
+      goId('add')
+      return
+    }
+
+    const boxKey : string | null = boxKeyOf(tracked)
+
+    if (boxKey === null) {
+      goId('add')
+      return
+    }
+
+    // Flush first: the Debug submit below reads the box from the committed
+    // render, so filling without flushing would submit the stale content.
+    flushSync(() => onFillBoxEditor(boxKey, TYPE_EXPRESSION))
+    tracked.querySelector('.open-as-debug')?.dispatchEvent(
+      new MouseEvent('click', { bubbles : true, cancelable : true })
+    )
   }
 
-  // Done on the last step: restart from the beginning next time.
-  const finish = () => {
-    persist(0, true)
-    onClose()
+  const chauffeurDelete = () => {
+    if (tracked === null || !tracked.isConnected) {
+      goId('add')
+      return
+    }
+
+    const boxKey : string | null = boxKeyOf(tracked)
+
+    if (boxKey === null) {
+      goId('add')
+      return
+    }
+
+    onDeleteBox(boxKey)
+  }
+
+  const next = () => {
+    // Chauffeur mode on the + step: work the control ourselves (its flagged
+    // events open the picker's UI but never advance), then walk on once.
+    if (current.advanceOn !== undefined) {
+      activateTarget(current.advanceOn)
+      goId(NEXT_MAIN[id] ?? id)
+      return
+    }
+
+    switch (id) {
+      case 'pick':
+        chauffeurPickLambda()
+        return
+      case 'type':
+        chauffeurTypeAndDebug()
+        return
+      case 'md-delete':
+        chauffeurDelete()
+        return
+      case 'yours':
+        finish()
+        return
+      default:
+        goId(NEXT_MAIN[id] ?? id)
+    }
   }
 
   useEffect(() => {
     setRing(null)
 
-    if (!current.target) {
-      return
-    }
-
-    const element : Element | null = document.querySelector(current.target)
+    const element : Element | null =
+      current.ringTracked === true ?
+        (tracked !== null && tracked.isConnected ? tracked : null)
+      : current.target !== undefined ?
+        document.querySelector(current.target)
+      :
+        null
 
     if (element === null) {
       return
@@ -193,7 +388,7 @@ export default function Tour (props : Props) : JSX.Element {
     }
 
     setRing({ top : rect.top, left : rect.left, width : rect.width, height : rect.height })
-  }, [ step, current.target ])
+  }, [ id, tracked ])
 
   return (
     <div className={ current.advanceOn !== undefined ? 'tour tour--interactive' : 'tour' }>
@@ -216,27 +411,34 @@ export default function Tour (props : Props) : JSX.Element {
           null
       }
       <div className='tour--card' role='dialog' aria-label={ `Guided tour: ${current.title}` }>
-        <p className='tour--kicker'>Guided tour · { step + 1 } of { TOUR_STEPS.length }</p>
+        <p className='tour--kicker'>
+          {
+            current.branch === true ?
+              'Guided tour · Markdown detour'
+            :
+              `Guided tour · ${dotIndex + 1} of ${MAIN_DOTS.length}`
+          }
+        </p>
         <p className='tour--title'>{ current.title }</p>
         <p className='tour--body'>{ current.body }</p>
         <div className='tour--dots' aria-hidden='true'>
           {
-            TOUR_STEPS.map((_, i : number) =>
-              <span key={ i } className={ i === step ? 'tour--dot tour--dot--active' : 'tour--dot' } />
+            MAIN_DOTS.map((dot : string) =>
+              <span key={ dot } className={ MAIN_DOTS[dotIndex] === dot ? 'tour--dot tour--dot--active' : 'tour--dot' } />
             )
           }
         </div>
         <div className='tour--actions'>
           {
-            step > 0 ?
-              <button className='tour--btn' onClick={ () => go(step - 1) }>Back</button>
+            BACK[id] !== null ?
+              <button className='tour--btn' onClick={ back }>Back</button>
             :
               <span />
           }
           <button className='tour--btn' onClick={ snooze }>Skip</button>
           {
             last ?
-              <button className='tour--btn tour--btn--primary' onClick={ finish }>Done</button>
+              <button className='tour--btn tour--btn--primary' onClick={ next }>Done</button>
             :
               <button className='tour--btn tour--btn--primary' onClick={ next }>Next</button>
           }

--- a/src/components/Tour.tsx
+++ b/src/components/Tour.tsx
@@ -15,18 +15,25 @@ export interface TourStep {
   // so steps never break on screens where the target is absent.
   target ?: string
   // CSS selector of a live control the user may operate mid-step. Clicking
-  // it advances the tour just like Next does; pressing Next activates
-  // ("clicks") it first, so both paths walk the same road.
+  // it advances the tour to advanceTo just like Next does; pressing Next
+  // activates ("clicks") it first, so both paths walk the same road.
   advanceOn ?: string
+  // Where operating advanceOn (or chauffeuring it through Next) walks to.
+  advanceTo ?: string
+  // Click-through step: the overlay dims but never intercepts, so the user
+  // can operate the app the step talks about. Every step that asks for a
+  // real click must be live, or the backdrop traps the user out.
+  live ?: boolean
   // Ring the box this tour run is working with instead of a selector.
   ringTracked ?: boolean
   // Detour steps render the main-path dots parked at the + step.
   branch ?: boolean
 }
 
-// The add-box affordance differs by notebook state: an empty notebook shows
-// the big + panel, an occupied one a + row after each box.
-const ADD_BOX_SELECTOR = '.top-level--create-box, .add_box_after, .create-box-plus'
+// The clickable add-box controls: the big + panel's button on empty
+// notebooks, the + row after each box on occupied ones. (Their inert
+// wrapper divs are deliberately excluded — "clicking" those opens nothing.)
+const ADD_BOX_SELECTOR = '.create-box-plus, .add_box_after'
 
 const LAMBDA_PICK_TITLE = 'Create new λ box'
 const TYPE_EXPRESSION = '(λ x . x y) a'
@@ -44,27 +51,33 @@ export const TOUR_STEPS : Array<TourStep> = [
     body : 'Boxes are the cells of a notebook. Add one now: click the + affordance — or press Next and I will click it for you.',
     target : ADD_BOX_SELECTOR,
     advanceOn : ADD_BOX_SELECTOR,
+    advanceTo : 'pick',
+    live : true,
   },
   {
     id : 'pick',
     title : 'Pick a box type',
     body : 'A λ Expression box evaluates lambda calculus step by step. A Markdown box holds notes and docs. Pick λ Expression to keep walking with me.',
+    live : true,
   },
   {
     id : 'type',
     title : 'Write and evaluate',
     body : 'Type (\\ x . x y) a into the editor — the backslash becomes λ as you type — then press Debug (Ctrl + Enter). Press Next and I will do it for you.',
+    live : true,
   },
   {
     id : 'stepping',
     title : 'Step through evaluation',
     body : 'There it is — evaluated and waiting at its first step. Run walks all the way to the normal form, Step advances once — try it now. A box\u2019s settings switch the strategy (normal, applicative…), toggle single-letter variables, and expand standalones.',
     ringTracked : true,
+    live : true,
   },
   {
     id : 'macros',
     title : 'Macros',
     body : 'Church numerals, booleans and arithmetic (Y, ZERO, SUC, +, *) are builtin. Your own definitions unfold in the Macros dock beside each box.',
+    live : true,
   },
   {
     id : 'yours',
@@ -77,6 +90,7 @@ export const TOUR_STEPS : Array<TourStep> = [
     title : 'A Markdown box',
     body : 'Notes, docs, headings — Markdown boxes hold text, not calculus. Since we came for lambda, let\u2019s remove this one next — deleting boxes is worth knowing anyway.',
     branch : true,
+    live : true,
   },
   {
     id : 'md-delete',
@@ -84,6 +98,7 @@ export const TOUR_STEPS : Array<TourStep> = [
     body : 'Every box deletes from its title-bar controls. Delete this Markdown box now — or press Next and I will do it for you.',
     branch : true,
     ringTracked : true,
+    live : true,
   },
 ]
 
@@ -204,13 +219,14 @@ export default function Tour (props : Props) : JSX.Element {
     }
 
     const selector : string = current.advanceOn
+    const target : string = current.advanceTo ?? id
     const onActivate = (e : Event) => {
       if ((e as Event & Record<string, boolean>)[CHAUFFEUR] === true) {
         return
       }
 
       if ((e.target as Element | null)?.closest?.(selector) != null) {
-        goId(MAIN_DOTS[MAIN_DOTS.indexOf(id) + 1] ?? id)
+        goId(target)
       }
     }
 
@@ -344,7 +360,7 @@ export default function Tour (props : Props) : JSX.Element {
     // events open the picker's UI but never advance), then walk on once.
     if (current.advanceOn !== undefined) {
       activateTarget(current.advanceOn)
-      goId(NEXT_MAIN[id] ?? id)
+      goId(current.advanceTo ?? id)
       return
     }
 
@@ -391,9 +407,10 @@ export default function Tour (props : Props) : JSX.Element {
   }, [ id, tracked ])
 
   return (
-    <div className={ current.advanceOn !== undefined ? 'tour tour--interactive' : 'tour' }>
-      { /* Interactive steps let clicks through to the live control below;
-           Skip stays the way out, so nothing can trap the user. */ }
+    <div className={ current.live === true ? 'tour tour--live' : 'tour' }>
+      { /* Live steps dim without intercepting, so the user can operate the
+           app the step talks about. Snoozing stays one click away on the
+           blocking steps; Skip is always there, so nothing can trap. */ }
       <div className='tour--backdrop' onClick={ snooze } />
       {
         ring !== null ?

--- a/src/components/Tour.tsx
+++ b/src/components/Tour.tsx
@@ -27,12 +27,15 @@ export interface TourStep {
   advanceOnInTracked ?: string
   // Where operating advanceOn (or chauffeuring it through Next) walks to.
   advanceTo ?: string
-  // Ring the box this tour run is working with instead of a selector.
-  ringTracked ?: boolean
   // The target only resolves once a box exists (the box map hides on an
   // empty notebook): the fresh-render selector sweep skips these, and the
   // conducted walk asserts them against its live box instead.
   needsBox ?: boolean
+  // The target lives inside transient UI the tour opens on arrival (the
+  // box-type picker, the clearing options, the theme panels): absent in
+  // a fresh render by construction, covered by the conducted walk with
+  // the panels actually open instead.
+  needsPanel ?: boolean
   // Detour steps render the main-path dots parked at the + step.
   branch ?: boolean
   // Park this step's dot on another step (settings cluster, detour).
@@ -45,7 +48,11 @@ export interface TourStep {
 const ADD_BOX_SELECTOR = '.create-box-plus, .add_box_after'
 
 const LAMBDA_PICK_TITLE = 'Create new λ box'
+const LAMBDA_PICK_SELECTOR = `[title="${LAMBDA_PICK_TITLE}"]`
 const TYPE_EXPRESSION = '(λ x . x y) a'
+
+// The Debug Step button, ringed alone — never the whole evaluated box.
+const STEP_SELECTOR = '.debug-controls--step'
 
 // Per-box controls the tour conducts: the settings gear and its panel,
 // the macros dock, and one row hook per box setting.
@@ -60,6 +67,27 @@ const STRATEGY_ROW = '.untyped-lambda-settings-strategies'
 // The top-bar themes control and its panel.
 const THEMES_ICON = '[title="Accent theme"]'
 const THEMES_PANEL = '.top-bar--accent-pick'
+
+// The zen switch, and the clearing-options eraser with the workspace
+// button that marks its open panel.
+const ZEN_SELECTOR = '.top-bar--zen'
+const CLEAR_SELECTOR = '[title="Clearing options"]'
+const CLEAN_WORKSPACE_TITLE = 'Erase all notebooks and start over with the defaults'
+
+// The take-with-you and meta controls closing the tour: notebook
+// export, the per-box share-link control, the bug reporter, and the
+// walkme icon itself.
+const EXPORT_SELECTOR = '[title="Download this Notebook"]'
+const SHARE_SELECTOR = '[title="Copy the link to this Expression."]'
+const BUG_SELECTOR = '[title="Submit a bug or a feature request"]'
+const TOUR_SELECTOR = '[title="Guided tour"]'
+
+// The clearing panel's two exits: Clear notebook is the plain button
+// (its title carries the live notebook name), Clean workspace the
+// danger one. The theme panel's accent row and box-style tiles.
+const CLEAR_NOTEBOOK_SELECTOR = '.top-bar--clear-btn:not(.btn-danger)'
+const CLEAN_WORKSPACE_SELECTOR = `[title="${CLEAN_WORKSPACE_TITLE}"]`
+const THEME_STYLE_SELECTOR = '.top-bar--boxpreview'
 
 export const TOUR_STEPS : Array<TourStep> = [
   {
@@ -79,7 +107,9 @@ export const TOUR_STEPS : Array<TourStep> = [
   {
     id : 'pick',
     title : 'Pick a box type',
-    body : 'A λ Expression box evaluates lambda calculus step by step. A Markdown box holds notes and docs. Pick λ Expression to keep walking with me.',
+    body : 'A λ Expression box evaluates lambda calculus step by step. A Markdown box holds notes and docs. Pick λ Expression — the highlighted one — to keep walking with me.',
+    target : LAMBDA_PICK_SELECTOR,
+    needsPanel : true,
   },
   {
     id : 'type',
@@ -90,7 +120,7 @@ export const TOUR_STEPS : Array<TourStep> = [
     id : 'stepping',
     title : 'Step through evaluation',
     body : 'Evaluated, waiting at its first step. Run walks all the way to the normal form; Step advances once. Try it now — or press `F8` to step, `F9` to run.',
-    ringTracked : true,
+    targetInTracked : STEP_SELECTOR,
   },
   {
     id : 'boxmap',
@@ -142,10 +172,86 @@ export const TOUR_STEPS : Array<TourStep> = [
     targetInTracked : MACRO_DOCK,
   },
   {
+    id : 'share',
+    title : 'Share one box',
+    body : 'This link control copies a link that carries exactly this one box — expression, macros and all. Send it to someone and they get this box, not the whole notebook.',
+    targetInTracked : SHARE_SELECTOR,
+  },
+  {
+    id : 'zen',
+    title : 'Zen mode',
+    body : 'One box gets the whole viewport — no siblings, no rails, nothing competing for your eyes. Flip the zen switch up top — or press Next and I will — and feel how quiet calculus gets.',
+    target : ZEN_SELECTOR,
+    advanceOn : ZEN_SELECTOR,
+    advanceTo : 'zen-dwell',
+  },
+  {
+    id : 'zen-dwell',
+    title : 'Settle into zen',
+    body : 'No sibling boxes, no rails, no panels — just this box and the top bar. Scroll it, keep stepping through the evaluation, feel how quiet calculus gets. When the quiet lands, walk on.',
+    dot : 'zen',
+  },
+  {
+    id : 'cleaning',
+    title : 'A clean slate',
+    body : 'The eraser up top holds both exits — let us walk them one by one. Showing only: your boxes stay exactly where they are.',
+    target : CLEAR_SELECTOR,
+  },
+  {
+    id : 'clean-notebook',
+    title : 'Clear notebook',
+    body : 'Clear notebook empties this notebook — every box goes, the notebook itself stays. Showing only: nothing is pressed behind your back.',
+    target : CLEAR_NOTEBOOK_SELECTOR,
+    needsPanel : true,
+    dot : 'cleaning',
+  },
+  {
+    id : 'clean-workspace',
+    title : 'Clean entire workspace',
+    body : 'Clean entire workspace restarts everything from the defaults — every notebook, back to a clean slate. Showing only: the box we built stays put, yours to keep.',
+    target : CLEAN_WORKSPACE_SELECTOR,
+    needsPanel : true,
+    dot : 'cleaning',
+  },
+  {
     id : 'yours',
     title : 'Make it yours',
-    body : 'The themes panel is open — hover the accent dots or box-style tiles to preview them live, click to keep. Notebook settings, zen mode and export live up here too.',
+    body : 'Lambdulus dresses to your taste — the themes panel is open. Two quick walks: accent color first, then box style. Notebook settings, zen mode and export live up here too.',
     target : THEMES_ICON,
+  },
+  {
+    id : 'theme-accent',
+    title : 'Accent color',
+    body : 'Hover the accent dots — Beta, Lambda, Eta, Alpha — to preview each live across the whole site. Click to keep the one you love.',
+    target : THEMES_PANEL,
+    needsPanel : true,
+    dot : 'yours',
+  },
+  {
+    id : 'theme-style',
+    title : 'Box style',
+    body : 'The tiles below switch the boxes themselves — Cards or Classic. Hover to preview, click to keep.',
+    target : THEME_STYLE_SELECTOR,
+    needsPanel : true,
+    dot : 'yours',
+  },
+  {
+    id : 'transfer',
+    title : 'Import and export',
+    body : 'The download arrow exports this notebook to a file — persistent storage for your work. The upload arrow imports such a file back, so notebooks are easy to share with other people.',
+    target : EXPORT_SELECTOR,
+  },
+  {
+    id : 'report',
+    title : 'Report a bug',
+    body : 'If something breaks or misbehaves, the bug icon reports it to the GitHub repo — issues and feature requests both live there.',
+    target : BUG_SELECTOR,
+  },
+  {
+    id : 'recap',
+    title : 'Walk me again',
+    body : 'And if you ever need a recap, here is the walkme again — this icon replays the tour whenever you want it.',
+    target : TOUR_SELECTOR,
   },
   {
     id : 'md-explain',
@@ -164,7 +270,7 @@ export const TOUR_STEPS : Array<TourStep> = [
   },
 ]
 
-const MAIN_DOTS = [ 'welcome', 'add', 'pick', 'type', 'stepping', 'boxmap', 'settings', 'macros', 'yours' ]
+const MAIN_DOTS = [ 'welcome', 'add', 'pick', 'type', 'stepping', 'boxmap', 'settings', 'macros', 'share', 'zen', 'cleaning', 'yours', 'transfer', 'report', 'recap' ]
 
 const BACK : Record<string, string | null> = {
   welcome : null,
@@ -179,7 +285,18 @@ const BACK : Record<string, string | null> = {
   'set-collapse' : 'set-sde',
   'set-strategy' : 'set-collapse',
   macros : 'set-strategy',
-  yours : 'macros',
+  share : 'macros',
+  zen : 'share',
+  'zen-dwell' : 'zen',
+  cleaning : 'zen-dwell',
+  'clean-notebook' : 'cleaning',
+  'clean-workspace' : 'clean-notebook',
+  yours : 'clean-workspace',
+  'theme-accent' : 'yours',
+  'theme-style' : 'theme-accent',
+  transfer : 'theme-style',
+  report : 'transfer',
+  recap : 'report',
   'md-explain' : 'pick',
   'md-delete' : 'md-explain',
 }
@@ -194,7 +311,18 @@ const NEXT_MAIN : Record<string, string> = {
   'set-sde' : 'set-collapse',
   'set-collapse' : 'set-strategy',
   'set-strategy' : 'macros',
-  macros : 'yours',
+  macros : 'share',
+  share : 'zen',
+  zen : 'zen-dwell',
+  'zen-dwell' : 'cleaning',
+  cleaning : 'clean-notebook',
+  'clean-notebook' : 'clean-workspace',
+  'clean-workspace' : 'yours',
+  yours : 'theme-accent',
+  'theme-accent' : 'theme-style',
+  'theme-style' : 'transfer',
+  transfer : 'report',
+  report : 'recap',
   'md-explain' : 'md-delete',
 }
 
@@ -225,7 +353,9 @@ interface Props {
   onFillBoxEditor (boxKey : string, content : string) : void
   onSetBoxSettings (boxKey : string, open : boolean) : void
   onShowBoxMacros (boxKey : string) : void
+  onHideBoxMacros (boxKey : string) : void
   onDeleteBox (boxKey : string) : void
+  onSetZenMode (zenMode : boolean) : void
 }
 
 interface Ring {
@@ -236,7 +366,7 @@ interface Ring {
 }
 
 export default function Tour (props : Props) : JSX.Element {
-  const { initialStep, onClose, onAddLambdaBox, onFillBoxEditor, onSetBoxSettings, onShowBoxMacros, onDeleteBox } : Props = props
+  const { initialStep, onClose, onAddLambdaBox, onFillBoxEditor, onSetBoxSettings, onShowBoxMacros, onHideBoxMacros, onDeleteBox, onSetZenMode } : Props = props
   const [ id, setId ] = useState(() => stepById(initialStep).id)
   // The box frame this tour run is working with. Session-only: a reload
   // forgets it, and the wait steps below loop back to 'add' instead of
@@ -245,7 +375,7 @@ export default function Tour (props : Props) : JSX.Element {
   const [ ring, setRing ] = useState<Ring | null>(null)
   const known = useRef<Set<Element>>(new Set())
   const current : TourStep = stepById(id)
-  const last : boolean = id === 'yours'
+  const last : boolean = id === 'recap'
   const dotIndex : number = MAIN_DOTS.indexOf(current.dot ?? id)
 
   const goId = (next : string) => {
@@ -264,9 +394,15 @@ export default function Tour (props : Props) : JSX.Element {
   }
 
   // Done on the last step: restart from the beginning next time.
+  // Done means done — and the finale's clearing panel steps out with
+  // the tour, never left open behind it.
   const finish = () => {
     saveTourState({ step : 'welcome', done : true })
     onClose()
+    const backdrop : HTMLElement | null = document.querySelector('.top-bar--backdrop')
+    if (backdrop !== null) {
+      backdrop.click()
+    }
   }
 
   const back = () => {
@@ -427,8 +563,30 @@ export default function Tour (props : Props) : JSX.Element {
       }
     }
 
-    if (id === 'yours' && document.querySelector(THEMES_PANEL) === null) {
+    // The themes walk re-opens its panel whenever a step lands without
+    // it — backing in from later steps replaces panels, so the accent
+    // row and tiles would otherwise point at nothing.
+    if ((id === 'yours' || id === 'theme-accent' || id === 'theme-style') && document.querySelector(THEMES_PANEL) === null) {
       (document.querySelector(THEMES_ICON) as HTMLElement | null)?.click()
+    }
+
+    // Entering zen declutters first: any open top-bar panel steps out
+    // with the rest of the furniture, so the quiet lands at once.
+    if (id === 'zen') {
+      (document.querySelector('.top-bar--backdrop') as HTMLElement | null)?.click()
+    }
+
+    // The finale only shows: open the clearing options so both exits
+    // read live, but press neither — the boxes stay put. Same re-open
+    // for the exit sub-steps, for the same backing-in reason as themes.
+    if ((id === 'cleaning' || id === 'clean-notebook' || id === 'clean-workspace') && document.querySelector(`[title="${CLEAN_WORKSPACE_TITLE}"]`) === null) {
+      (document.querySelector(CLEAR_SELECTOR) as HTMLElement | null)?.click()
+    }
+
+    // Stepping on to take-with-you closes the themes panel behind us —
+    // its rows would otherwise linger over the export and import icons.
+    if (id === 'transfer') {
+      (document.querySelector('.top-bar--backdrop') as HTMLElement | null)?.click()
     }
   }, [ id ])
 
@@ -504,7 +662,24 @@ export default function Tour (props : Props) : JSX.Element {
     onDeleteBox(boxKey)
   }
 
+  // Explicit zen value through state, never the switch toggle: working
+  // the toggle programmatically would flip an already-zen notebook
+  // back out. The user's own hand still works the real switch (and
+  // the advance listener walks on from it, same destination).
+  const chauffeurZen = () => {
+    onSetZenMode(true)
+    goId('zen-dwell')
+  }
+
   const next = () => {
+    // The zen step carries a document advanceOn for the user's hand,
+    // but Next must set — never toggle — so it chauffeurs past the
+    // generic activate-target road above, same destination.
+    if (id === 'zen') {
+      chauffeurZen()
+      return
+    }
+
     // Chauffeur mode on the + step: work the control ourselves (its flagged
     // events open the picker's UI but never advance), then walk on once.
     if (current.advanceOn !== undefined) {
@@ -526,7 +701,20 @@ export default function Tour (props : Props) : JSX.Element {
       case 'md-delete':
         chauffeurDelete()
         return
-      case 'yours':
+      case 'macros': {
+        // Demonstrated, now out of the way: collapse the dock before
+        // share, so the next step never starts obstructed. The want
+        // survives for Back; zen forgets it right after.
+        const boxKey : string | null = tracked !== null && tracked.isConnected ? boxKeyOf(tracked) : null
+
+        if (boxKey !== null) {
+          onHideBoxMacros(boxKey)
+        }
+
+        goId(NEXT_MAIN[id] ?? id)
+        return
+      }
+      case 'recap':
         finish()
         return
       default:
@@ -534,13 +722,47 @@ export default function Tour (props : Props) : JSX.Element {
     }
   }
 
+  // Seating on init and every step change — start, resume or walk-on:
+  // the tour conducts from the top of its subject, so a scrolled page
+  // (or boxes seated above the tour's own) can never leave the card
+  // pointing off-screen. Only subjects actually out of view move — under
+  // the fixed bar or off the fold; anything visible stays exactly where
+  // the user put it. Seated below the fixed top bar, mirroring the
+  // notebook's own focus seating (60 normal, 76 zen, same 2px hush).
+  useEffect(() => {
+    const subject : Element | null =
+      (
+        tracked !== null && tracked.isConnected && current.targetInTracked !== undefined ?
+          tracked.querySelector(current.targetInTracked)
+        :
+          null
+      )
+      ?? (current.target !== undefined ? document.querySelector(current.target) : null)
+      ?? (tracked !== null && tracked.isConnected ? tracked : null)
+      ?? document.querySelector('.box-frame')
+
+    if (subject === null) {
+      return
+    }
+
+    const rect : DOMRect = subject.getBoundingClientRect()
+
+    if (rect.width === 0 && rect.height === 0) {
+      return
+    }
+
+    const seat : number = document.querySelector('.mainSpace.zen') === null ? 60 : 76
+
+    if (rect.top < seat - 2 || rect.bottom < seat || rect.top > window.innerHeight - 2) {
+      window.scrollTo({ top : Math.max(window.scrollY + rect.top - seat, 0), behavior : 'auto' })
+    }
+  }, [ id, tracked ])
+
   useEffect(() => {
     setRing(null)
 
     const element : Element | null =
-      current.ringTracked === true ?
-        (tracked !== null && tracked.isConnected ? tracked : null)
-      : current.targetInTracked !== undefined ?
+      current.targetInTracked !== undefined ?
         (tracked !== null && tracked.isConnected ? tracked.querySelector(current.targetInTracked) : null)
       : current.target !== undefined ?
         document.querySelector(current.target)
@@ -551,17 +773,28 @@ export default function Tour (props : Props) : JSX.Element {
       return
     }
 
-    // The ring re-seats on resize, scroll and the element's own growth —
-    // a stepping box grows under it — so the highlight never lags behind.
+    // The ring re-seats on resize, scroll, the element's own growth — a
+    // stepping box grows under it — and any DOM arrival: panels the tour
+    // itself opens (macros dock, clearing and theme options) land after
+    // this effect runs, so without the observer their rings would never
+    // appear. The rect guard keeps the observer from re-rendering on
+    // unrelated mutations.
+    let lastKey : string | null = null
+
     const place = () => {
       const rect : DOMRect = element.getBoundingClientRect()
+      const key : string =
+        rect.width === 0 && rect.height === 0 ?
+          'null'
+        :
+          [ rect.top, rect.left, rect.width, rect.height ].map((n : number) => Math.round(n)).join(',')
 
-      if (rect.width === 0 && rect.height === 0) {
-        setRing(null)
+      if (key === lastKey) {
         return
       }
 
-      setRing({ top : rect.top, left : rect.left, width : rect.width, height : rect.height })
+      lastKey = key
+      setRing(key === 'null' ? null : { top : rect.top, left : rect.left, width : rect.width, height : rect.height })
     }
 
     place()
@@ -572,11 +805,14 @@ export default function Tour (props : Props) : JSX.Element {
     ro?.observe(element)
     window.addEventListener('resize', place)
     document.addEventListener('scroll', place, true)
+    const mo : MutationObserver = new MutationObserver(place)
+    mo.observe(document.body, { childList : true, subtree : true })
 
     return () => {
       ro?.disconnect()
       window.removeEventListener('resize', place)
       document.removeEventListener('scroll', place, true)
+      mo.disconnect()
     }
   }, [ id, tracked ])
 

--- a/src/screens/Notebook.test.tsx
+++ b/src/screens/Notebook.test.tsx
@@ -4,7 +4,7 @@ import { test, expect, vi, afterEach } from 'vitest';
 import { render, fireEvent, cleanup } from '@testing-library/react';
 import Notebook, { syncDocksToFocus, selectPrimeBox, zenStep, mapBoxLabel } from './Notebook';
 import { createNewUntypedLambdaExpression, defaultSettings } from '../untyped-lambda-integration/Constants';
-import { BoxType, NotebookState } from '../Types';
+import { BoxType, BoxState, NotebookState } from '../Types';
 import { NoteState } from '../markdown-integration/AppTypes';
 import { tokenize, parse, None } from '@lambdulus/core';
 import { EvaluationStrategy, StepValidity, UntypedLambdaState, UntypedLambdaType } from '../untyped-lambda-integration/Types';
@@ -237,6 +237,384 @@ test('zen arrow keys never nudge the page, even past the last box', () => {
   expect(fireEvent.keyDown(document, { key : 'ArrowDown' })).toBe(false);
   expect(patches.length).toBe(0);
   last.unmount();
+});
+
+test('zen wheel over the map pages one box per push', async () => {
+  const patches : Array<Partial<NotebookState>> = [];
+  const { container, unmount } = renderZenNotebook((patch) => { patches.push(patch); });
+  try {
+    const nav = container.querySelector('.box-map') as HTMLElement;
+    expect(nav).not.toBeNull();
+
+    // One push past the travel bar steps exactly one box down.
+    fireEvent.wheel(nav, { deltaY : 120 });
+    expect(patches.length).toBe(1);
+    expect(patches[0]).toMatchObject({ activeBoxIndex : 1, focusedBoxIndex : 1 });
+
+    // The gesture's tail (trackpad momentum included) goes quiet:
+    // pushing on inside the lock steps nothing more.
+    fireEvent.wheel(nav, { deltaY : 120 });
+    fireEvent.wheel(nav, { deltaY : 30 });
+    expect(patches.length).toBe(1);
+
+    // Pushing on after the lock re-arms the trigger, so continuous
+    // scrolling keeps paging.
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    fireEvent.wheel(nav, { deltaY : 120 });
+    expect(patches.length).toBe(2);
+  }
+  finally {
+    unmount();
+  }
+});
+
+test('a flick with a long momentum tail still pages exactly once', async () => {
+  const patches : Array<Partial<NotebookState>> = [];
+  const { container, unmount } = renderZenNotebook((patch) => { patches.push(patch); });
+  try {
+    const nav = container.querySelector('.box-map') as HTMLElement;
+    const nap = (ms : number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+    // The flick: one decisive push pages at once.
+    fireEvent.wheel(nav, { deltaY : 120 });
+    expect(patches.length).toBe(1);
+
+    // Its momentum tail runs half a second with no quiet gap: deaf
+    // through all of it, never a second page.
+    for (let i = 0; i < 12; i++) {
+      await nap(40);
+      fireEvent.wheel(nav, { deltaY : 18 });
+    }
+    expect(patches.length).toBe(1);
+
+    // The next real push pages again.
+    await nap(250);
+    fireEvent.wheel(nav, { deltaY : 120 });
+    expect(patches.length).toBe(2);
+  }
+  finally {
+    unmount();
+  }
+});
+
+test('a fresh push into the tail pages again at once', async () => {
+  const patches : Array<Partial<NotebookState>> = [];
+  const { container, unmount } = renderZenNotebook((patch) => { patches.push(patch); });
+  try {
+    const nav = container.querySelector('.box-map') as HTMLElement;
+    const nap = (ms : number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+    // The first swipe pages at once.
+    fireEvent.wheel(nav, { deltaY : 120 });
+    expect(patches.length).toBe(1);
+
+    // Its cooling tail flows on, dense and decaying: deaf through all
+    // of it, never a second page from the same swipe.
+    for (const tail of [ 90, 75, 60, 50, 40, 32, 26, 21, 17, 14, 12, 10, 9, 8, 7 ]) {
+      fireEvent.wheel(nav, { deltaY : tail });
+    }
+    expect(patches.length).toBe(1);
+
+    // A new push ramping out of the cooled tail re-arms mid-gesture:
+    // no trap gap, the second swipe pages without waiting out the
+    // momentum — while its own third event correctly stays quiet.
+    fireEvent.wheel(nav, { deltaY : 30 });
+    fireEvent.wheel(nav, { deltaY : 45 });
+    expect(patches.length).toBe(2);
+    fireEvent.wheel(nav, { deltaY : 60 });
+    expect(patches.length).toBe(2);
+
+    // ...and the road after is normal again.
+    await nap(250);
+    fireEvent.wheel(nav, { deltaY : 120 });
+    expect(patches.length).toBe(3);
+  }
+  finally {
+    unmount();
+  }
+});
+
+test('rapid mouse notches page per notch', async () => {
+  const patches : Array<Partial<NotebookState>> = [];
+  const mkState = (anchor : number) : NotebookState => ({
+    name : 'Test',
+    zenMode : true,
+    boxList : [ noteBox('first', 'a'), noteBox('second', 'b') ],
+    activeBoxIndex : anchor,
+    focusedBoxIndex : anchor,
+    menuOpen : false,
+    settings : {},
+    __key : 'nb',
+  });
+  const onPatch = (patch : Partial<NotebookState>) => { patches.push(patch); };
+  const { container, unmount, rerender } = render(<Notebook state={ mkState(0) } updateNotebook={ onPatch } />);
+  try {
+    const nav = container.querySelector('.box-map') as HTMLElement;
+    const nap = (ms : number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+    // Notches 100ms apart never reach the quiet window, but each is a
+    // full discrete shove: every one pages.
+    fireEvent.wheel(nav, { deltaY : 120 });
+    expect(patches.length).toBe(1);
+    expect(patches[0]).toMatchObject({ focusedBoxIndex : 1 });
+
+    await nap(100);
+    rerender(<Notebook state={ mkState(1) } updateNotebook={ onPatch } />);
+    fireEvent.wheel(nav, { deltaY : -120 });
+    expect(patches.length).toBe(2);
+    expect(patches[1]).toMatchObject({ focusedBoxIndex : 0 });
+
+    await nap(100);
+    rerender(<Notebook state={ mkState(0) } updateNotebook={ onPatch } />);
+    fireEvent.wheel(nav, { deltaY : 120 });
+    expect(patches.length).toBe(3);
+    expect(patches[2]).toMatchObject({ focusedBoxIndex : 1 });
+  }
+  finally {
+    unmount();
+  }
+});
+
+test('sustained scrolling cruises past the first window', async () => {
+  const patches : Array<Partial<NotebookState>> = [];
+  const { container, unmount } = renderZenNotebook((patch) => { patches.push(patch); });
+  try {
+    const nav = container.querySelector('.box-map') as HTMLElement;
+    const nap = (ms : number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+    fireEvent.wheel(nav, { deltaY : 120 });
+    expect(patches.length).toBe(1);
+
+    // Steady pushing past the cap window: strength stays up, so the
+    // stream cruises into a second page on its own.
+    for (let t = 0; t < 2200; t += 50) {
+      await nap(50);
+      fireEvent.wheel(nav, { deltaY : 30 });
+    }
+    expect(patches.length).toBeGreaterThanOrEqual(2);
+
+    // ...and keeps cruising on the short cadence while the flow runs.
+    for (let t = 0; t < 400; t += 50) {
+      await nap(50);
+      fireEvent.wheel(nav, { deltaY : 30 });
+    }
+    expect(patches.length).toBeGreaterThanOrEqual(3);
+  }
+  finally {
+    unmount();
+  }
+});
+
+test('a gentle but deliberate re-push still pages', () => {
+  const patches : Array<Partial<NotebookState>> = [];
+  const { container, unmount } = renderZenNotebook((patch) => { patches.push(patch); });
+  try {
+    const nav = container.querySelector('.box-map') as HTMLElement;
+
+    // Opening push pages at once; its tail dips low and stays quiet.
+    fireEvent.wheel(nav, { deltaY : 120 });
+    expect(patches.length).toBe(1);
+    for (const tail of [ 60, 40, 25, 15, 10, 6, 4, 2 ]) {
+      fireEvent.wheel(nav, { deltaY : tail });
+    }
+    expect(patches.length).toBe(1);
+
+    // A soft ramp — no hard shove anywhere — re-arms on its first
+    // event and pages once its travel arrives, still exactly once.
+    fireEvent.wheel(nav, { deltaY : 28 });
+    expect(patches.length).toBe(1);
+    fireEvent.wheel(nav, { deltaY : 32 });
+    expect(patches.length).toBe(2);
+  }
+  finally {
+    unmount();
+  }
+});
+
+test('micro-swipes peaking at single pixels still page', () => {
+  const patches : Array<Partial<NotebookState>> = [];
+  const { container, unmount } = renderZenNotebook((patch) => { patches.push(patch); });
+  try {
+    const nav = container.querySelector('.box-map') as HTMLElement;
+    const stream = (deltas : Array<number>) => {
+      for (const deltaY of deltas) {
+        fireEvent.wheel(nav, { deltaY });
+      }
+    };
+
+    // A gentle push totaling just past the bar pages, on small events.
+    stream([ 1, 2, 3, 4, 6, 7, 8, 8, 8, 8, 7 ]);
+    expect(patches.length).toBe(1);
+
+    // Its tail dies out quietly, never a second page.
+    stream([ 7, 6, 5, 4, 3, 2, 2, 1, 1 ]);
+    expect(patches.length).toBe(1);
+
+    // A re-push hump peaking at 8px re-arms through the low floor and
+    // pages on its travel — while the event right after the page,
+    // with no dip behind it, stays quiet.
+    stream([ 5, 7, 8, 8, 8, 8, 8, 8, 7 ]);
+    expect(patches.length).toBe(2);
+    stream([ 8 ]);
+    expect(patches.length).toBe(2);
+  }
+  finally {
+    unmount();
+  }
+});
+
+test('re-pushes inside one unbroken stream page push by push', () => {
+  const patches : Array<Partial<NotebookState>> = [];
+  const { container, unmount } = renderZenNotebook((patch) => { patches.push(patch); });
+  try {
+    const nav = container.querySelector('.box-map') as HTMLElement;
+    const stream = (deltas : Array<number>) => {
+      for (const deltaY of deltas) {
+        fireEvent.wheel(nav, { deltaY });
+      }
+    };
+
+    // The opening push pages at once; its tail never pages twice.
+    stream([ 66 ]);
+    expect(patches.length).toBe(1);
+    stream([ 62, 60, 55, 48, 40, 32, 25, 18, 12, 8, 5, 3, 2 ]);
+    expect(patches.length).toBe(1);
+
+    // A re-push ramping out of the dip re-arms mid-flow and pages —
+    // while its own continuation stays quiet.
+    stream([ 9, 16, 26, 40 ]);
+    expect(patches.length).toBe(2);
+    stream([ 48 ]);
+    expect(patches.length).toBe(2);
+
+    // ...and the next hump pages again the same way.
+    stream([ 45, 38, 30, 22, 15, 10, 6, 4, 3, 2 ]);
+    expect(patches.length).toBe(2);
+    stream([ 11, 26, 38 ]);
+    expect(patches.length).toBe(3);
+    stream([ 52, 73, 83, 70, 50, 30, 15, 8, 4, 2, 1 ]);
+    expect(patches.length).toBe(3);
+  }
+  finally {
+    unmount();
+  }
+});
+
+test('a stalled tail held back past the window never pages twice', async () => {
+  const patches : Array<Partial<NotebookState>> = [];
+  const { container, unmount } = renderZenNotebook((patch) => { patches.push(patch); });
+  try {
+    const nav = container.querySelector('.box-map') as HTMLElement;
+    const nap = (ms : number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+    fireEvent.wheel(nav, { deltaY : 120 });
+    expect(patches.length).toBe(1);
+
+    // The page's own re-render stalls the main thread: the tail event
+    // was born mid-gesture but handled after a long wall pause. The
+    // event clock betrays the stall, so the gesture stays one page.
+    await nap(400);
+    const stale = new WheelEvent('wheel', { deltaY : 40, bubbles : true, cancelable : true });
+    Object.defineProperty(stale, 'timeStamp', { value : performance.now() - 350 });
+    nav.dispatchEvent(stale);
+    expect(patches.length).toBe(1);
+
+    // A genuinely fresh push afterwards pages again.
+    await nap(250);
+    fireEvent.wheel(nav, { deltaY : 120 });
+    expect(patches.length).toBe(2);
+  }
+  finally {
+    unmount();
+  }
+});
+
+test('zen wheel lets a scrolling map list keep the event', () => {
+  const patches : Array<Partial<NotebookState>> = [];
+  const { container, unmount } = renderZenNotebook((patch) => { patches.push(patch); });
+  try {
+    const list = container.querySelector('.box-map-list') as HTMLElement;
+    let top = 0;
+    Object.defineProperty(list, 'scrollHeight', { value : 500, configurable : true });
+    Object.defineProperty(list, 'clientHeight', { value : 100, configurable : true });
+    Object.defineProperty(list, 'scrollTop', { get : () => top, set : (v : number) => { top = v; }, configurable : true });
+    const nav = container.querySelector('.box-map') as HTMLElement;
+
+    // Room below: the list scrolls, no paging.
+    fireEvent.wheel(nav, { deltaY : 120 });
+    expect(patches.length).toBe(0);
+
+    // Scrolled to the end: paging continues past it.
+    top = 400;
+    fireEvent.wheel(nav, { deltaY : 120 });
+    expect(patches.length).toBe(1);
+    expect(patches[0]).toMatchObject({ focusedBoxIndex : 1 });
+  }
+  finally {
+    unmount();
+  }
+});
+
+test('zen swipe over the map pages, taps do not', () => {
+  const patches : Array<Partial<NotebookState>> = [];
+  const { container, unmount } = renderZenNotebook((patch) => { patches.push(patch); }, 0);
+  try {
+    const nav = container.querySelector('.box-map') as HTMLElement;
+
+    // Swipe up travels past the bar: one box forward.
+    fireEvent.touchStart(nav, { touches : [ { clientY : 100 } ] });
+    fireEvent.touchEnd(nav, { changedTouches : [ { clientY : 40 } ] });
+    expect(patches.length).toBe(1);
+    expect(patches[0]).toMatchObject({ focusedBoxIndex : 1 });
+
+    // A tap stays under the bar: nothing pages.
+    fireEvent.touchStart(nav, { touches : [ { clientY : 100 } ] });
+    fireEvent.touchEnd(nav, { changedTouches : [ { clientY : 90 } ] });
+    expect(patches.length).toBe(1);
+  }
+  finally {
+    unmount();
+  }
+});
+
+test('map wheel outside zen pages nothing', () => {
+  const patches : Array<Partial<NotebookState>> = [];
+  const state : NotebookState = {
+    name : 'Test',
+    boxList : [ noteBox('first', 'a'), noteBox('second', 'b') ],
+    activeBoxIndex : 0,
+    focusedBoxIndex : 0,
+    menuOpen : false,
+    settings : {},
+    __key : 'nb',
+  };
+  const { container, unmount } = render(<Notebook state={ state } updateNotebook={ (patch) => { patches.push(patch); } } />);
+  try {
+    fireEvent.wheel(container.querySelector('.box-map') as HTMLElement, { deltaY : 500 });
+    expect(patches.length).toBe(0);
+  }
+  finally {
+    unmount();
+  }
+});
+
+test('map paging hitbox reaches past a short map without covering the lines', () => {
+  const { container, unmount } = renderZenNotebook(() => void 0);
+  try {
+    // The layer mounts behind the list content inside the nav.
+    const hitbox = container.querySelector('.box-map > .box-map-hitbox') as HTMLElement;
+    expect(hitbox).not.toBeNull();
+    expect(hitbox.getAttribute('aria-hidden')).toBe('true');
+  }
+  finally {
+    unmount();
+  }
+
+  const css = readFileSync('src/App.css', 'utf8');
+  const block = css.match(/\.box-map-hitbox\s*\{[^}]*\}/)?.[0] ?? '';
+  expect(block).toMatch(/top\s*:\s*-18vh/);
+  expect(block).toMatch(/bottom\s*:\s*-18vh/);
+  expect(block).toMatch(/z-index\s*:\s*-1/);
 });
 
 test('zen single box fits the viewport with no page scroll', () => {
@@ -645,22 +1023,49 @@ test('silent layout shifts re-prime the anchor', () => {
   }
 });
 
-function lambdaBox (key : string, dockOpen : boolean) : UntypedLambdaState {
+function lambdaBox (key : string, dockOpen : boolean, dockWanted : boolean = dockOpen) : UntypedLambdaState {
   const box = createNewUntypedLambdaExpression(defaultSettings);
   box.__key = key;
   box.macrolistOpen = dockOpen;
+  box.macrolistWanted = dockWanted;
   return box;
 }
 
-test('macro tables follow focus: open on the focused box only', () => {
-  const first = lambdaBox('a', false);
+test('focus restores a remembered table and collapses the rest', () => {
+  const first = lambdaBox('a', false, true);
   const note = noteBox('note', 'b');
-  const second = lambdaBox('c', true);
+  const second = lambdaBox('c', true, true);
   const next = syncDocksToFocus([ first, note, second ], 0);
 
   expect((next[0] as UntypedLambdaState).macrolistOpen).toBe(true);
   expect(next[1]).toBe(note);
   expect((next[2] as UntypedLambdaState).macrolistOpen).toBe(false);
+  // Remembering survives the collapse, so refocus brings it back.
+  expect((next[2] as UntypedLambdaState).macrolistWanted).toBe(true);
+});
+
+test('focus alone never opens a dock nobody asked for', () => {
+  const shut = [ lambdaBox('a', false, false), noteBox('note', 'b'), lambdaBox('c', false, false) ];
+  expect(syncDocksToFocus(shut, 0)).toBe(shut);
+  expect(syncDocksToFocus(shut, 2)).toBe(shut);
+
+  // A stray open table still collapses on blur — without opening another.
+  const stray = [ lambdaBox('a', true, true), lambdaBox('b', false, false) ];
+  const next = syncDocksToFocus(stray, 1);
+  expect(next).not.toBe(stray);
+  expect((next[0] as UntypedLambdaState).macrolistOpen).toBe(false);
+  expect((next[1] as UntypedLambdaState).macrolistOpen).toBe(false);
+});
+
+test('zen focus never restores a remembered table', () => {
+  const boxes = [ lambdaBox('a', true, true), lambdaBox('b', false, false) ];
+  const next = syncDocksToFocus(boxes, 0, true);
+  expect(next).not.toBe(boxes);
+  expect((next[0] as UntypedLambdaState).macrolistOpen).toBe(false);
+  // Remembered, not forgotten: leaving zen brings it back.
+  expect((next[0] as UntypedLambdaState).macrolistWanted).toBe(true);
+  expect(syncDocksToFocus(next, 0, false)).not.toBe(next);
+  expect(((syncDocksToFocus(next, 0, false))[0] as UntypedLambdaState).macrolistOpen).toBe(true);
 });
 
 test('syncing docks is a no-op when every table matches', () => {
@@ -670,7 +1075,22 @@ test('syncing docks is a no-op when every table matches', () => {
   expect(syncDocksToFocus(cleared, undefined)).toBe(cleared);
 });
 
-test('focusing a box opens its table and collapses the old one', () => {
+test('a hand-closed dock stays shut across refocus', () => {
+  // Open by hand, unfocused away, back again: remembered, restored.
+  let boxes : Array<BoxState> = [ lambdaBox('a', false, true), lambdaBox('b', false, false) ];
+  boxes = syncDocksToFocus(boxes, 0);
+  expect((boxes[0] as UntypedLambdaState).macrolistOpen).toBe(true);
+  boxes = syncDocksToFocus(boxes, 1);
+  expect((boxes[0] as UntypedLambdaState).macrolistOpen).toBe(false);
+  boxes = syncDocksToFocus(boxes, 0);
+  expect((boxes[0] as UntypedLambdaState).macrolistOpen).toBe(true);
+
+  // Closed by hand (head clears the wish): refocus leaves it shut.
+  boxes = [ lambdaBox('a', false, false), lambdaBox('b', false, false) ];
+  expect(syncDocksToFocus(boxes, 0)).toBe(boxes);
+});
+
+test('focusing a box collapses the old table and opens nothing unasked', () => {
   const state : NotebookState = {
     name : 'Test',
     boxList : [ lambdaBox('a', true), lambdaBox('b', false) ],
@@ -687,7 +1107,7 @@ test('focusing a box opens its table and collapses the old one', () => {
     expect(updateNotebook).toHaveBeenCalledWith(expect.objectContaining({ activeBoxIndex : 1, focusedBoxIndex : 1 }));
     const patched = updateNotebook.mock.calls[0][0] as NotebookState;
     expect((patched.boxList[0] as UntypedLambdaState).macrolistOpen).toBe(false);
-    expect((patched.boxList[1] as UntypedLambdaState).macrolistOpen).toBe(true);
+    expect((patched.boxList[1] as UntypedLambdaState).macrolistOpen).toBe(false);
   }
   finally {
     unmount();

--- a/src/screens/Notebook.test.tsx
+++ b/src/screens/Notebook.test.tsx
@@ -2,7 +2,8 @@ import { readFileSync } from 'fs';
 import { useState } from 'react';
 import { test, expect, vi, afterEach } from 'vitest';
 import { render, fireEvent, cleanup } from '@testing-library/react';
-import Notebook, { selectPrimeBox, zenStep, mapBoxLabel } from './Notebook';
+import Notebook, { collapseForeignDocks, selectPrimeBox, zenStep, mapBoxLabel } from './Notebook';
+import { createNewUntypedLambdaExpression, defaultSettings } from '../untyped-lambda-integration/Constants';
 import { BoxType, NotebookState } from '../Types';
 import { NoteState } from '../markdown-integration/AppTypes';
 import { tokenize, parse, None } from '@lambdulus/core';
@@ -641,6 +642,54 @@ test('silent layout shifts re-prime the anchor', () => {
   finally {
     unmount();
     vi.unstubAllGlobals();
+  }
+});
+
+function lambdaBox (key : string, dockOpen : boolean) : UntypedLambdaState {
+  const box = createNewUntypedLambdaExpression(defaultSettings);
+  box.__key = key;
+  box.macrolistOpen = dockOpen;
+  return box;
+}
+
+test('focusing a box collapses only the foreign macro docks', () => {
+  const first = lambdaBox('a', true);
+  const note = noteBox('note', 'b');
+  const second = lambdaBox('c', true);
+  const next = collapseForeignDocks([ first, note, second ], 2);
+
+  expect((next[0] as UntypedLambdaState).macrolistOpen).toBe(false);
+  expect(next[1]).toBe(note);
+  expect((next[2] as UntypedLambdaState).macrolistOpen).toBe(true);
+});
+
+test('collapsing docks is a no-op without open tables', () => {
+  const boxes = [ lambdaBox('a', false), noteBox('note', 'b') ];
+  expect(collapseForeignDocks(boxes, 0)).toBe(boxes);
+  expect(collapseForeignDocks(boxes, undefined)).toBe(boxes);
+});
+
+test('focusing a box collapses the unfocused macro dock', () => {
+  const state : NotebookState = {
+    name : 'Test',
+    boxList : [ lambdaBox('a', true), lambdaBox('b', false) ],
+    activeBoxIndex : 0,
+    focusedBoxIndex : 0,
+    menuOpen : false,
+    settings : {},
+    __key : 'nb',
+  };
+  const updateNotebook = vi.fn();
+  const { container, unmount } = render(<Notebook state={ state } updateNotebook={ updateNotebook } />);
+  try {
+    fireEvent.click(container.querySelectorAll('.box-rail')[1]);
+    expect(updateNotebook).toHaveBeenCalledWith(expect.objectContaining({ activeBoxIndex : 1, focusedBoxIndex : 1 }));
+    const patched = updateNotebook.mock.calls[0][0] as NotebookState;
+    expect((patched.boxList[0] as UntypedLambdaState).macrolistOpen).toBe(false);
+    expect((patched.boxList[1] as UntypedLambdaState).macrolistOpen).toBe(false);
+  }
+  finally {
+    unmount();
   }
 });
 

--- a/src/screens/Notebook.test.tsx
+++ b/src/screens/Notebook.test.tsx
@@ -2,7 +2,7 @@ import { readFileSync } from 'fs';
 import { useState } from 'react';
 import { test, expect, vi, afterEach } from 'vitest';
 import { render, fireEvent, cleanup } from '@testing-library/react';
-import Notebook, { collapseForeignDocks, selectPrimeBox, zenStep, mapBoxLabel } from './Notebook';
+import Notebook, { syncDocksToFocus, selectPrimeBox, zenStep, mapBoxLabel } from './Notebook';
 import { createNewUntypedLambdaExpression, defaultSettings } from '../untyped-lambda-integration/Constants';
 import { BoxType, NotebookState } from '../Types';
 import { NoteState } from '../markdown-integration/AppTypes';
@@ -652,24 +652,25 @@ function lambdaBox (key : string, dockOpen : boolean) : UntypedLambdaState {
   return box;
 }
 
-test('focusing a box collapses only the foreign macro docks', () => {
-  const first = lambdaBox('a', true);
+test('macro tables follow focus: open on the focused box only', () => {
+  const first = lambdaBox('a', false);
   const note = noteBox('note', 'b');
   const second = lambdaBox('c', true);
-  const next = collapseForeignDocks([ first, note, second ], 2);
+  const next = syncDocksToFocus([ first, note, second ], 0);
 
-  expect((next[0] as UntypedLambdaState).macrolistOpen).toBe(false);
+  expect((next[0] as UntypedLambdaState).macrolistOpen).toBe(true);
   expect(next[1]).toBe(note);
-  expect((next[2] as UntypedLambdaState).macrolistOpen).toBe(true);
+  expect((next[2] as UntypedLambdaState).macrolistOpen).toBe(false);
 });
 
-test('collapsing docks is a no-op without open tables', () => {
-  const boxes = [ lambdaBox('a', false), noteBox('note', 'b') ];
-  expect(collapseForeignDocks(boxes, 0)).toBe(boxes);
-  expect(collapseForeignDocks(boxes, undefined)).toBe(boxes);
+test('syncing docks is a no-op when every table matches', () => {
+  const boxes = [ lambdaBox('a', true), noteBox('note', 'b'), lambdaBox('c', false) ];
+  expect(syncDocksToFocus(boxes, 0)).toBe(boxes);
+  const cleared = [ lambdaBox('a', false), noteBox('note', 'b') ];
+  expect(syncDocksToFocus(cleared, undefined)).toBe(cleared);
 });
 
-test('focusing a box collapses the unfocused macro dock', () => {
+test('focusing a box opens its table and collapses the old one', () => {
   const state : NotebookState = {
     name : 'Test',
     boxList : [ lambdaBox('a', true), lambdaBox('b', false) ],
@@ -686,7 +687,7 @@ test('focusing a box collapses the unfocused macro dock', () => {
     expect(updateNotebook).toHaveBeenCalledWith(expect.objectContaining({ activeBoxIndex : 1, focusedBoxIndex : 1 }));
     const patched = updateNotebook.mock.calls[0][0] as NotebookState;
     expect((patched.boxList[0] as UntypedLambdaState).macrolistOpen).toBe(false);
-    expect((patched.boxList[1] as UntypedLambdaState).macrolistOpen).toBe(false);
+    expect((patched.boxList[1] as UntypedLambdaState).macrolistOpen).toBe(true);
   }
   finally {
     unmount();

--- a/src/screens/Notebook.test.tsx
+++ b/src/screens/Notebook.test.tsx
@@ -67,6 +67,22 @@ test('zen hides the grab rail', () => {
   expect(css).toMatch(/\.mainSpace\.zen \.box-rail\s*\{[^}]*display\s*:\s*none/);
 });
 
+test('the + row breathes a line-high on both sides', () => {
+  // Small boxes need the vertical room for the scrolling autofocus,
+  // and an open macro dock must not invade the box below.
+  const css = readFileSync('src/styles/BoxContainer.css', 'utf8');
+  const row = css.match(/\.add_box_after\s*\{[^}]*\}/)?.[0] ?? '';
+  expect(row).toMatch(/margin\s*:\s*1\.5em\s+auto/);
+});
+
+test('cards drop the invisible rail so the card meets the + row', () => {
+  // The rail is a transparent duplicate of the card's own click to
+  // focus; hiding it lets the card stretch left edge-to-edge with
+  // the full-width + row. Classic keeps its visible anchor line.
+  const css = readFileSync('src/styles/BoxContainer.css', 'utf8');
+  expect(css).toMatch(/#app\[data-box-style='cards'\] \.box-frame \.box-rail\s*\{[^}]*display\s*:\s*none/);
+});
+
 test('zen hides the collapse toggle', () => {
   // Collapsing the single zen box serves nothing, so the toggle
   // steps out with the other box furniture.

--- a/src/screens/Notebook.test.tsx
+++ b/src/screens/Notebook.test.tsx
@@ -99,6 +99,21 @@ test('prime hands over once the next box owns the upper view', () => {
   ], 520)).toBe(1);
 });
 
+test('a tiny middle box wins its window on a high prime line', () => {
+  // One-term middle box, fully visible, predecessor almost gone, tall
+  // last box rising below. On the old center-ish line (585 of 900) the
+  // last box outshares it at every scroll position, so slow scrolling
+  // skips the middle outright; on the upper-third line (315) the last
+  // box has not entered the upper view yet and the middle box wins.
+  const boxes = [
+    { top : -350, height : 400 },
+    { top : 162, height : 120 },
+    { top : 394, height : 500 },
+  ];
+  expect(selectPrimeBox(boxes, 585)).toBe(2);
+  expect(selectPrimeBox(boxes, 315)).toBe(1);
+});
+
 test('a seated short box keeps focus over the next one', () => {
   // Clicking the second-to-last box seats it at the top; the last box
   // sits above the line too, but the seated box owns as much of the

--- a/src/screens/Notebook.tsx
+++ b/src/screens/Notebook.tsx
@@ -37,19 +37,84 @@ const SEAT_SETTLE_MS : number = 600
 // Scroll-end backstop: re-prime once motion stops so the focus always
 // ends on the landed layout.
 const SCROLL_END_MS : number = 150
-// Macro tables follow focus: the focused box always shows its table,
-// every other box collapses its own, so an open table never overlaps
-// the boxes below. Closing the focused box's table by hand sticks
-// until focus leaves and comes back. Returns the same array when every
-// table already matches, so callers never re-render for a no-op.
-export function syncDocksToFocus (boxList : Array<BoxState>, focusedIndex : number | null | undefined) : Array<BoxState> {
+// One wheel push over the map pages a single box in zen: enough
+// travel for a mouse notch or a short trackpad push. The gesture then
+// goes deaf until it truly ends (a sliding quiet window, so a flick's
+// momentum tail — however long — can never page twice), and the next
+// push starts fresh. An endless stream is deliberate continuous
+// scrolling, not momentum: past the first window it cruises, paging
+// on a short cadence while the strength stays up, never from a dying
+// tail. A quiet pause restarts the accumulation instead.
+const ZEN_WHEEL_STEP_PX : number = 60
+// A gap this long ends the gesture: the next event starts fresh.
+const ZEN_WHEEL_QUIET_MS : number = 150
+// A stream still flowing past this long after a page is deliberate,
+// not momentum: violent flicks coast well under two seconds, and a
+// tail that old has decayed past the cruise gate anyway. Strength
+// decides whether the survivor cruises or waits out.
+const ZEN_WHEEL_CAP_MS : number = 2000
+// A fresh push landing mid-flow re-arms at once: new finger energy
+// spikes past the flow's slow baseline, while one flick's own ramp
+// never dips first. Past this multiple of the baseline (and a floor,
+// so jitter never trips it), and only once the flow has dipped below
+// this many pixels since the page (a re-push follows a dip — the
+// lift and return — while a still-rising ramp never dips at all),
+// the motion is a new push, not the old tail. The baseline chases
+// cooling fast and warming slow, so it hugs a decaying tail but lags
+// a rising push.
+const ZEN_WHEEL_ONSET_RATIO : number = 1.6
+const ZEN_WHEEL_ONSET_FLOOR : number = 6
+const ZEN_WHEEL_BASE_DOWN_ALPHA : number = 0.3
+const ZEN_WHEEL_BASE_UP_ALPHA : number = 0.05
+const ZEN_WHEEL_DIP_PX : number = 15
+// A full-notch shove after a short gap is a mouse wheel, not a
+// trackpad stream: honor it at once instead of holding it for the
+// quiet window, so rapid spinning pages per notch.
+const ZEN_WHEEL_QUICK_MS : number = 80
+const ZEN_WHEEL_NOTCH_PX : number = 100
+// Cruise cadence once sustained input proves itself deliberate.
+const ZEN_WHEEL_CRUISE_MS : number = 300
+// Gesture strength tracker: trip the cruise only while the flow runs
+// hot against the page's own onset, never on a cooling tail.
+const ZEN_WHEEL_EMA_ALPHA : number = 0.25
+const ZEN_WHEEL_CRUISE_RATIO : number = 0.4
+
+// Paging revision marker: the console reports which gesture logic a
+// tab actually runs, so a stale tab never gets debugged as live code
+// again. Bump on every behavior change to the strip gestures.
+const ZEN_WHEEL_REV : number = 9
+const zenWheelRevTarget : Record<string, unknown> = window as unknown as Record<string, unknown>
+zenWheelRevTarget.__zenWheelRev = ZEN_WHEEL_REV
+
+// Paging diagnostics: set window.__zenWheelDebug = true in the
+// console and swipe over the map strip — one line per wheel event,
+// each naming the rule that owned it.
+function zenWheelLog (message : string) : void {
+  if ((window as unknown as Record<string, unknown>).__zenWheelDebug === true) {
+    console.log(`zenwheel rev=${ZEN_WHEEL_REV} ${message}`)
+  }
+}
+// A touchscreen swipe pages past this travel, taps (and list scrolls)
+// staying below it.
+const ZEN_TOUCH_STEP_PX : number = 24
+
+// Macro tables follow focus, but only the ones the user opened: the
+// focused box restores its remembered dock, every other box collapses
+// its own, so an open table never overlaps the boxes below. Focus never
+// opens a dock by itself — a fresh box stays a pill until its head is
+// worked — and a hand-closed dock stays shut across refocus. Zen mode
+// restores nothing: one clean box owns the viewport, and a table the
+// hand opens there still collapses on blur like everywhere else.
+// Returns the same array when every table already matches, so callers
+// never re-render for a no-op.
+export function syncDocksToFocus (boxList : Array<BoxState>, focusedIndex : number | null | undefined, zenMode : boolean = false) : Array<BoxState> {
   let changed : boolean = false
   const next : Array<BoxState> = boxList.map((box : BoxState, i : number) => {
     if (box.type !== BoxType.UNTYPED_LAMBDA) {
       return box
     }
 
-    const wantOpen : boolean = i === focusedIndex
+    const wantOpen : boolean = ! zenMode && i === focusedIndex && (box as UntypedLambdaState).macrolistWanted === true
 
     if ((box as UntypedLambdaState).macrolistOpen === wantOpen) {
       return box
@@ -120,6 +185,21 @@ export default class Notebook extends PureComponent<Props, State> {
   private primeTrail : number | null
   private listRef : React.RefObject<HTMLUListElement>
   private listObserver : ResizeObserver | null
+  private mapNavRef : React.RefObject<HTMLElement>
+  private mapNavEl : HTMLElement | null
+  private zenWheelAccum : number
+  private zenWheelDir : 1 | -1 | 0
+  private zenWheelLast : number
+  private zenWheelLastStamp : number
+  private zenWheelDeaf : boolean
+  private zenWheelEma : number
+  private zenWheelFireEma : number
+  private zenWheelBase : number
+  private zenWheelDipMin : number
+  private zenWheelQuietTimer : number | null
+  private zenWheelCapTimer : number | null
+  private zenTouchY : number | null
+  private zenTouchListTop : number | null
 
   constructor (props : Props) {
     super(props)
@@ -132,6 +212,21 @@ export default class Notebook extends PureComponent<Props, State> {
     this.primeTrail = null
     this.listRef = React.createRef<HTMLUListElement>()
     this.listObserver = null
+    this.mapNavRef = React.createRef<HTMLElement>()
+    this.mapNavEl = null
+    this.zenWheelAccum = 0
+    this.zenWheelDir = 0
+    this.zenWheelLast = 0
+    this.zenWheelLastStamp = 0
+    this.zenWheelDeaf = false
+    this.zenWheelEma = 0
+    this.zenWheelFireEma = 0
+    this.zenWheelBase = 0
+    this.zenWheelDipMin = Number.POSITIVE_INFINITY
+    this.zenWheelQuietTimer = null
+    this.zenWheelCapTimer = null
+    this.zenTouchY = null
+    this.zenTouchListTop = null
     this.state = { mapAtTop : true, mapAtBottom : true }
 
     this.insertBefore = this.insertBefore.bind(this)
@@ -142,6 +237,9 @@ export default class Notebook extends PureComponent<Props, State> {
     this.onBlur = this.onBlur.bind(this)
     this.onPageKeyDown = this.onPageKeyDown.bind(this)
     this.onPageScroll = this.onPageScroll.bind(this)
+    this.onMapWheel = this.onMapWheel.bind(this)
+    this.onMapTouchStart = this.onMapTouchStart.bind(this)
+    this.onMapTouchEnd = this.onMapTouchEnd.bind(this)
   }
 
   componentDidMount () : void {
@@ -159,6 +257,29 @@ export default class Notebook extends PureComponent<Props, State> {
     }
     this.syncBodyZen()
     this.syncMapEdges()
+    this.attachMapGestures()
+  }
+
+  // The map's paging gestures listen natively: React's delegated wheel
+  // listener is passive, but paging needs preventDefault, and the map
+  // nav mounts conditionally (empty notebooks have none). Tracked by
+  // node, so each nav gets exactly one set across remounts.
+  attachMapGestures () : void {
+    const nav : HTMLElement | null = this.mapNavRef.current
+    if (nav === this.mapNavEl) {
+      return
+    }
+    if (this.mapNavEl !== null) {
+      this.mapNavEl.removeEventListener('wheel', this.onMapWheel)
+      this.mapNavEl.removeEventListener('touchstart', this.onMapTouchStart)
+      this.mapNavEl.removeEventListener('touchend', this.onMapTouchEnd)
+    }
+    this.mapNavEl = nav
+    if (nav !== null) {
+      nav.addEventListener('wheel', this.onMapWheel, { passive : false })
+      nav.addEventListener('touchstart', this.onMapTouchStart, { passive : true })
+      nav.addEventListener('touchend', this.onMapTouchEnd, { passive : true })
+    }
   }
 
   // The map fades only at the ends scrolled away from, mirroring the
@@ -186,6 +307,20 @@ export default class Notebook extends PureComponent<Props, State> {
     }
     if (this.listObserver !== null) {
       this.listObserver.disconnect()
+    }
+    if (this.mapNavEl !== null) {
+      this.mapNavEl.removeEventListener('wheel', this.onMapWheel)
+      this.mapNavEl.removeEventListener('touchstart', this.onMapTouchStart)
+      this.mapNavEl.removeEventListener('touchend', this.onMapTouchEnd)
+      this.mapNavEl = null
+    }
+    if (this.zenWheelQuietTimer !== null) {
+      window.clearTimeout(this.zenWheelQuietTimer)
+      this.zenWheelQuietTimer = null
+    }
+    if (this.zenWheelCapTimer !== null) {
+      window.clearTimeout(this.zenWheelCapTimer)
+      this.zenWheelCapTimer = null
     }
     document.body.classList.remove('zen')
   }
@@ -283,7 +418,203 @@ export default class Notebook extends PureComponent<Props, State> {
     })
     const prime : number = selectPrimeBox(tops, window.innerHeight * PRIME_LINE_RATIO)
     if (prime !== (focusedBoxIndex ?? activeBoxIndex)) {
-      this.props.updateNotebook({ focusedBoxIndex : prime, boxList : syncDocksToFocus(boxList, prime) })
+      this.props.updateNotebook({ focusedBoxIndex : prime, boxList : syncDocksToFocus(boxList, prime, this.props.state.zenMode) })
+    }
+  }
+
+  // Zen paging over the map strip: one accumulated push steps a single
+  // box. The gesture then goes deaf: the tail never pages twice, while
+  // a fresh push spiking out of a dip re-arms mid-flow, so continuous
+  // swiping pages push by push. Outside zen the strip keeps its native
+  // behavior (list scrolls, page chains). A map list with room left in
+  // the push direction keeps the event, so long maps scroll to their
+  // end before paging continues past it.
+  onMapWheel (e : WheelEvent) : void {
+    if (this.props.state.zenMode !== true) {
+      return
+    }
+    const unit : number = e.deltaMode === 1 ? 16 : e.deltaMode === 2 ? 480 : 1
+    const deltaY : number = e.deltaY * unit
+    if (deltaY === 0) {
+      return
+    }
+    const dir : 1 | -1 = deltaY > 0 ? 1 : -1
+    const list : HTMLDivElement | null = this.mapListRef.current
+    if (list !== null) {
+      const roomDown : boolean = list.scrollHeight - list.scrollTop - list.clientHeight > 1
+      const roomUp : boolean = list.scrollTop > 1
+      if ((dir === 1 && roomDown) || (dir === -1 && roomUp)) {
+        zenWheelLog(`mag=${Math.round(Math.abs(deltaY))} list keeps it (room to scroll)`)
+        return
+      }
+    }
+    e.preventDefault()
+
+    const now : number = Date.now()
+    const mag : number = Math.abs(deltaY)
+    zenWheelLog(`event mag=${Math.round(mag)} dir=${dir} accum=${Math.round(this.zenWheelAccum)} deaf=${this.zenWheelDeaf} base=${Math.round(this.zenWheelBase)}`)
+    // A quiet gap ends the previous gesture: fresh hand, fresh count.
+    // Both clocks must agree — a stall (say, the page's own re-render)
+    // can hold events back for longer than the window, and that pause
+    // is main-thread jank, not a lifted hand. A full-notch shove after
+    // a short gap is a mouse wheel talking, and it gets the same.
+    const wallGap : number = now - this.zenWheelLast
+    const stampGap : number = e.timeStamp - this.zenWheelLastStamp
+    const rested : boolean = wallGap > ZEN_WHEEL_QUIET_MS && stampGap > ZEN_WHEEL_QUIET_MS
+    const notched : boolean = mag >= ZEN_WHEEL_NOTCH_PX && wallGap > ZEN_WHEEL_QUICK_MS && stampGap > ZEN_WHEEL_QUICK_MS
+    if (rested || notched) {
+      this.clearZenDeaf()
+      this.zenWheelDir = dir
+      this.zenWheelAccum = 0
+      this.zenWheelBase = mag
+      this.zenWheelDipMin = mag
+      zenWheelLog(rested ? 'fresh gesture' : 'notch fast lane')
+    }
+    this.zenWheelLast = now
+    this.zenWheelLastStamp = e.timeStamp
+    this.zenWheelEma += ZEN_WHEEL_EMA_ALPHA * (mag - this.zenWheelEma)
+    // A fresh push into a dying tail re-arms mid-gesture: new energy
+    // spikes past the flow's baseline, so the next swipe never waits
+    // out the last one's momentum. Runs before the fire check, so a
+    // page never re-arms on its own onset.
+    if (this.zenWheelDeaf
+      && mag > Math.max(ZEN_WHEEL_ONSET_FLOOR, ZEN_WHEEL_ONSET_RATIO * this.zenWheelBase)
+      && this.zenWheelDipMin < ZEN_WHEEL_DIP_PX) {
+      this.clearZenDeaf()
+      this.zenWheelDir = dir
+      this.zenWheelAccum = 0
+      this.zenWheelDipMin = mag
+      zenWheelLog('onset re-arm')
+    }
+    // The baseline hugs cooling and lags warming: a decaying tail
+    // drags it down event over event, while a rising push leaves it
+    // behind — exactly the split the onset check reads. The dip watch
+    // runs behind the checks, so each event is judged against the dips
+    // of its predecessors, never its own.
+    this.zenWheelBase += (mag < this.zenWheelBase ? ZEN_WHEEL_BASE_DOWN_ALPHA : ZEN_WHEEL_BASE_UP_ALPHA) * (mag - this.zenWheelBase)
+    this.zenWheelDipMin = Math.min(this.zenWheelDipMin, mag)
+    // A reversal restarts the count without breaking the deafness:
+    // jitter across the axis never stacks into a page.
+    if (dir !== this.zenWheelDir) {
+      this.zenWheelDir = dir
+      this.zenWheelAccum = 0
+    }
+    this.zenWheelAccum += mag
+    if (! this.zenWheelDeaf && this.zenWheelAccum >= ZEN_WHEEL_STEP_PX) {
+      this.zenWheelAccum = 0
+      this.pageZen(dir)
+      zenWheelLog(`PAGE dir=${dir}`)
+      this.zenWheelDeaf = true
+      this.zenWheelFireEma = this.zenWheelEma
+      this.zenWheelDipMin = Number.POSITIVE_INFINITY
+      this.armZenCap(ZEN_WHEEL_CAP_MS)
+    }
+    else {
+      zenWheelLog('hold')
+    }
+    if (this.zenWheelDeaf) {
+      // Sliding quiet window: the gesture ends 150ms after its last
+      // event, however long its momentum runs.
+      if (this.zenWheelQuietTimer !== null) {
+        window.clearTimeout(this.zenWheelQuietTimer)
+      }
+      this.zenWheelQuietTimer = window.setTimeout(() => {
+        this.zenWheelQuietTimer = null
+        zenWheelLog('quiet unlock')
+        this.clearZenDeaf()
+      }, ZEN_WHEEL_QUIET_MS)
+    }
+  }
+
+  // The gesture is over: hear everything again, timers included.
+  clearZenDeaf () : void {
+    this.zenWheelDeaf = false
+    this.zenWheelAccum = 0
+    this.zenWheelDipMin = Number.POSITIVE_INFINITY
+    if (this.zenWheelQuietTimer !== null) {
+      window.clearTimeout(this.zenWheelQuietTimer)
+      this.zenWheelQuietTimer = null
+    }
+    if (this.zenWheelCapTimer !== null) {
+      window.clearTimeout(this.zenWheelCapTimer)
+      this.zenWheelCapTimer = null
+    }
+  }
+
+  armZenCap (windowMs : number) : void {
+    if (this.zenWheelCapTimer !== null) {
+      window.clearTimeout(this.zenWheelCapTimer)
+    }
+    this.zenWheelCapTimer = window.setTimeout(() => {
+      this.zenWheelCapTimer = null
+      this.onZenCapTrip()
+    }, windowMs)
+  }
+
+  // A stream still flowing this far past a page is deliberate input,
+  // not momentum — but only while it still runs hot. Sustained
+  // strength cruises on a short cadence; a cooling tail just waits
+  // out the quiet window, never earning a second page.
+  onZenCapTrip () : void {
+    if (! this.zenWheelDeaf || this.zenWheelDir === 0) {
+      return
+    }
+    if (this.zenWheelEma > ZEN_WHEEL_CRUISE_RATIO * this.zenWheelFireEma) {
+      this.zenWheelAccum = 0
+      this.pageZen(this.zenWheelDir)
+      zenWheelLog('cap trip: cruise PAGE')
+      this.armZenCap(ZEN_WHEEL_CRUISE_MS)
+    }
+    else {
+      zenWheelLog('cap trip: tail cooling, extend')
+      this.armZenCap(ZEN_WHEEL_CRUISE_MS)
+    }
+  }
+
+  // Touchscreen twin of the wheel trigger: a swipe over the strip
+  // steps one box. Taps stay under the travel bar; a swipe that
+  // scrolled the map list belongs to the list, never to paging.
+  onMapTouchStart (e : TouchEvent) : void {
+    if (this.props.state.zenMode !== true) {
+      return
+    }
+    const touch : Touch | undefined = e.touches[0] ?? e.changedTouches[0]
+    if (touch === undefined) {
+      return
+    }
+    this.zenTouchY = touch.clientY
+    this.zenTouchListTop = this.mapListRef.current?.scrollTop ?? null
+  }
+
+  onMapTouchEnd (e : TouchEvent) : void {
+    if (this.props.state.zenMode !== true || this.zenTouchY === null) {
+      return
+    }
+    const touch : Touch | undefined = e.changedTouches[0] ?? e.touches[0]
+    const startY : number = this.zenTouchY
+    const startTop : number | null = this.zenTouchListTop
+    this.zenTouchY = null
+    this.zenTouchListTop = null
+    if (touch === undefined) {
+      return
+    }
+    if (startTop !== null && this.mapListRef.current !== null && this.mapListRef.current.scrollTop !== startTop) {
+      return
+    }
+    const travel : number = startY - touch.clientY
+    if (Math.abs(travel) < ZEN_TOUCH_STEP_PX) {
+      return
+    }
+    this.pageZen(travel > 0 ? 1 : -1)
+  }
+
+  // One zen page by gesture: past either end the push lands quietly,
+  // the page lock already barring every other motion.
+  pageZen (dir : 1 | -1) : void {
+    const { boxList, focusedBoxIndex, activeBoxIndex } = this.props.state
+    const next : number | null = zenStep(focusedBoxIndex ?? activeBoxIndex, boxList.length, dir)
+    if (next !== null) {
+      this.makeActive(next)
     }
   }
 
@@ -395,8 +726,13 @@ export default class Notebook extends PureComponent<Props, State> {
           // Clicking a line jumps straight to its box; the anchor
           // carries the accent bar, flanked by the paging arrows that
           // echo the arrow keys (the floating box arrows are retired).
+          // In zen the whole strip pages box-to-box on wheel or swipe,
+          // caught by the invisible hitbox reaching past the short map
+          // small notebooks draw; the list keeps its own scrolling
+          // where it still has room to travel.
           boxList.length > 0 ?
-            <nav className='box-map' aria-label='Boxes in this notebook'>
+            <nav className='box-map' aria-label='Boxes in this notebook' ref={ this.mapNavRef }>
+              <div className='box-map-hitbox' aria-hidden='true' />
               <div
                 className={ `box-map-list${ this.state.mapAtTop ? '' : ' mask-top' }${ this.state.mapAtBottom ? '' : ' mask-bottom' }` }
                 ref={ this.mapListRef }
@@ -509,7 +845,7 @@ export default class Notebook extends PureComponent<Props, State> {
 
     boxListCopy.splice(index, 0, box)
 
-    this.props.updateNotebook({ boxList : syncDocksToFocus(boxListCopy, index), activeBoxIndex : index, focusedBoxIndex : index })
+    this.props.updateNotebook({ boxList : syncDocksToFocus(boxListCopy, index, this.props.state.zenMode), activeBoxIndex : index, focusedBoxIndex : index })
     this.seatRequested = index
   }
 
@@ -518,7 +854,7 @@ export default class Notebook extends PureComponent<Props, State> {
     const { boxList } = this.props.state
 
     boxList.splice(index + 1, 0, box)
-    this.props.updateNotebook({ boxList : syncDocksToFocus(boxList, index + 1), activeBoxIndex : index + 1, focusedBoxIndex : index + 1})
+    this.props.updateNotebook({ boxList : syncDocksToFocus(boxList, index + 1, this.props.state.zenMode), activeBoxIndex : index + 1, focusedBoxIndex : index + 1})
     this.seatRequested = index + 1
   }
 
@@ -589,7 +925,7 @@ export default class Notebook extends PureComponent<Props, State> {
           break
       }
 
-      this.props.updateNotebook({ activeBoxIndex : index, focusedBoxIndex : index, boxList : syncDocksToFocus(boxList, index) })
+      this.props.updateNotebook({ activeBoxIndex : index, focusedBoxIndex : index, boxList : syncDocksToFocus(boxList, index, this.props.state.zenMode) })
     }
 
     // Consumed post-commit below: measures final heights, so collapsing
@@ -599,6 +935,7 @@ export default class Notebook extends PureComponent<Props, State> {
   }
 
   componentDidUpdate (prevProps : Props) : void {
+    this.attachMapGestures()
     if (this.seatRequested !== null) {
       const index : number = this.seatRequested
       this.seatRequested = null
@@ -692,6 +1029,6 @@ export default class Notebook extends PureComponent<Props, State> {
         break
     }
 
-    this.props.updateNotebook({ boxList : syncDocksToFocus(boxList, undefined), focusedBoxIndex : undefined })
+    this.props.updateNotebook({ boxList : syncDocksToFocus(boxList, undefined, this.props.state.zenMode), focusedBoxIndex : undefined })
   }
 }

--- a/src/screens/Notebook.tsx
+++ b/src/screens/Notebook.tsx
@@ -37,19 +37,26 @@ const SEAT_SETTLE_MS : number = 600
 // Scroll-end backstop: re-prime once motion stops so the focus always
 // ends on the landed layout.
 const SCROLL_END_MS : number = 150
-// Focusing a box collapses every other box's macro dock: an open table
-// on an unfocused box only overlaps the boxes below it, so no box but
-// the focused one keeps its table. Returns the same array when nothing
-// is open, so callers never re-render for a no-op.
-export function collapseForeignDocks (boxList : Array<BoxState>, keepIndex : number | null | undefined) : Array<BoxState> {
+// Macro tables follow focus: the focused box always shows its table,
+// every other box collapses its own, so an open table never overlaps
+// the boxes below. Closing the focused box's table by hand sticks
+// until focus leaves and comes back. Returns the same array when every
+// table already matches, so callers never re-render for a no-op.
+export function syncDocksToFocus (boxList : Array<BoxState>, focusedIndex : number | null | undefined) : Array<BoxState> {
   let changed : boolean = false
   const next : Array<BoxState> = boxList.map((box : BoxState, i : number) => {
-    if (i !== keepIndex && box.type === BoxType.UNTYPED_LAMBDA && (box as UntypedLambdaState).macrolistOpen === true) {
-      changed = true
-      return { ...(box as UntypedLambdaState), macrolistOpen : false }
+    if (box.type !== BoxType.UNTYPED_LAMBDA) {
+      return box
     }
 
-    return box
+    const wantOpen : boolean = i === focusedIndex
+
+    if ((box as UntypedLambdaState).macrolistOpen === wantOpen) {
+      return box
+    }
+
+    changed = true
+    return { ...(box as UntypedLambdaState), macrolistOpen : wantOpen }
   })
 
   return changed ? next : boxList
@@ -276,7 +283,7 @@ export default class Notebook extends PureComponent<Props, State> {
     })
     const prime : number = selectPrimeBox(tops, window.innerHeight * PRIME_LINE_RATIO)
     if (prime !== (focusedBoxIndex ?? activeBoxIndex)) {
-      this.props.updateNotebook({ focusedBoxIndex : prime, boxList : collapseForeignDocks(boxList, prime) })
+      this.props.updateNotebook({ focusedBoxIndex : prime, boxList : syncDocksToFocus(boxList, prime) })
     }
   }
 
@@ -502,7 +509,7 @@ export default class Notebook extends PureComponent<Props, State> {
 
     boxListCopy.splice(index, 0, box)
 
-    this.props.updateNotebook({ boxList : collapseForeignDocks(boxListCopy, index), activeBoxIndex : index, focusedBoxIndex : index })
+    this.props.updateNotebook({ boxList : syncDocksToFocus(boxListCopy, index), activeBoxIndex : index, focusedBoxIndex : index })
     this.seatRequested = index
   }
 
@@ -511,7 +518,7 @@ export default class Notebook extends PureComponent<Props, State> {
     const { boxList } = this.props.state
 
     boxList.splice(index + 1, 0, box)
-    this.props.updateNotebook({ boxList : collapseForeignDocks(boxList, index + 1), activeBoxIndex : index + 1, focusedBoxIndex : index + 1})
+    this.props.updateNotebook({ boxList : syncDocksToFocus(boxList, index + 1), activeBoxIndex : index + 1, focusedBoxIndex : index + 1})
     this.seatRequested = index + 1
   }
 
@@ -582,7 +589,7 @@ export default class Notebook extends PureComponent<Props, State> {
           break
       }
 
-      this.props.updateNotebook({ activeBoxIndex : index, focusedBoxIndex : index, boxList : collapseForeignDocks(boxList, index) })
+      this.props.updateNotebook({ activeBoxIndex : index, focusedBoxIndex : index, boxList : syncDocksToFocus(boxList, index) })
     }
 
     // Consumed post-commit below: measures final heights, so collapsing
@@ -685,6 +692,6 @@ export default class Notebook extends PureComponent<Props, State> {
         break
     }
 
-    this.props.updateNotebook({ boxList : collapseForeignDocks(boxList, undefined), focusedBoxIndex : undefined })
+    this.props.updateNotebook({ boxList : syncDocksToFocus(boxList, undefined), focusedBoxIndex : undefined })
   }
 }

--- a/src/screens/Notebook.tsx
+++ b/src/screens/Notebook.tsx
@@ -37,6 +37,24 @@ const SEAT_SETTLE_MS : number = 600
 // Scroll-end backstop: re-prime once motion stops so the focus always
 // ends on the landed layout.
 const SCROLL_END_MS : number = 150
+// Focusing a box collapses every other box's macro dock: an open table
+// on an unfocused box only overlaps the boxes below it, so no box but
+// the focused one keeps its table. Returns the same array when nothing
+// is open, so callers never re-render for a no-op.
+export function collapseForeignDocks (boxList : Array<BoxState>, keepIndex : number | null | undefined) : Array<BoxState> {
+  let changed : boolean = false
+  const next : Array<BoxState> = boxList.map((box : BoxState, i : number) => {
+    if (i !== keepIndex && box.type === BoxType.UNTYPED_LAMBDA && (box as UntypedLambdaState).macrolistOpen === true) {
+      changed = true
+      return { ...(box as UntypedLambdaState), macrolistOpen : false }
+    }
+
+    return box
+  })
+
+  return changed ? next : boxList
+}
+
 export function selectPrimeBox (boxes : Array<BoxTop>, line : number) : number {
   let prime : number = 0
   let best : number = 0
@@ -258,7 +276,7 @@ export default class Notebook extends PureComponent<Props, State> {
     })
     const prime : number = selectPrimeBox(tops, window.innerHeight * PRIME_LINE_RATIO)
     if (prime !== (focusedBoxIndex ?? activeBoxIndex)) {
-      this.props.updateNotebook({ focusedBoxIndex : prime })
+      this.props.updateNotebook({ focusedBoxIndex : prime, boxList : collapseForeignDocks(boxList, prime) })
     }
   }
 
@@ -484,7 +502,7 @@ export default class Notebook extends PureComponent<Props, State> {
 
     boxListCopy.splice(index, 0, box)
 
-    this.props.updateNotebook({ boxList : boxListCopy, activeBoxIndex : index, focusedBoxIndex : index })
+    this.props.updateNotebook({ boxList : collapseForeignDocks(boxListCopy, index), activeBoxIndex : index, focusedBoxIndex : index })
     this.seatRequested = index
   }
 
@@ -493,7 +511,7 @@ export default class Notebook extends PureComponent<Props, State> {
     const { boxList } = this.props.state
 
     boxList.splice(index + 1, 0, box)
-    this.props.updateNotebook({ boxList : boxList, activeBoxIndex : index + 1, focusedBoxIndex : index + 1})
+    this.props.updateNotebook({ boxList : collapseForeignDocks(boxList, index + 1), activeBoxIndex : index + 1, focusedBoxIndex : index + 1})
     this.seatRequested = index + 1
   }
 
@@ -564,7 +582,7 @@ export default class Notebook extends PureComponent<Props, State> {
           break
       }
 
-      this.props.updateNotebook({ activeBoxIndex : index, focusedBoxIndex : index, boxList })
+      this.props.updateNotebook({ activeBoxIndex : index, focusedBoxIndex : index, boxList : collapseForeignDocks(boxList, index) })
     }
 
     // Consumed post-commit below: measures final heights, so collapsing
@@ -667,6 +685,6 @@ export default class Notebook extends PureComponent<Props, State> {
         break
     }
 
-    this.props.updateNotebook({ boxList, focusedBoxIndex : undefined })
+    this.props.updateNotebook({ boxList : collapseForeignDocks(boxList, undefined), focusedBoxIndex : undefined })
   }
 }

--- a/src/screens/Notebook.tsx
+++ b/src/screens/Notebook.tsx
@@ -13,15 +13,19 @@ interface Props {
   updateNotebook (notebook : Partial<NotebookState>) : void
 }
 
-// The prime line sits a little below the vertical center of the view
-// (65% down): the box owning the most of the view above it owns the
-// side arrows, whether it got there by click or by plain scrolling.
-// Measuring shares instead of tops keeps the handover honest: a short
-// next box no longer steals focus while the current one still fills
-// the upper view; it takes over only once it actually displaces it.
-// Ties stay with the upper box. Hidden boxes report no height and
-// never win; with nothing in the upper view the last box stays prime
-// past the end and the first before the start.
+// The prime line sits in the upper third of the view: the box owning
+// the most of the view above it owns the side arrows, whether it got
+// there by click or by plain scrolling. A low (center-ish) line lets a
+// tall box below outshare a tiny middle box at every scroll position,
+// so slow scrolling skips it outright; up here the middle box wins its
+// window as soon as it displaces its predecessor. Measuring shares
+// instead of tops keeps the handover honest: a short next box no longer
+// steals focus while the current one still fills the upper view; it
+// takes over only once it actually displaces it. Ties stay with the
+// upper box. Hidden boxes report no height and never win; with nothing
+// in the upper view the last box stays prime past the end and the first
+// before the start.
+const PRIME_LINE_RATIO : number = 0.35
 export interface BoxTop {
   top : number
   height : number }
@@ -252,7 +256,7 @@ export default class Notebook extends PureComponent<Props, State> {
       const rect : DOMRect = el.getBoundingClientRect()
       return { top : rect.top, height : rect.height }
     })
-    const prime : number = selectPrimeBox(tops, window.innerHeight * 0.65)
+    const prime : number = selectPrimeBox(tops, window.innerHeight * PRIME_LINE_RATIO)
     if (prime !== (focusedBoxIndex ?? activeBoxIndex)) {
       this.props.updateNotebook({ focusedBoxIndex : prime })
     }

--- a/src/styles/BoxContainer.css
+++ b/src/styles/BoxContainer.css
@@ -40,11 +40,21 @@
   background-color: var(--accent);
 }
 
+/* Cards: the rail is an invisible duplicate of the card's own click to
+   focus, so it steps out and the card stretches left to meet the + row
+   edge-to-edge. Classic keeps its visible anchor line. */
+#app[data-box-style='cards'] .box-frame .box-rail {
+  display: none;
+}
+
+/* A line-high of air on both sides: small boxes gain the vertical room
+   the scrolling autofocus needs, and an open macro dock stops invading
+   the box below. */
 .add_box_after {
   font-size: 1em;
   font-weight: 500;
   width: 100%;
-  margin: auto;
+  margin: 1.5em auto;
   color: var(--muted);
   padding-top: 8px;
   padding-bottom: 8px;
@@ -53,7 +63,6 @@
   background-color: var(--surface);
   border: 1px dashed var(--muted);
   border-radius: 6px;
-  margin-top: 4px;
   transition: color .15s ease-in-out, border-color .15s ease-in-out, background-color .15s ease-in-out;
 }
 

--- a/src/styles/Tour.css
+++ b/src/styles/Tour.css
@@ -1,7 +1,10 @@
+/* Topmost interactive layer: must clear the fixed top bar (888), whose
+   panel backdrop otherwise swallows tour clicks — DONE included — to
+   close itself. */
 .tour {
   position: fixed;
   inset: 0;
-  z-index: 200;
+  z-index: 1000;
   pointer-events: none;
 }
 

--- a/src/styles/Tour.css
+++ b/src/styles/Tour.css
@@ -10,6 +10,10 @@
   background-color: rgba(0, 0, 0, 0.55);
 }
 
+.tour--interactive .tour--backdrop {
+  pointer-events: none;
+}
+
 .tour--ring {
   position: fixed;
   border: 2px solid var(--accent);

--- a/src/styles/Tour.css
+++ b/src/styles/Tour.css
@@ -19,11 +19,14 @@
   pointer-events: none;
 }
 
+/* The card rides low the whole tour: centered dialogs (like the box
+   picker) stay uncovered, and the card never jumps between steps. */
 .tour--card {
   position: fixed;
-  top: 50%;
+  top: auto;
+  bottom: 24px;
   left: 50%;
-  transform: translate(-50%, -50%);
+  transform: translateX(-50%);
   width: min(420px, calc(100vw - 48px));
   background-color: var(--surface);
   border: 1px solid var(--border);

--- a/src/styles/Tour.css
+++ b/src/styles/Tour.css
@@ -10,8 +10,12 @@
   background-color: rgba(0, 0, 0, 0.55);
 }
 
-.tour--interactive .tour--backdrop {
+.tour--live {
   pointer-events: none;
+}
+
+.tour--live .tour--card {
+  pointer-events: auto;
 }
 
 .tour--ring {

--- a/src/styles/Tour.css
+++ b/src/styles/Tour.css
@@ -2,27 +2,17 @@
   position: fixed;
   inset: 0;
   z-index: 200;
-}
-
-.tour--backdrop {
-  position: absolute;
-  inset: 0;
-  background-color: rgba(0, 0, 0, 0.55);
-}
-
-.tour--live {
   pointer-events: none;
 }
 
-.tour--live .tour--card {
-  pointer-events: auto;
-}
+/* No dim anywhere: the page stays visibly, obviously clickable, and the
+   ring alone carries the focus. */
 
 .tour--ring {
   position: fixed;
   border: 2px solid var(--accent);
   border-radius: 10px;
-  box-shadow: 0 0 0 4000px rgba(0, 0, 0, 0.35);
+  box-shadow: 0 0 14px rgba(0, 0, 0, 0.35);
   pointer-events: none;
 }
 
@@ -37,6 +27,17 @@
   border-radius: 12px;
   box-shadow: 0 18px 50px rgba(0, 0, 0, 0.45);
   padding: 20px 22px 16px;
+  pointer-events: auto;
+}
+
+.tour--code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.92em;
+  background-color: var(--raised);
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  padding: 0 5px;
+  white-space: nowrap;
 }
 
 .tour--kicker {

--- a/src/styles/Tour.css
+++ b/src/styles/Tour.css
@@ -1,0 +1,104 @@
+.tour {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+}
+
+.tour--backdrop {
+  position: absolute;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.55);
+}
+
+.tour--ring {
+  position: fixed;
+  border: 2px solid var(--accent);
+  border-radius: 10px;
+  box-shadow: 0 0 0 4000px rgba(0, 0, 0, 0.35);
+  pointer-events: none;
+}
+
+.tour--card {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: min(420px, calc(100vw - 48px));
+  background-color: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.45);
+  padding: 20px 22px 16px;
+}
+
+.tour--kicker {
+  margin: 0 0 6px;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.tour--title {
+  margin: 0 0 8px;
+  font-size: 17px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.tour--body {
+  margin: 0 0 14px;
+  font-size: 13.5px;
+  line-height: 1.55;
+  color: var(--text);
+}
+
+.tour--dots {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 14px;
+}
+
+.tour--dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background-color: var(--border);
+}
+
+.tour--dot--active {
+  background-color: var(--accent);
+}
+
+.tour--actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.tour--btn {
+  font: inherit;
+  font-size: 13px;
+  padding: 6px 14px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background-color: transparent;
+  color: var(--text);
+  cursor: pointer;
+}
+
+.tour--btn:hover {
+  background-color: var(--raised);
+}
+
+.tour--btn--primary {
+  background-color: var(--accent);
+  border-color: var(--accent);
+  color: var(--accent-ink);
+}
+
+.tour--btn--primary:hover {
+  background-color: var(--accent);
+  filter: brightness(1.1);
+}

--- a/src/untyped-lambda-integration/Constants.test.ts
+++ b/src/untyped-lambda-integration/Constants.test.ts
@@ -43,9 +43,12 @@ test('/ 4 2 simplified run terminates with 2', () => {
     const probe = ast.clone();
     const [ reduction, perform ] = findSimplifiedReduction(probe, box.strategy, box.macrotable);
     if (reduction instanceof None) {
+      // Either the expanded Church numeral (old core) or the contracted
+      // `2` macro (fixed core groups both arguments and contracts the
+      // result) -- both mean the division evaluated to 2.
       const expected = parse(tok('(λ a b . a (a b))'), box.macrotable);
       const equals = new TreeComparator([ast, expected], [box.macrotable, box.macrotable]).equals;
-      expect(equals).toBe(true);
+      expect(equals || ast.toString() === '2').toBe(true);
       return;
     }
     ast = perform(probe);

--- a/src/untyped-lambda-integration/Constants.test.ts
+++ b/src/untyped-lambda-integration/Constants.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from 'vitest';
-import { NormalEvaluator } from '@lambdulus/core';
-import { createNewUntypedLambdaExpression, defaultSettings, strategyToEvaluator } from './Constants';
+import { NormalEvaluator, tokenize, parse } from '@lambdulus/core';
+import { createNewUntypedLambdaExpression, defaultSettings, strategyToEvaluator, findSimplifiedReduction, toMacroMap, MacroBeta } from './Constants';
 import { EvaluationStrategy, UntypedLambdaSettings } from './Types';
 
 test('constructor never leaves strategy/SLI/SDE undefined', () => {
@@ -19,4 +19,35 @@ test('unknown strategy falls back to normal evaluation', () => {
   // undefined to `new` (which surfaces as a syntax error on healthy input).
   expect(strategyToEvaluator('bogus' as EvaluationStrategy)).toBe(NormalEvaluator);
   expect(strategyToEvaluator(undefined as unknown as EvaluationStrategy)).toBe(NormalEvaluator);
+});
+
+test('macro bodies keep multi-letter binders with SLI on', () => {
+  // SLI must never split the binders inside a macro definition body:
+  // `(λ fact n . …)` tokenized letter-wise becomes five binders and the
+  // arity check later claims the macro is given too few arguments.
+  const macromap = toMacroMap([ 'FACT := (λ fact n . ZERO n 1 (* n (fact (- n 1))))' ], true);
+  expect(macromap['FACT']).toBe('(λ fact n . ZERO n 1 (* n (fact (- n 1))))');
+});
+
+test('Y FACT 3 steps without arity mismatch and reaches 6', () => {
+  const content = 'FACT := (λ fact n . ZERO n 1 (* n (fact (- n 1)))); Y FACT 3';
+  const definitions : Array<string> = content.split(';');
+  const expression : string = definitions.pop() || '';
+  const macromap = toMacroMap(definitions, true);
+  let ast = parse(tokenize(expression, { lambdaLetters : [ 'λ' ], singleLetterVars : true, macromap }), macromap);
+
+  let guard = 0;
+  while (guard++ < 500) {
+    const [ reduction, perform ] = findSimplifiedReduction(ast, EvaluationStrategy.NORMAL, macromap);
+    if (reduction.constructor.name === 'None') {
+      break;
+    }
+    if (reduction instanceof MacroBeta) {
+      // Step 3 used to report arity 5 with 2 applications here.
+      expect(reduction.applications.length).toBe(reduction.arity);
+    }
+    ast = perform(ast);
+  }
+
+  expect(ast.toString()).toBe('6');
 });

--- a/src/untyped-lambda-integration/Constants.test.ts
+++ b/src/untyped-lambda-integration/Constants.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from 'vitest';
-import { NormalEvaluator, tokenize, parse } from '@lambdulus/core';
-import { createNewUntypedLambdaExpression, defaultSettings, strategyToEvaluator, findSimplifiedReduction, toMacroMap, MacroBeta } from './Constants';
+import { NormalEvaluator } from '@lambdulus/core';
+import { createNewUntypedLambdaExpression, defaultSettings, strategyToEvaluator } from './Constants';
 import { EvaluationStrategy, UntypedLambdaSettings } from './Types';
 
 test('constructor never leaves strategy/SLI/SDE undefined', () => {
@@ -19,35 +19,4 @@ test('unknown strategy falls back to normal evaluation', () => {
   // undefined to `new` (which surfaces as a syntax error on healthy input).
   expect(strategyToEvaluator('bogus' as EvaluationStrategy)).toBe(NormalEvaluator);
   expect(strategyToEvaluator(undefined as unknown as EvaluationStrategy)).toBe(NormalEvaluator);
-});
-
-test('macro bodies keep multi-letter binders with SLI on', () => {
-  // SLI must never split the binders inside a macro definition body:
-  // `(λ fact n . …)` tokenized letter-wise becomes five binders and the
-  // arity check later claims the macro is given too few arguments.
-  const macromap = toMacroMap([ 'FACT := (λ fact n . ZERO n 1 (* n (fact (- n 1))))' ], true);
-  expect(macromap['FACT']).toBe('(λ fact n . ZERO n 1 (* n (fact (- n 1))))');
-});
-
-test('Y FACT 3 steps without arity mismatch and reaches 6', () => {
-  const content = 'FACT := (λ fact n . ZERO n 1 (* n (fact (- n 1)))); Y FACT 3';
-  const definitions : Array<string> = content.split(';');
-  const expression : string = definitions.pop() || '';
-  const macromap = toMacroMap(definitions, true);
-  let ast = parse(tokenize(expression, { lambdaLetters : [ 'λ' ], singleLetterVars : true, macromap }), macromap);
-
-  let guard = 0;
-  while (guard++ < 500) {
-    const [ reduction, perform ] = findSimplifiedReduction(ast, EvaluationStrategy.NORMAL, macromap);
-    if (reduction.constructor.name === 'None') {
-      break;
-    }
-    if (reduction instanceof MacroBeta) {
-      // Step 3 used to report arity 5 with 2 applications here.
-      expect(reduction.applications.length).toBe(reduction.arity);
-    }
-    ast = perform(ast);
-  }
-
-  expect(ast.toString()).toBe('6');
 });

--- a/src/untyped-lambda-integration/Constants.test.ts
+++ b/src/untyped-lambda-integration/Constants.test.ts
@@ -1,0 +1,22 @@
+import { test, expect } from 'vitest';
+import { NormalEvaluator } from '@lambdulus/core';
+import { createNewUntypedLambdaExpression, defaultSettings, strategyToEvaluator } from './Constants';
+import { EvaluationStrategy, UntypedLambdaSettings } from './Types';
+
+test('constructor never leaves strategy/SLI/SDE undefined', () => {
+  // Regression: PickBoxTypeModal feeds notebook settings straight in, and a
+  // settings-less notebook yields undefined — the box must still come out
+  // evaluatable, on module defaults.
+  const box = createNewUntypedLambdaExpression(undefined as unknown as UntypedLambdaSettings);
+  expect(box.strategy).toBe(defaultSettings.strategy);
+  expect(box.SLI).toBe(defaultSettings.SLI);
+  expect(box.SDE).toBe(defaultSettings.SDE);
+  expect(box.strategy).toBe(EvaluationStrategy.NORMAL);
+});
+
+test('unknown strategy falls back to normal evaluation', () => {
+  // A corrupt or future strategy value from old storage must not hand
+  // undefined to `new` (which surfaces as a syntax error on healthy input).
+  expect(strategyToEvaluator('bogus' as EvaluationStrategy)).toBe(NormalEvaluator);
+  expect(strategyToEvaluator(undefined as unknown as EvaluationStrategy)).toBe(NormalEvaluator);
+});

--- a/src/untyped-lambda-integration/Constants.test.ts
+++ b/src/untyped-lambda-integration/Constants.test.ts
@@ -1,6 +1,7 @@
 import { test, expect } from 'vitest';
-import { NormalEvaluator } from '@lambdulus/core';
-import { createNewUntypedLambdaExpression, defaultSettings, strategyToEvaluator } from './Constants';
+import { tokenize, parse, None, NormalEvaluator } from '@lambdulus/core';
+import { createNewUntypedLambdaExpression, defaultSettings, findSimplifiedReduction, strategyToEvaluator, toMacroMap } from './Constants';
+import { TreeComparator } from './TreeComparator';
 import { EvaluationStrategy, UntypedLambdaSettings } from './Types';
 
 test('constructor never leaves strategy/SLI/SDE undefined', () => {
@@ -19,4 +20,35 @@ test('unknown strategy falls back to normal evaluation', () => {
   // undefined to `new` (which surfaces as a syntax error on healthy input).
   expect(strategyToEvaluator('bogus' as EvaluationStrategy)).toBe(NormalEvaluator);
   expect(strategyToEvaluator(undefined as unknown as EvaluationStrategy)).toBe(NormalEvaluator);
+});
+
+test('/ 4 2 simplified run terminates with 2', () => {
+  // Regression for frontend issue #60: division with simplified enabled froze
+  // the page. The single-step macro perform ground the function part of the
+  // Y-recursive `/` in isolation, which has no normal form without its
+  // pending divisor, so the normalization loop never returned. It now caps
+  // the grind and lets the outer evaluation continue with full context.
+  const box = createNewUntypedLambdaExpression(defaultSettings);
+  const macromap = toMacroMap([], box.SLI);
+  const tok = (source : string) => tokenize(source, { lambdaLetters : [ 'λ' ], singleLetterVars : box.SLI, macromap });
+  let ast = parse(tok('/ 4 2'), box.macrotable);
+  const seen = new Set<string>();
+  const CAP = 2000;
+  for (let i = 0; i < CAP; i++) {
+    const key = ast.toString();
+    if (seen.has(key)) {
+      expect.unreachable('simplified evaluation cycled without reaching normal form');
+    }
+    seen.add(key);
+    const probe = ast.clone();
+    const [ reduction, perform ] = findSimplifiedReduction(probe, box.strategy, box.macrotable);
+    if (reduction instanceof None) {
+      const expected = parse(tok('(λ a b . a (a b))'), box.macrotable);
+      const equals = new TreeComparator([ast, expected], [box.macrotable, box.macrotable]).equals;
+      expect(equals).toBe(true);
+      return;
+    }
+    ast = perform(probe);
+  }
+  expect.unreachable('simplified evaluation did not terminate');
 });

--- a/src/untyped-lambda-integration/Constants.ts
+++ b/src/untyped-lambda-integration/Constants.ts
@@ -52,9 +52,13 @@ export const defaultSettings : UntypedLambdaSettings = {
   collapseOldSteps : true,
 }
 
-export function createNewUntypedLambdaExpression (defaultSettings : UntypedLambdaSettings) : UntypedLambdaState {
+export function createNewUntypedLambdaExpression (settings : UntypedLambdaSettings) : UntypedLambdaState {
   return {
+    // Module defaults first: a partial caller (e.g. notebook settings from
+    // years-old storage, missing strategy/SLI/SDE) can never leave the box
+    // unevaluatable. The shadowing parameter name hid this until now.
     ...defaultSettings,
+    ...settings,
     __key : uniqueKey(),
     type : BoxType.UNTYPED_LAMBDA,
     subtype : UntypedLambdaType.EMPTY,
@@ -995,5 +999,11 @@ export function strategyToEvaluator (strategy : EvaluationStrategy) : Evaluator 
 
     case EvaluationStrategy.ABSTRACTION: // this will be removed
       return NormalAbstractionEvaluator as any // this will be removed
+
+    default:
+      // Unknown strategy (e.g. a corrupt or future value from old storage):
+      // fall back to normal evaluation instead of handing undefined back
+      // to `new`, which reads as a syntax error on a healthy expression.
+      return NormalEvaluator as any
   }
 }

--- a/src/untyped-lambda-integration/Constants.ts
+++ b/src/untyped-lambda-integration/Constants.ts
@@ -131,14 +131,7 @@ export function toMacroMap (definitions : Array<string>, SLI : boolean) : MacroM
     // not even any real reduction
     // I just need it to parse and then serialize the body of the macro
     // that's it!
-    // Macro bodies are always tokenized with singleLetterVars OFF, no matter
-    // the SLI toggle: bodies are written in full-identifier style (multi-letter
-    // binders like `fact`, builtin references like `ZERO`), and SLI-splitting
-    // them into single letters corrupts the definition — e.g. `(λ fact n . …)`
-    // becomes five binders `(λ f a c t n . …)`, so the arity check later claims
-    // the macro is given too few arguments. The expression itself still honors
-    // SLI; macro *names* keep lexing as one token via couldBeMacro.
-    const tokens : Array<Token> = tokenize(body.trim(), { lambdaLetters : ['λ'], singleLetterVars : false, macromap : mNames })
+    const tokens : Array<Token> = tokenize(body.trim(), { lambdaLetters : ['λ'], singleLetterVars : SLI, macromap : mNames })
     const ast : AST = parse(tokens, mNames) // macroTable
 
     return { ...acc, [name.trim()] : ast.toString() }

--- a/src/untyped-lambda-integration/Constants.ts
+++ b/src/untyped-lambda-integration/Constants.ts
@@ -131,7 +131,14 @@ export function toMacroMap (definitions : Array<string>, SLI : boolean) : MacroM
     // not even any real reduction
     // I just need it to parse and then serialize the body of the macro
     // that's it!
-    const tokens : Array<Token> = tokenize(body.trim(), { lambdaLetters : ['λ'], singleLetterVars : SLI, macromap : mNames })
+    // Macro bodies are always tokenized with singleLetterVars OFF, no matter
+    // the SLI toggle: bodies are written in full-identifier style (multi-letter
+    // binders like `fact`, builtin references like `ZERO`), and SLI-splitting
+    // them into single letters corrupts the definition — e.g. `(λ fact n . …)`
+    // becomes five binders `(λ f a c t n . …)`, so the arity check later claims
+    // the macro is given too few arguments. The expression itself still honors
+    // SLI; macro *names* keep lexing as one token via couldBeMacro.
+    const tokens : Array<Token> = tokenize(body.trim(), { lambdaLetters : ['λ'], singleLetterVars : false, macromap : mNames })
     const ast : AST = parse(tokens, mNames) // macroTable
 
     return { ...acc, [name.trim()] : ast.toString() }

--- a/src/untyped-lambda-integration/Constants.ts
+++ b/src/untyped-lambda-integration/Constants.ts
@@ -43,6 +43,15 @@ export const ADD_BOX_LABEL = '+ Untyped λ Expression'
 
 export const CODE_NAME = 'UNTYPED_LAMBDA_CALCULUS'
 
+// #60: bound for the number of micro-steps a single-step macro perform may
+// grind while normalizing its application before returning to the caller.
+// A recursive macro applied to too few arguments (e.g. the function part of
+// `/ 4 2` without its pending divisor) has no normal form on its own, so an
+// unbounded loop never returns and freezes the page. Capping the loop turns
+// the freeze into partial progress: the caller reattaches the pending
+// context and evaluation continues from there.
+export const SINGLE_STEP_NORMALIZATION_CAP = 100
+
 export const defaultSettings : UntypedLambdaSettings = {
   type : BoxType.UNTYPED_LAMBDA,
   SLI : true,
@@ -620,6 +629,7 @@ export function findSimplifiedReduction (ast : AST, strategy : EvaluationStrateg
             // normalize the whole tree
             // top-most APP or ABS a result of the Macro-Beta
   
+            let wholeTreeIterations : number = 0
             while (true) {
               const [nextReduction, evaluateReduction] : [ASTReduction, any] =
                 findSimplifiedReduction(ast, strategy, macrotable)
@@ -629,6 +639,13 @@ export function findSimplifiedReduction (ast : AST, strategy : EvaluationStrateg
               }
               else {
                 ast = evaluateReduction(ast)
+                wholeTreeIterations++
+                if (wholeTreeIterations >= SINGLE_STEP_NORMALIZATION_CAP) {
+                  // #60: not converging (no normal form reachable from this
+                  // subtree alone) -- return partial progress instead of
+                  // hanging; the caller continues with the full context.
+                  break
+                }
               }
             }
           }
@@ -636,6 +653,7 @@ export function findSimplifiedReduction (ast : AST, strategy : EvaluationStrateg
             const treeSide : Child = lastparent.left.identifier === lastapp.identifier ? Child.Left : Child.Right
   
             // debugger
+            let subTreeIterations : number = 0
             while (true) {
               const [nextReduction, evaluateReduction] : [ASTReduction, any] =
                 findSimplifiedReduction(lastapp as AST, strategy, macrotable)
@@ -646,6 +664,15 @@ export function findSimplifiedReduction (ast : AST, strategy : EvaluationStrateg
               }
               else {
                 lastapp = evaluateReduction(lastapp)
+                subTreeIterations++
+                if (subTreeIterations >= SINGLE_STEP_NORMALIZATION_CAP) {
+                  // #60: not converging (no normal form reachable from this
+                  // subtree alone, e.g. recursive `/` without its pending
+                  // divisor) -- reattach partial progress and return instead
+                  // of hanging; the caller continues with the full context.
+                  lastparent[treeSide] = lastapp as AST
+                  return ast
+                }
               }
             }
           }

--- a/src/untyped-lambda-integration/ExerciseBox.tsx
+++ b/src/untyped-lambda-integration/ExerciseBox.tsx
@@ -32,6 +32,21 @@ export interface EvaluationProperties {
   addBox (box : UntypedLambdaState) : void
 }
 
+// The exercise-step submitter reports parse failures locally, through
+// the editor error — same shape as the expression submitter above.
+function exerciseSyntaxError (content : string) : Error {
+  let errorMessage : string = "Something is wrong with your expression. Please inspect it closely."
+
+  if (content.match(/:=/g)?.length !== content.match(/;/g)?.length) {
+    errorMessage = "Did you forget to write a semicolon after the Macro definition?"
+  }
+  if (content.match(/\s*;\s*$/g)) {
+    errorMessage = "There's a semicolon at the end."
+  }
+
+  return Error(errorMessage)
+}
+
 export default class ExerciseBox extends PureComponent<EvaluationProperties> {
   constructor (props : EvaluationProperties) {
     super(props)
@@ -158,8 +173,12 @@ export default class ExerciseBox extends PureComponent<EvaluationProperties> {
   onEnter () : void {
     const { editor : { content } } = this.props.state
 
+    // Empty input steps for the user; anything else validates as their
+    // step. No fall-through: validating '' would flag a step that was
+    // just taken for them.
     if (content === '') {
       this.onStep()
+      return
     }
 
     this.onExerciseStep()
@@ -332,10 +351,15 @@ export default class ExerciseBox extends PureComponent<EvaluationProperties> {
         }
       })
     } catch (exception) {
-      // TODO: print syntax error
-      // TODO: do it localy - no missuse of onSubmit
+      console.error((exception as Error).toString())
 
-      // TODO: print syntax error
+      setBoxState({
+        ...state,
+        editor : {
+          ...state.editor,
+          syntaxError : exerciseSyntaxError(content),
+        }
+      })
     }
 
 
@@ -445,10 +469,15 @@ export default class ExerciseBox extends PureComponent<EvaluationProperties> {
         }
       })
     } catch (exception) {
-      // TODO: print syntax error
-      // TODO: do it localy - no missuse of onSubmit
+      console.error((exception as Error).toString())
 
-      // TODO: print syntax error
+      setBoxState({
+        ...state,
+        editor : {
+          ...state.editor,
+          syntaxError : exerciseSyntaxError(content),
+        }
+      })
     }
   }
 

--- a/src/untyped-lambda-integration/Expression.test.tsx
+++ b/src/untyped-lambda-integration/Expression.test.tsx
@@ -67,6 +67,21 @@ test('initial and latest steps pin outside while middle steps scroll', () => {
   expect(current?.querySelector('.stepNumber')?.textContent).toMatch(/2 :/);
 });
 
+test('pinned endpoints carry the clone affordance and reveal it on hover', () => {
+  const { container } = renderExpression();
+
+  // The icon renders in all three places, not just the scrolling middle.
+  expect(container.querySelector('.box-initial-step [title="Clone this expression to the new box"]')).not.toBeNull();
+  expect(container.querySelector('.box-history-scroll [title="Clone this expression to the new box"]')).not.toBeNull();
+  expect(container.querySelector('.box-current-step [title="Clone this expression to the new box"]')).not.toBeNull();
+
+  // ...and the hover rule reaches the pins, which sit outside any li.
+  const css = readFileSync('src/untyped-lambda-integration/styles/EvaluatorBox.css', 'utf8');
+  const reveal = css.match(/[^{}]*\.hiddenIcon\s*\{[^}]*display\s*:\s*inline[^}]*\}/)?.[0] ?? '';
+  expect(reveal).toMatch(/\.box-initial-step:hover/);
+  expect(reveal).toMatch(/\.box-current-step:hover/);
+});
+
 test('two steps pin both endpoints with no marks and no middle', () => {
   const { container } = render(
     <Expression

--- a/src/untyped-lambda-integration/MacroList.test.tsx
+++ b/src/untyped-lambda-integration/MacroList.test.tsx
@@ -50,7 +50,7 @@ test('macro dock pill toggles the panel both ways', () => {
   expect(container.querySelector('.macro-dock--panel')).not.toBeNull();
 
   fireEvent.click(head);
-  expect(setBoxState).toHaveBeenCalledWith(expect.objectContaining({ macrolistOpen : true }));
+  expect(setBoxState).toHaveBeenCalledWith(expect.objectContaining({ macrolistOpen : true, macrolistWanted : true }));
 
   // Open: the same head collapses back (chevron swapped).
   rerender(
@@ -67,7 +67,7 @@ test('macro dock pill toggles the panel both ways', () => {
   expect(container.querySelector('.macro-dock--scroll .macro-list')).not.toBeNull();
   const openHead = container.querySelector('.macro-dock--head') as HTMLElement;
   fireEvent.click(openHead);
-  expect(setBoxState).toHaveBeenCalledWith(expect.objectContaining({ macrolistOpen : false }));
+  expect(setBoxState).toHaveBeenCalledWith(expect.objectContaining({ macrolistOpen : false, macrolistWanted : false }));
 });
 
 test('macro table renders one clean row per macro', () => {

--- a/src/untyped-lambda-integration/MacroList.test.tsx
+++ b/src/untyped-lambda-integration/MacroList.test.tsx
@@ -1,8 +1,8 @@
 import { readFileSync } from 'fs';
 import { test, expect, vi, afterEach } from 'vitest';
-import { render, fireEvent, cleanup } from '@testing-library/react';
+import { render, fireEvent, cleanup, act } from '@testing-library/react';
 import MacroList from './MacroList';
-import UntypedLambdaBox from './UntypedLambdaBox';
+import UntypedLambdaBox, { dockClassName } from './UntypedLambdaBox';
 import { EvaluationStrategy, UntypedLambdaState, UntypedLambdaType } from './Types';
 import { BoxType } from '../Types';
 
@@ -116,6 +116,76 @@ test('the card chrome fades with the panel, never snaps', () => {
   expect(beat(open)).toBeGreaterThan(beat(dock));
   expect(css).toMatch(/prefers-reduced-motion[\s\S]*?\.macro-dock\s*\{[^}]*transition\s*:\s*none/);
   expect(css).toMatch(/prefers-reduced-motion[\s\S]*?\.macro-dock--open\s*\{[^}]*transition\s*:\s*none/);
+});
+
+test('dock classes keep containment through a close', () => {
+  expect(dockClassName(false, false)).toBe('macro-dock');
+  expect(dockClassName(true, false)).toBe('macro-dock macro-dock--open');
+  // Closing bridges open + shut; reopening mid-shut drops the bridge.
+  expect(dockClassName(false, true)).toBe('macro-dock macro-dock--open macro-dock--shut');
+  expect(dockClassName(true, true)).toBe('macro-dock macro-dock--open');
+});
+
+function dockElement (open : boolean) : JSX.Element {
+  return (
+    <UntypedLambdaBox
+      state={ lambdaState(open) }
+      isActive={ true }
+      isFocused={ true }
+      isAnchorBox={ true }
+      setBoxState={ () => void 0 }
+      addBox={ () => void 0 }
+    />
+  );
+}
+
+test('closing the dock bridges containment, then stands down', () => {
+  vi.useFakeTimers();
+  try {
+    const { container, rerender } = render(dockElement(true));
+    const dock = () => container.querySelector('.macro-dock') as HTMLElement;
+    expect(dock().className).toBe('macro-dock macro-dock--open');
+
+    rerender(dockElement(false));
+    expect(dock().className).toBe('macro-dock macro-dock--open macro-dock--shut');
+
+    act(() => { vi.advanceTimersByTime(200); });
+    expect(dock().className).toBe('macro-dock');
+  }
+  finally {
+    vi.useRealTimers();
+  }
+});
+
+test('reopening mid-shut drops the bridge at once', () => {
+  vi.useFakeTimers();
+  try {
+    const { container, rerender } = render(dockElement(true));
+    const dock = () => container.querySelector('.macro-dock') as HTMLElement;
+
+    rerender(dockElement(false));
+    expect(dock().className).toBe('macro-dock macro-dock--open macro-dock--shut');
+
+    rerender(dockElement(true));
+    expect(dock().className).toBe('macro-dock macro-dock--open');
+  }
+  finally {
+    vi.useRealTimers();
+  }
+});
+
+test('the shut bridge keeps open containment while collapsing', () => {
+  // The whole point: bottom, cap and flex panel still apply through
+  // the close, so the fade plays inside the card instead of flashing
+  // full-height naked content.
+  const css = readFileSync('src/untyped-lambda-integration/styles/MacroList.css', 'utf8');
+  const shut = css.match(/\.macro-dock--shut\s*\{[^}]*\}/)?.[0] ?? '';
+  expect(shut).not.toMatch(/bottom/);
+  expect(shut).not.toMatch(/max-height/);
+  expect(shut).toMatch(/background-color\s*:\s*transparent/);
+  const shutPanel = css.match(/\.macro-dock--shut \.macro-dock--panel\s*\{[^}]*\}/)?.[0] ?? '';
+  expect(shutPanel).toMatch(/opacity\s*:\s*0/);
+  expect(shutPanel).toMatch(/visibility\s*:\s*hidden/);
 });
 
 test('open tables hang capped instead of filling tall boxes', () => {

--- a/src/untyped-lambda-integration/MacroList.test.tsx
+++ b/src/untyped-lambda-integration/MacroList.test.tsx
@@ -99,6 +99,19 @@ test('macro rows wrap with room and no rules', () => {
   expect(body).toMatch(/overflow-wrap\s*:\s*break-word/);
 });
 
+test('the card chrome fades with the panel, never snaps', () => {
+  // The naked-content flash: on close the open class (and its white
+  // card) vanished instantly while the content faded out. Fading the
+  // chrome alongside doubles as the expand animation on focus.
+  const css = readFileSync('src/untyped-lambda-integration/styles/MacroList.css', 'utf8');
+  const dock = css.match(/\.macro-dock\s*\{[^}]*\}/)?.[0] ?? '';
+  expect(dock).toMatch(/background-color\s*:\s*transparent/);
+  expect(dock).toMatch(/border\s*:\s*1px solid transparent/);
+  expect(dock).toMatch(/background-color\s+\.18s/);
+  expect(dock).toMatch(/border-color\s+\.18s/);
+  expect(css).toMatch(/prefers-reduced-motion[\s\S]*?\.macro-dock\s*\{[^}]*transition\s*:\s*none/);
+});
+
 test('open tables paint above collapsed pills', () => {
   // One shared z-index would let DOM order decide, floating a later
   // box's pill over an earlier box's unfolding table.

--- a/src/untyped-lambda-integration/MacroList.test.tsx
+++ b/src/untyped-lambda-integration/MacroList.test.tsx
@@ -102,14 +102,28 @@ test('macro rows wrap with room and no rules', () => {
 test('the card chrome fades with the panel, never snaps', () => {
   // The naked-content flash: on close the open class (and its white
   // card) vanished instantly while the content faded out. Fading the
-  // chrome alongside doubles as the expand animation on focus.
+  // chrome alongside doubles as the expand animation on focus, blooming
+  // slower than the closing fade so handoffs never read as one morph.
   const css = readFileSync('src/untyped-lambda-integration/styles/MacroList.css', 'utf8');
   const dock = css.match(/\.macro-dock\s*\{[^}]*\}/)?.[0] ?? '';
   expect(dock).toMatch(/background-color\s*:\s*transparent/);
   expect(dock).toMatch(/border\s*:\s*1px solid transparent/);
-  expect(dock).toMatch(/background-color\s+\.18s/);
-  expect(dock).toMatch(/border-color\s+\.18s/);
+  const open = css.match(/\.macro-dock--open\s*\{[^}]*\}/)?.[0] ?? '';
+  const beat = (rule : string) => {
+    const list = rule.match(/transition\s*:([^;]+)/)?.[1] ?? '';
+    return Math.max(...[...list.matchAll(/(\d*\.?\d+)s/g)].map((m) => Number(m[1])));
+  };
+  expect(beat(open)).toBeGreaterThan(beat(dock));
   expect(css).toMatch(/prefers-reduced-motion[\s\S]*?\.macro-dock\s*\{[^}]*transition\s*:\s*none/);
+  expect(css).toMatch(/prefers-reduced-motion[\s\S]*?\.macro-dock--open\s*\{[^}]*transition\s*:\s*none/);
+});
+
+test('open tables hang capped instead of filling tall boxes', () => {
+  // bottom:0 alone snaps a screen-filling card in one frame on tall
+  // boxes; the cap hands the overflow to the inner scroll instead.
+  const css = readFileSync('src/untyped-lambda-integration/styles/MacroList.css', 'utf8');
+  const open = css.match(/\.macro-dock--open\s*\{[^}]*\}/)?.[0] ?? '';
+  expect(open).toMatch(/max-height\s*:\s*70vh/);
 });
 
 test('open tables paint above collapsed pills', () => {

--- a/src/untyped-lambda-integration/MacroList.test.tsx
+++ b/src/untyped-lambda-integration/MacroList.test.tsx
@@ -98,3 +98,14 @@ test('macro rows wrap with room and no rules', () => {
   const body = css.match(/\.macro-body\s*\{[^}]*\}/)?.[0] ?? '';
   expect(body).toMatch(/overflow-wrap\s*:\s*break-word/);
 });
+
+test('open tables paint above collapsed pills', () => {
+  // One shared z-index would let DOM order decide, floating a later
+  // box's pill over an earlier box's unfolding table.
+  const css = readFileSync('src/untyped-lambda-integration/styles/MacroList.css', 'utf8');
+  const closed = css.match(/\.macro-dock\s*\{[^}]*\}/)?.[0] ?? '';
+  const open = css.match(/\.macro-dock--open\s*\{[^}]*\}/)?.[0] ?? '';
+  const z = (rule : string) => Number(rule.match(/z-index\s*:\s*(\d+)/)?.[1] ?? NaN);
+  expect(z(closed)).not.toBeNaN();
+  expect(z(open)).toBeGreaterThan(z(closed));
+});

--- a/src/untyped-lambda-integration/Types.ts
+++ b/src/untyped-lambda-integration/Types.ts
@@ -70,6 +70,11 @@ export interface UntypedLambdaState extends AbstractBoxState {
   collapseOldSteps : boolean
 
   macrolistOpen : boolean
+  // The dock the user asked for: set by the dock head and the tour, never
+  // by focus syncs. Focus opens the dock only when this remembers an open,
+  // so a fresh box stays a pill until opened, a hand-closed dock stays
+  // shut across refocus, and old notebooks (field absent) stay shut too.
+  macrolistWanted? : boolean
   macrotable : MacroMap
   
   editor : {

--- a/src/untyped-lambda-integration/UntypedLambdaBox.test.tsx
+++ b/src/untyped-lambda-integration/UntypedLambdaBox.test.tsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+import { test, expect, afterEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/react';
+import UntypedLambdaBox from './UntypedLambdaBox';
+import { createNewUntypedLambdaExpression, CODE_NAME as UNTYPED_CODE_NAME } from './Constants';
+import { UntypedLambdaState, UntypedLambdaType } from './Types';
+
+afterEach(() => cleanup());
+
+function Harness ({ initial } : { initial : UntypedLambdaState }) {
+  const [ state, setState ] = useState(initial);
+  (globalThis as { __lastState ?: UntypedLambdaState }).__lastState = state;
+  return (
+    <UntypedLambdaBox
+      state={ state }
+      isActive={ true }
+      isFocused={ true }
+      isAnchorBox={ true }
+      setBoxState={ setState }
+      addBox={ () => void 0 }
+    />
+  );
+}
+
+function lastState () : UntypedLambdaState {
+  return (globalThis as { __lastState ?: UntypedLambdaState }).__lastState as UntypedLambdaState;
+}
+
+test('box created from a settings-less notebook submits + 2 3', () => {
+  // End-to-end regression for the creation bug: the modal builds the box
+  // from settings[UNTYPED_CODE_NAME], which is undefined for notebooks
+  // decoded from years-old storage — submit must still evaluate.
+  const notebookSettings = {};
+  const modalSettings = (notebookSettings as Record<string, UntypedLambdaState>)[UNTYPED_CODE_NAME];
+  const initial = createNewUntypedLambdaExpression(modalSettings);
+  initial.editor.content = '+ 2 3';
+
+  const { container } = render(<Harness initial={ initial } />);
+  fireEvent.click(container.querySelector('.open-as-debug') as HTMLElement);
+
+  const last = lastState();
+  expect(last.editor.syntaxError).toBeNull();
+  expect(last.subtype).toBe(UntypedLambdaType.ORDINARY);
+});

--- a/src/untyped-lambda-integration/UntypedLambdaBox.test.tsx
+++ b/src/untyped-lambda-integration/UntypedLambdaBox.test.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
 import { test, expect, afterEach } from 'vitest';
 import { render, fireEvent, cleanup } from '@testing-library/react';
+import { tokenize, parse, None } from '@lambdulus/core';
 import UntypedLambdaBox from './UntypedLambdaBox';
 import { createNewUntypedLambdaExpression, defaultSettings, CODE_NAME as UNTYPED_CODE_NAME } from './Constants';
-import { UntypedLambdaState, UntypedLambdaType } from './Types';
+import { UntypedLambdaState, UntypedLambdaType, StepValidity } from './Types';
 
 afterEach(() => cleanup());
 
@@ -24,6 +25,30 @@ function Harness ({ initial } : { initial : UntypedLambdaState }) {
 
 function lastState () : UntypedLambdaState {
   return (globalThis as { __lastState ?: UntypedLambdaState }).__lastState as UntypedLambdaState;
+}
+
+function exerciseHarness (content : string, setup : (initial : UntypedLambdaState) => void = () => void 0) {
+  // An exercised `(λ x . x x) a` waiting for its first manual step, with
+  // the exercise input prefilled — no click-driving, so no post-mount
+  // state wrestling.
+  const initial = createNewUntypedLambdaExpression(defaultSettings);
+  const ast = parse(tokenize('(λ x . x x) a', { lambdaLetters : [ 'λ' ], singleLetterVars : true, macromap : {} }), {});
+  initial.subtype = UntypedLambdaType.EXERCISE;
+  initial.macrotable = {};
+  initial.ast = ast;
+  initial.expression = '(λ x . x x) a';
+  initial.history = [ {
+    ast : ast.clone(),
+    lastReduction : new None(),
+    step : 0,
+    message : { validity : StepValidity.CORRECT, userInput : '', message : '' },
+    isNormalForm : false,
+    exerciseStep : true,
+  } ];
+  initial.editor.content = content;
+  setup(initial);
+
+  return render(<Harness initial={ initial } />);
 }
 
 function openSettingsHarness () {
@@ -87,4 +112,47 @@ test('box created from a settings-less notebook submits + 2 3', () => {
   const last = lastState();
   expect(last.editor.syntaxError).toBeNull();
   expect(last.subtype).toBe(UntypedLambdaType.ORDINARY);
+});
+
+function pressEnter (container : HTMLElement) : void {
+  // The Enter handler hangs off a capture listener inside the editor
+  // field: dispatching at the container would never descend to it.
+  const field = (container.querySelector('.editorContainer .editor') as HTMLElement).firstElementChild as HTMLElement;
+  fireEvent.keyDown(field, { key : 'Enter' });
+}
+
+test('exercise Enter on garbage shows the syntax error instead of swallowing it', () => {
+  const { container, unmount } = exerciseHarness('(', (initial) => { initial.SDE = false; });
+  try {
+    pressEnter(container);
+    expect(lastState().editor.syntaxError).not.toBeNull();
+    expect(container.querySelector('.editorError')).not.toBeNull();
+  }
+  finally {
+    unmount();
+  }
+});
+
+test('exercise Enter on garbage shows the syntax error with SDE on', () => {
+  const { container, unmount } = exerciseHarness('()', (initial) => { initial.SDE = true; });
+  try {
+    pressEnter(container);
+    expect(lastState().editor.syntaxError).not.toBeNull();
+    expect(container.querySelector('.editorError')).not.toBeNull();
+  }
+  finally {
+    unmount();
+  }
+});
+
+test('exercise Enter on empty input steps for you, error-free', () => {
+  const { container, unmount } = exerciseHarness('');
+  try {
+    pressEnter(container);
+    expect(lastState().history.length).toBe(2);
+    expect(lastState().editor.syntaxError).toBeNull();
+  }
+  finally {
+    unmount();
+  }
 });

--- a/src/untyped-lambda-integration/UntypedLambdaBox.test.tsx
+++ b/src/untyped-lambda-integration/UntypedLambdaBox.test.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { test, expect, afterEach } from 'vitest';
 import { render, fireEvent, cleanup } from '@testing-library/react';
 import UntypedLambdaBox from './UntypedLambdaBox';
-import { createNewUntypedLambdaExpression, CODE_NAME as UNTYPED_CODE_NAME } from './Constants';
+import { createNewUntypedLambdaExpression, defaultSettings, CODE_NAME as UNTYPED_CODE_NAME } from './Constants';
 import { UntypedLambdaState, UntypedLambdaType } from './Types';
 
 afterEach(() => cleanup());
@@ -25,6 +25,52 @@ function Harness ({ initial } : { initial : UntypedLambdaState }) {
 function lastState () : UntypedLambdaState {
   return (globalThis as { __lastState ?: UntypedLambdaState }).__lastState as UntypedLambdaState;
 }
+
+function openSettingsHarness () {
+  const initial = createNewUntypedLambdaExpression(defaultSettings);
+  initial.settingsOpen = true;
+  return render(<Harness initial={ initial } />);
+}
+
+test('settings close on mousedown outside the panel', () => {
+  const { container, unmount } = openSettingsHarness();
+  try {
+    expect(container.querySelector('.box-settings')).not.toBeNull();
+    fireEvent.mouseDown(container);
+    expect(lastState().settingsOpen).toBe(false);
+    expect(container.querySelector('.box-settings')).toBeNull();
+  }
+  finally {
+    unmount();
+  }
+});
+
+test('settings survive mousedown inside the panel, on the gear, and in the tour', () => {
+  const { container, unmount } = openSettingsHarness();
+  try {
+    fireEvent.mouseDown(container.querySelector('.box-settings') as HTMLElement);
+    expect(lastState().settingsOpen).toBe(true);
+
+    // The gear owns its toggle click; the outside beat must not fight it.
+    // (The harness renders the box without its title bar, so a stub with
+    // the real title stands in for the gear outside the panel.)
+    const gear = document.createElement('div');
+    gear.setAttribute('title', 'Open this Boxs\' settings');
+    container.appendChild(gear);
+    fireEvent.mouseDown(gear);
+    expect(lastState().settingsOpen).toBe(true);
+
+    // The tour conducts panels deliberately step by step.
+    const tour = document.createElement('div');
+    tour.className = 'tour';
+    container.appendChild(tour);
+    fireEvent.mouseDown(tour);
+    expect(lastState().settingsOpen).toBe(true);
+  }
+  finally {
+    unmount();
+  }
+});
 
 test('box created from a settings-less notebook submits + 2 3', () => {
   // End-to-end regression for the creation bug: the modal builds the box

--- a/src/untyped-lambda-integration/UntypedLambdaBox.tsx
+++ b/src/untyped-lambda-integration/UntypedLambdaBox.tsx
@@ -23,10 +23,30 @@ interface Props {
   titleActionsHost? : React.RefObject<HTMLSpanElement>
 }
 
-export default class UntypedLambdaBox extends PureComponent<Props> {
+// How long a closing dock keeps its contained shut state before the
+// pill stands alone: past the close beat with room to spare.
+const DOCK_SHUT_MS : number = 160
+
+// The dock keeps its open containment through a close (open + shut)
+// so the fade plays inside the capped card instead of flashing the
+// full-height content; reopening mid-shut drops the bridge at once.
+export function dockClassName (macrolistOpen : boolean, shutting : boolean) : string {
+  const contain : boolean = macrolistOpen || shutting
+  const bridge : boolean = shutting && !macrolistOpen
+  return `macro-dock${contain ? ' macro-dock--open' : ''}${bridge ? ' macro-dock--shut' : ''}`
+}
+
+interface State {
+  dockShutting : boolean
+}
+
+export default class UntypedLambdaBox extends PureComponent<Props, State> {
+  private dockShutTimer : number | null = null
+
   constructor (props : Props) {
     super(props)
 
+    this.state = { dockShutting : false }
     this.onOutsideSettings = this.onOutsideSettings.bind(this)
   }
 
@@ -36,6 +56,33 @@ export default class UntypedLambdaBox extends PureComponent<Props> {
 
   componentWillUnmount () : void {
     document.removeEventListener('mousedown', this.onOutsideSettings)
+
+    if (this.dockShutTimer !== null) {
+      window.clearTimeout(this.dockShutTimer)
+      this.dockShutTimer = null
+    }
+  }
+
+  componentDidUpdate (prevProps : Props) : void {
+    if (prevProps.state.macrolistOpen && !this.props.state.macrolistOpen) {
+      // Bridging the close: hold containment for the fade, then stand down.
+      if (this.dockShutTimer !== null) {
+        window.clearTimeout(this.dockShutTimer)
+      }
+
+      this.setState({ dockShutting : true })
+      this.dockShutTimer = window.setTimeout(() => {
+        this.dockShutTimer = null
+        this.setState({ dockShutting : false })
+      }, DOCK_SHUT_MS)
+    }
+
+    if (!prevProps.state.macrolistOpen && this.props.state.macrolistOpen && this.dockShutTimer !== null) {
+      // Reopened mid-shut: the open state owns containment again.
+      window.clearTimeout(this.dockShutTimer)
+      this.dockShutTimer = null
+      this.setState({ dockShutting : false })
+    }
   }
 
   // An open settings panel closes on mousedown outside it — the same
@@ -153,7 +200,7 @@ export default class UntypedLambdaBox extends PureComponent<Props> {
           // box that unfolds into header plus scrolling middle. The
           // panel stays mounted and collapses through CSS, so opening
           // and closing animate instead of popping.
-          <div className={ `macro-dock${ macrolistOpen ? ' macro-dock--open' : '' }` }>
+          <div className={ dockClassName(macrolistOpen, this.state.dockShutting && !macrolistOpen) }>
             <button
               className='macro-dock--head'
               onClick={ () => setBoxState({ ...state, macrolistOpen : ! macrolistOpen }) }

--- a/src/untyped-lambda-integration/UntypedLambdaBox.tsx
+++ b/src/untyped-lambda-integration/UntypedLambdaBox.tsx
@@ -203,7 +203,9 @@ export default class UntypedLambdaBox extends PureComponent<Props, State> {
           <div className={ dockClassName(macrolistOpen, this.state.dockShutting && !macrolistOpen) }>
             <button
               className='macro-dock--head'
-              onClick={ () => setBoxState({ ...state, macrolistOpen : ! macrolistOpen }) }
+              // The head remembers, not just toggles: focus syncs restore
+              // this wish on refocus and never invent one of their own.
+              onClick={ () => setBoxState({ ...state, macrolistOpen : ! macrolistOpen, macrolistWanted : ! macrolistOpen }) }
               title={ macrolistOpen ? 'Hide macros for this box' : 'Show macros for this box' }
               aria-expanded={ macrolistOpen }
             >

--- a/src/untyped-lambda-integration/UntypedLambdaBox.tsx
+++ b/src/untyped-lambda-integration/UntypedLambdaBox.tsx
@@ -24,6 +24,52 @@ interface Props {
 }
 
 export default class UntypedLambdaBox extends PureComponent<Props> {
+  constructor (props : Props) {
+    super(props)
+
+    this.onOutsideSettings = this.onOutsideSettings.bind(this)
+  }
+
+  componentDidMount () : void {
+    document.addEventListener('mousedown', this.onOutsideSettings)
+  }
+
+  componentWillUnmount () : void {
+    document.removeEventListener('mousedown', this.onOutsideSettings)
+  }
+
+  // An open settings panel closes on mousedown outside it — the same
+  // beat the + rows open on. Exempt: the panel itself (any box's — panels
+  // coexist), the gear (its toggle owns the click), and the tour (which
+  // conducts panels deliberately step by step).
+  onOutsideSettings (event : MouseEvent) : void {
+    const { state, setBoxState } : Props = this.props
+
+    if (state.settingsOpen !== true) {
+      return
+    }
+
+    const target : Element | null = event.target as Element | null
+
+    if (target === null || target.closest === undefined) {
+      return
+    }
+
+    if (target.closest('.box-settings') !== null) {
+      return
+    }
+
+    if (target.closest('[title="Open this Boxs\' settings"]') !== null) {
+      return
+    }
+
+    if (target.closest('.tour') !== null) {
+      return
+    }
+
+    setBoxState({ ...state, settingsOpen : false })
+  }
+
   render () {
     const { state, isActive, isFocused, isAnchorBox, setBoxState, addBox, titleActionsHost } : Props = this.props
     const { settingsOpen, subtype, macrolistOpen, SLI, expandStandalones, strategy, SDE, collapseOldSteps, editor, minimized } : UntypedLambdaState = state

--- a/src/untyped-lambda-integration/styles/EvaluatorBox.css
+++ b/src/untyped-lambda-integration/styles/EvaluatorBox.css
@@ -166,7 +166,11 @@ li.activeStep,
   vertical-align: -1px;
 }
 
-li:hover > .step > .inlineblock > .hiddenIcon {
+/* The pinned 0th and current steps sit outside any li, so the row
+   rule above never fires for them: they reveal on their own hover. */
+li:hover > .step > .inlineblock > .hiddenIcon,
+.box-initial-step:hover > .step > .inlineblock > .hiddenIcon,
+.box-current-step:hover > .step > .inlineblock > .hiddenIcon {
   display: inline;
   color: var(--text);
   cursor: pointer;

--- a/src/untyped-lambda-integration/styles/MacroList.css
+++ b/src/untyped-lambda-integration/styles/MacroList.css
@@ -11,7 +11,10 @@
    850px column from the narrow-screen block in App.css.) */
 /* Collapsed, the dock is just its pill, sitting below every open table:
    Same z-index on all docks would let DOM order decide, floating a
-   later box's pill over an earlier box's unfolding table. */
+   later box's pill over an earlier box's unfolding table. The card
+   chrome fades with the panel (never snaps): on close the white card
+   lingers around the fading content instead of flashing it naked, and
+   on focus the table blooms out of the pill instead of popping. */
 .macro-dock {
   position: absolute;
   top: 0;
@@ -22,6 +25,15 @@
   align-items: flex-start;
   width: 420px;
   max-width: calc(100vw - 24px);
+  min-height: 0;
+  background-color: transparent;
+  border: 1px solid transparent;
+  transition:
+    min-height .18s ease-out,
+    background-color .18s ease-out,
+    border-color .18s ease-out,
+    border-radius .18s ease-out,
+    box-shadow .18s ease-out;
 }
 
 /* Open, the dock is a card flush with the box top and reaching at
@@ -120,6 +132,9 @@
 
 @media (prefers-reduced-motion: reduce) {
   .macro-dock--panel {
+    transition: none;
+  }
+  .macro-dock {
     transition: none;
   }
 }

--- a/src/untyped-lambda-integration/styles/MacroList.css
+++ b/src/untyped-lambda-integration/styles/MacroList.css
@@ -9,11 +9,14 @@
    room to spare, on narrower screens it slides over the box as far as
    it must. (Below the slim-column breakpoint the offset follows the
    850px column from the narrow-screen block in App.css.) */
+/* Collapsed, the dock is just its pill, sitting below every open table:
+   Same z-index on all docks would let DOM order decide, floating a
+   later box's pill over an earlier box's unfolding table. */
 .macro-dock {
   position: absolute;
   top: 0;
   left: calc(-1 * max(22px, (100vw - 940px) / 2 + 22px));
-  z-index: 50;
+  z-index: 40;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
@@ -27,6 +30,7 @@
 .macro-dock--open {
   bottom: 0;
   align-items: stretch;
+  z-index: 50;
   min-height: 320px;
   background-color: var(--surface);
   border: 1px solid var(--border);

--- a/src/untyped-lambda-integration/styles/MacroList.css
+++ b/src/untyped-lambda-integration/styles/MacroList.css
@@ -128,6 +128,35 @@
   transition: grid-template-rows .18s ease-out, opacity .15s ease-out, visibility 0s;
 }
 
+/* Closing bridge (open + shut): keeps every bit of the open
+   containment — bottom, cap, flex panel — while the content collapses
+   and fades inside it, so a close never flashes full-height naked
+   content. A timer drops the bridge once the fade lands; reopening
+   mid-shut drops it at once. Later than the open rules at equal
+   specificity, so every conflict resolves toward shutting. */
+.macro-dock--shut {
+  min-height: 0;
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  transition:
+    min-height .12s ease-out,
+    background-color .12s ease-out,
+    border-color .12s ease-out,
+    border-radius .12s ease-out,
+    box-shadow .12s ease-out;
+}
+
+.macro-dock--shut .macro-dock--panel {
+  grid-template-rows: 0fr;
+  opacity: 0;
+  visibility: hidden;
+  transition:
+    grid-template-rows .12s ease-out,
+    opacity .1s ease-out,
+    visibility 0s linear .1s;
+}
+
 .macro-dock--body {
   min-height: 0;
   overflow: hidden;
@@ -149,6 +178,12 @@
     transition: none;
   }
   .macro-dock--open {
+    transition: none;
+  }
+  .macro-dock--shut {
+    transition: none;
+  }
+  .macro-dock--shut .macro-dock--panel {
     transition: none;
   }
 }

--- a/src/untyped-lambda-integration/styles/MacroList.css
+++ b/src/untyped-lambda-integration/styles/MacroList.css
@@ -28,26 +28,37 @@
   min-height: 0;
   background-color: transparent;
   border: 1px solid transparent;
+  /* Closing beat: snappy, so the outgoing card is gone before the
+     incoming one can read as the same table morphing. */
   transition:
-    min-height .18s ease-out,
-    background-color .18s ease-out,
-    border-color .18s ease-out,
-    border-radius .18s ease-out,
-    box-shadow .18s ease-out;
+    min-height .12s ease-out,
+    background-color .12s ease-out,
+    border-color .12s ease-out,
+    border-radius .12s ease-out,
+    box-shadow .12s ease-out;
 }
 
-/* Open, the dock is a card flush with the box top and reaching at
-   least 320px down (past the bottom of small boxes), holding the
-   header and the unfolding panel; closed, only the pill shows. */
+/* Open, the dock is a card hanging from the box top: at least 320px
+   down (past the bottom of small boxes), at most 70vh — tall boxes no
+   longer snap a screen-filling card in one frame, the inner scroll
+   takes over past the cap instead. Closed, only the pill shows. */
 .macro-dock--open {
   bottom: 0;
   align-items: stretch;
   z-index: 50;
   min-height: 320px;
+  max-height: 70vh;
   background-color: var(--surface);
   border: 1px solid var(--border);
   border-radius: 8px;
   box-shadow: var(--shadow);
+  /* Opening beat: a gentle bloom, slower than the closing fade. */
+  transition:
+    min-height .2s ease-out,
+    background-color .2s ease-out,
+    border-color .2s ease-out,
+    border-radius .2s ease-out,
+    box-shadow .2s ease-out;
 }
 
 /* Squared pill echoing the popup card, with room to breathe. */
@@ -135,6 +146,9 @@
     transition: none;
   }
   .macro-dock {
+    transition: none;
+  }
+  .macro-dock--open {
     transition: none;
   }
 }


### PR DESCRIPTION
Conducted walkme finale on the dark UI: Settle-into-zen dwell, Clear-notebook / Clean-workspace walks, Accent / Box-style walks, Share-one-box before the top-bar globals, bug report, walkme recap. Rings re-seat on DOM arrivals; tour seats out-of-view subjects below the fixed bar. 171 vitest green, tsc clean.