### PR TITLE
Develop to master: cleanup, scroll/zen fixes, share-link settings, sync status

### DIFF
--- a/.github/workflows/sync-badge.yml
+++ b/.github/workflows/sync-badge.yml
@@ -1,0 +1,98 @@
+name: Production sync status
+
+# Keeps the "Production status" line in README.md truthful on both
+# branches: whether production (master) serves the latest build
+# (develop's tip, i.e. what staging runs). "Latest" means the develop
+# tip is contained in master -- promotions land as merge commits that
+# develop itself lacks, so a raw ahead/behind count would cry
+# "diverged" forever; containment is the honest check. Runs on every
+# push to either branch plus hourly to heal outside moves. Bot commits
+# carry [skip ci] so they never trigger deploys themselves.
+
+on:
+  push:
+    branches: [ develop, master ]
+  schedule:
+    - cron: '17 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: production-sync
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          token: ${{ secrets.ACCESS_TOKEN }}
+          fetch-depth: 0
+
+      - name: Compute and publish sync status
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git fetch origin develop master
+
+          export STATUS_SHA STATUS_COUNT STATUS_SYNCED
+          STATUS_SHA=$(git rev-parse --short origin/develop)
+          STATUS_COUNT=$(git rev-list --count origin/master..origin/develop)
+          if git merge-base --is-ancestor origin/develop origin/master; then
+            STATUS_SYNCED=true
+          else
+            STATUS_SYNCED=false
+          fi
+
+          for BRANCH in develop master; do
+            git checkout -B "$BRANCH" "origin/$BRANCH"
+
+            python3 - <<'EOF'
+          import os
+
+          synced = os.environ['STATUS_SYNCED'] == 'true'
+          sha = os.environ['STATUS_SHA']
+          count = int(os.environ['STATUS_COUNT'])
+          compare_url = 'https://github.com/lambdulus/frontend/compare/master...develop'
+
+          if synced:
+              line = f'**Production status:** on the latest build ✅ (`{sha}`)'
+          else:
+              n = 'build' if count == 1 else 'builds'
+              line = f'**Production status:** {count} {n} behind staging ⚠️ — [compare]({compare_url})'
+
+          with open('README.md') as f:
+              readme = f.read()
+
+          start = '<!-- production-sync:start -->'
+          end = '<!-- production-sync:end -->'
+          before, sep, rest = readme.partition(start)
+          _, sep2, after = rest.partition(end)
+          if not sep or not sep2:
+              raise SystemExit('sync markers missing from README.md')
+
+          with open('README.md', 'w') as f:
+              f.write(f'{before}{start}\n{line}\n{end}{after}')
+          EOF
+
+            if git diff --quiet; then
+              echo "README already fresh on $BRANCH"
+              continue
+            fi
+
+            git add README.md
+            git commit -m "[skip ci] production sync status on $BRANCH"
+
+            for i in 1 2 3; do
+              if git push origin "$BRANCH"; then
+                break
+              fi
+              git fetch origin "$BRANCH"
+              git rebase "origin/$BRANCH"
+            done
+          done

--- a/.github/workflows/sync-badge.yml
+++ b/.github/workflows/sync-badge.yml
@@ -51,6 +51,7 @@ jobs:
 
           for BRANCH in develop master; do
             git checkout -B "$BRANCH" "origin/$BRANCH"
+            export SYNC_BRANCH="$BRANCH"
 
             python3 - <<'EOF'
           import os
@@ -74,11 +75,23 @@ jobs:
           before, sep, rest = readme.partition(start)
           _, sep2, after = rest.partition(end)
           if not sep or not sep2:
-              raise SystemExit('sync markers missing from README.md')
+              # No markers on this branch yet (the table hasn't arrived
+              # here): leave it alone. The upcoming merge delivers the
+              # markers, and inventing structure now would only buy a
+              # merge conflict later.
+              print(f'::warning::sync markers missing on {os.environ["SYNC_BRANCH"]}, skipping')
+              raise SystemExit(7)
 
           with open('README.md', 'w') as f:
               f.write(f'{before}{start}\n{line}\n{end}{after}')
           EOF
+          STATUS=$?
+          if [ $STATUS -eq 7 ]; then
+            continue
+          fi
+          if [ $STATUS -ne 0 ]; then
+            exit $STATUS
+          fi
 
             if git diff --quiet; then
               echo "README already fresh on $BRANCH"

--- a/.github/workflows/sync-badge.yml
+++ b/.github/workflows/sync-badge.yml
@@ -53,7 +53,8 @@ jobs:
             git checkout -B "$BRANCH" "origin/$BRANCH"
             export SYNC_BRANCH="$BRANCH"
 
-            python3 - <<'EOF'
+            SYNC_STATUS=0
+            python3 - <<'EOF' || SYNC_STATUS=$?
           import os
 
           synced = os.environ['STATUS_SYNCED'] == 'true'
@@ -85,12 +86,10 @@ jobs:
           with open('README.md', 'w') as f:
               f.write(f'{before}{start}\n{line}\n{end}{after}')
           EOF
-          STATUS=$?
-          if [ $STATUS -eq 7 ]; then
+          if [ "$SYNC_STATUS" -eq 7 ]; then
             continue
-          fi
-          if [ $STATUS -ne 0 ]; then
-            exit $STATUS
+          elif [ "$SYNC_STATUS" -ne 0 ]; then
+            exit "$SYNC_STATUS"
           fi
 
             if git diff --quiet; then

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 | Staging | [![Staging deploy](https://github.com/lambdulus/frontend/actions/workflows/deploy-staging.yml/badge.svg?branch=develop)](https://github.com/lambdulus/frontend/actions/workflows/deploy-staging.yml) | [![Staging site](https://github.com/lambdulus/staging/actions/workflows/deploy.yml/badge.svg)](https://github.com/lambdulus/staging/actions/workflows/deploy.yml) |
 | Production | [![Production deploy](https://github.com/lambdulus/frontend/actions/workflows/deploy.yml/badge.svg?branch=master)](https://github.com/lambdulus/frontend/actions/workflows/deploy.yml) | [![Production site](https://github.com/lambdulus/lambdulus.github.io/actions/workflows/handle-deploy.yml/badge.svg)](https://github.com/lambdulus/lambdulus.github.io/actions/workflows/handle-deploy.yml) |
 
+<!-- production-sync:start -->
+**Production status:** 15 builds behind staging ⚠️ — [compare](https://github.com/lambdulus/frontend/compare/master...develop)
+<!-- production-sync:end -->
+
 The web notebook for playing with lambda calculus (teaching at FIT CTU).
 Vite + React 18 + TypeScript. The compute engine is `@lambdulus/core`,
 consumed straight from its git tag (see `package.json`, no npm registry).
@@ -28,6 +32,10 @@ Requires Node 20+.
 - `master` is production: merging `develop` builds, tests, and dispatches
   to `lambdulus/lambdulus.github.io`, which publishes to
   https://lambdulus.github.io/
+- The "Production status" line under the badge table tells at a glance whether
+  production serves the latest build (develop's tip, i.e. what staging
+  runs). A bot (`sync-badge.yml`, on every push plus hourly) keeps it
+  truthful on both branches; its commits carry `[skip ci]`.
 
 Builds bake in `VITE_VERSION_INFO`/`VITE_COMMIT` stamps (shown in Help and
 the dev console). Assets use relative URLs, so one build serves every

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 | Production | [![Production deploy](https://github.com/lambdulus/frontend/actions/workflows/deploy.yml/badge.svg?branch=master)](https://github.com/lambdulus/frontend/actions/workflows/deploy.yml) | [![Production site](https://github.com/lambdulus/lambdulus.github.io/actions/workflows/handle-deploy.yml/badge.svg)](https://github.com/lambdulus/lambdulus.github.io/actions/workflows/handle-deploy.yml) |
 
 <!-- production-sync:start -->
-**Production status:** 18 builds behind staging ⚠️ — [compare](https://github.com/lambdulus/frontend/compare/master...develop)
+**Production status:** 20 builds behind staging ⚠️ — [compare](https://github.com/lambdulus/frontend/compare/master...develop)
 <!-- production-sync:end -->
 
 The web notebook for playing with lambda calculus (teaching at FIT CTU).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 | Production | [![Production deploy](https://github.com/lambdulus/frontend/actions/workflows/deploy.yml/badge.svg?branch=master)](https://github.com/lambdulus/frontend/actions/workflows/deploy.yml) | [![Production site](https://github.com/lambdulus/lambdulus.github.io/actions/workflows/handle-deploy.yml/badge.svg)](https://github.com/lambdulus/lambdulus.github.io/actions/workflows/handle-deploy.yml) |
 
 <!-- production-sync:start -->
-**Production status:** 16 builds behind staging ⚠️ — [compare](https://github.com/lambdulus/frontend/compare/master...develop)
+**Production status:** 18 builds behind staging ⚠️ — [compare](https://github.com/lambdulus/frontend/compare/master...develop)
 <!-- production-sync:end -->
 
 The web notebook for playing with lambda calculus (teaching at FIT CTU).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 | Production | [![Production deploy](https://github.com/lambdulus/frontend/actions/workflows/deploy.yml/badge.svg?branch=master)](https://github.com/lambdulus/frontend/actions/workflows/deploy.yml) | [![Production site](https://github.com/lambdulus/lambdulus.github.io/actions/workflows/handle-deploy.yml/badge.svg)](https://github.com/lambdulus/lambdulus.github.io/actions/workflows/handle-deploy.yml) |
 
 <!-- production-sync:start -->
-**Production status:** 15 builds behind staging ⚠️ — [compare](https://github.com/lambdulus/frontend/compare/master...develop)
+**Production status:** 16 builds behind staging ⚠️ — [compare](https://github.com/lambdulus/frontend/compare/master...develop)
 <!-- production-sync:end -->
 
 The web notebook for playing with lambda calculus (teaching at FIT CTU).

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Lambdulus Frontend
 
-[![Staging deploy](https://github.com/lambdulus/frontend/actions/workflows/deploy-staging.yml/badge.svg?branch=develop)](https://github.com/lambdulus/frontend/actions/workflows/deploy-staging.yml)
-[![Production deploy](https://github.com/lambdulus/frontend/actions/workflows/deploy.yml/badge.svg?branch=master)](https://github.com/lambdulus/frontend/actions/workflows/deploy.yml)
-[![Staging site](https://github.com/lambdulus/staging/actions/workflows/deploy.yml/badge.svg)](https://github.com/lambdulus/staging/actions/workflows/deploy.yml)
-[![Production site](https://github.com/lambdulus/lambdulus.github.io/actions/workflows/handle-deploy.yml/badge.svg)](https://github.com/lambdulus/lambdulus.github.io/actions/workflows/handle-deploy.yml)
+| Environment | Pipeline (build, test, dispatch) | Site (received and deployed) |
+| ----------- | -------------------------------- | ---------------------------- |
+| Staging | [![Staging deploy](https://github.com/lambdulus/frontend/actions/workflows/deploy-staging.yml/badge.svg?branch=develop)](https://github.com/lambdulus/frontend/actions/workflows/deploy-staging.yml) | [![Staging site](https://github.com/lambdulus/staging/actions/workflows/deploy.yml/badge.svg)](https://github.com/lambdulus/staging/actions/workflows/deploy.yml) |
+| Production | [![Production deploy](https://github.com/lambdulus/frontend/actions/workflows/deploy.yml/badge.svg?branch=master)](https://github.com/lambdulus/frontend/actions/workflows/deploy.yml) | [![Production site](https://github.com/lambdulus/lambdulus.github.io/actions/workflows/handle-deploy.yml/badge.svg)](https://github.com/lambdulus/lambdulus.github.io/actions/workflows/handle-deploy.yml) |
 
 The web notebook for playing with lambda calculus (teaching at FIT CTU).
 Vite + React 18 + TypeScript. The compute engine is `@lambdulus/core`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "ISC",
       "dependencies": {
-        "@lambdulus/core": "git+https://github.com/lambdulus/core.git#v0.0.10",
+        "@lambdulus/core": "git+https://github.com/lambdulus/core.git#v0.0.11",
         "@monaco-editor/react": "^4.7.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^14.0.0",
@@ -900,8 +900,8 @@
       }
     },
     "node_modules/@lambdulus/core": {
-      "version": "0.0.10",
-      "resolved": "git+ssh://git@github.com/lambdulus/core.git#d4a2d617c1fd650bde26eeed15996c5d19d97cee",
+      "version": "0.0.11",
+      "resolved": "git+ssh://git@github.com/lambdulus/core.git#988e77e28e352c1a47122ed64796e98ef74f4e06",
       "license": "MIT"
     },
     "node_modules/@monaco-editor/loader": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "ISC",
       "dependencies": {
-        "@lambdulus/core": "git+https://github.com/lambdulus/core.git#v0.0.12",
+        "@lambdulus/core": "git+https://github.com/lambdulus/core.git#v0.0.13",
         "@monaco-editor/react": "^4.7.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^14.0.0",
@@ -900,8 +900,8 @@
       }
     },
     "node_modules/@lambdulus/core": {
-      "version": "0.0.12",
-      "resolved": "git+ssh://git@github.com/lambdulus/core.git#a73cf86cd26d89b0b5889a2b54a53de7ea81be27",
+      "version": "0.0.13",
+      "resolved": "git+ssh://git@github.com/lambdulus/core.git#8e4d1fa066d2dae7d9726cc9fd590871480092f4",
       "license": "MIT"
     },
     "node_modules/@monaco-editor/loader": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "ISC",
       "dependencies": {
-        "@lambdulus/core": "git+https://github.com/lambdulus/core.git#v0.0.11",
+        "@lambdulus/core": "git+https://github.com/lambdulus/core.git#v0.0.12",
         "@monaco-editor/react": "^4.7.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^14.0.0",
@@ -900,8 +900,8 @@
       }
     },
     "node_modules/@lambdulus/core": {
-      "version": "0.0.11",
-      "resolved": "git+ssh://git@github.com/lambdulus/core.git#988e77e28e352c1a47122ed64796e98ef74f4e06",
+      "version": "0.0.12",
+      "resolved": "git+ssh://git@github.com/lambdulus/core.git#a73cf86cd26d89b0b5889a2b54a53de7ea81be27",
       "license": "MIT"
     },
     "node_modules/@monaco-editor/loader": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@lambdulus/core": "git+https://github.com/lambdulus/core.git#v0.0.12",
+    "@lambdulus/core": "git+https://github.com/lambdulus/core.git#v0.0.13",
     "@monaco-editor/react": "^4.7.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^14.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@lambdulus/core": "git+https://github.com/lambdulus/core.git#v0.0.10",
+    "@lambdulus/core": "git+https://github.com/lambdulus/core.git#v0.0.11",
     "@monaco-editor/react": "^4.7.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^14.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@lambdulus/core": "git+https://github.com/lambdulus/core.git#v0.0.11",
+    "@lambdulus/core": "git+https://github.com/lambdulus/core.git#v0.0.12",
     "@monaco-editor/react": "^4.7.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^14.0.0",

--- a/src/App.css
+++ b/src/App.css
@@ -451,3 +451,68 @@ body.zen {
   margin-top: 0.5em;
 }
 
+
+/* Box delete confirmation: fixed overlay, card on a dimmed backdrop. */
+.box-delete-confirm {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.box-delete-confirm-backdrop {
+  position: absolute;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.35);
+}
+
+.box-delete-confirm-card {
+  position: relative;
+  width: 300px;
+  background-color: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: var(--shadow);
+  padding: 16px 18px;
+}
+
+.box-delete-confirm-title {
+  margin: 0 0 10px;
+  font-weight: 600;
+}
+
+.box-delete-confirm-again {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.9em;
+  color: var(--muted);
+  cursor: pointer;
+}
+
+.box-delete-confirm-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 14px;
+}
+
+.box-delete-confirm-cancel {
+  background-color: transparent;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 3px 14px;
+  cursor: pointer;
+}
+
+.box-delete-confirm-delete {
+  background-color: var(--accent);
+  color: var(--accent-ink);
+  border: none;
+  border-radius: 999px;
+  padding: 4px 14px;
+  font-weight: 600;
+  cursor: pointer;
+}

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { test, expect, afterEach } from 'vitest';
+import { test, expect, afterEach, vi } from 'vitest';
 import { render, fireEvent, waitFor, cleanup } from '@testing-library/react';
 import App from './App';
 
@@ -7,6 +7,8 @@ afterEach(() => cleanup());
 import { createDefaultAppState, preferredTheme, saveTourState, loadTourState } from './Constants';
 import { TOUR_STEPS } from './components/Tour';
 import { defaultSettings, createNewUntypedLambdaExpression } from './untyped-lambda-integration/Constants';
+import { UntypedLambdaType } from './untyped-lambda-integration/Types';
+import { buildBoxShareURL } from './components/BoxTitleBar';
 import { Theme } from './contexts/Theme';
 
 test('renders the app shell (top-level smoke test)', () => {
@@ -353,6 +355,97 @@ test('accent hover previews site-wide, click commits, popup stays open', () => {
   expect(shellAccent()).toBe('amber');
   expect(storedAccent()).toBe('amber');
   expect(container.querySelector('.top-bar--accent-pick')).not.toBeNull();
+});
+
+test('creating a notebook parks the page at the top', () => {
+  window.localStorage.clear();
+  const { container } = render(<App />);
+  const originalScrollTo = window.scrollTo;
+  const spy = vi.fn();
+  window.scrollTo = spy;
+  try {
+    spy.mockClear();
+    fireEvent.click(container.querySelector('[title="New notebook"]') as HTMLElement);
+    // The old notebook's scroll would otherwise clamp into the short
+    // new content, hiding the title one line up.
+    expect(spy).toHaveBeenCalledWith({ top : 0, behavior : 'auto' });
+    expect(container.querySelector('.top-bar--tab--active .top-bar--tab-name')?.textContent).toBe('Notebook 2');
+  }
+  finally {
+    window.scrollTo = originalScrollTo;
+  }
+});
+
+test('creating a notebook in zen mode stays in zen mode', () => {
+  window.localStorage.clear();
+  const { container } = render(<App />);
+  fireEvent.click(container.querySelector('.top-bar--zen') as Element);
+  expect(container.querySelector('.mainSpace.zen')).not.toBeNull();
+  fireEvent.click(container.querySelector('[title="New notebook"]') as HTMLElement);
+  expect(container.querySelector('.top-bar--tab--active .top-bar--tab-name')?.textContent).toBe('Notebook 2');
+  expect(container.querySelector('.mainSpace.zen')).not.toBeNull();
+});
+
+test('creating a notebook outside zen mode stays outside it', () => {
+  window.localStorage.clear();
+  const { container } = render(<App />);
+  expect(container.querySelector('.mainSpace.zen')).toBeNull();
+  fireEvent.click(container.querySelector('[title="New notebook"]') as HTMLElement);
+  expect(container.querySelector('.top-bar--tab--active .top-bar--tab-name')?.textContent).toBe('Notebook 2');
+  expect(container.querySelector('.mainSpace.zen')).toBeNull();
+});
+
+test('share links carry every local setting', () => {
+  const fresh = createNewUntypedLambdaExpression(defaultSettings);
+  const url = buildBoxShareURL({
+    ...fresh,
+    subtype : UntypedLambdaType.ORDINARY,
+    editor : { ...fresh.editor, content : 'x' },
+    ETA : true,
+  });
+  for (const param of [ 'SDE=true', 'SLI=true', 'ETA=true', 'expandStandalones=false', 'collapseOldSteps=true' ]) {
+    expect(url, param).toContain(param);
+  }
+});
+
+function sharedBoxSettings () : any {
+  const stored = JSON.parse(window.localStorage.getItem('AppState') ?? '{}');
+  return stored.notebooks.find((nb : any) => nb.name === 'Shared').boxList[0];
+}
+
+test('years-old links without the new params fall back to defaults', () => {
+  window.localStorage.clear();
+  window.history.replaceState(null, '', '/?type=UNTYPED_LAMBDA&source=x&macros={}&subtype=ORDINARY&strategy=Normal%20Evaluation&SDE=false&SLI=false');
+  try {
+    render(<App />);
+    const box = sharedBoxSettings();
+    // Old params still parse.
+    expect(box.SDE).toBe(false);
+    expect(box.SLI).toBe(false);
+    expect(box.strategy).toBe('Normal Evaluation');
+    // New params absent: defaults, not failure.
+    expect(box.ETA).toBe(false);
+    expect(box.expandStandalones).toBe(false);
+    expect(box.collapseOldSteps).toBe(true);
+  }
+  finally {
+    window.history.replaceState(null, '', '/');
+  }
+});
+
+test('new links express every local setting', () => {
+  window.localStorage.clear();
+  window.history.replaceState(null, '', '/?type=UNTYPED_LAMBDA&source=x&macros={}&subtype=ORDINARY&strategy=Normal%20Evaluation&SDE=false&SLI=false&ETA=true&expandStandalones=true&collapseOldSteps=false');
+  try {
+    render(<App />);
+    const box = sharedBoxSettings();
+    expect(box.ETA).toBe(true);
+    expect(box.expandStandalones).toBe(true);
+    expect(box.collapseOldSteps).toBe(false);
+  }
+  finally {
+    window.history.replaceState(null, '', '/');
+  }
 });
 
 test('box style hover previews shell-wide, click commits, popup stays open', () => {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -278,6 +278,9 @@ test('deleting the markdown box on the delete step loops back at once', async ()
   expect(frame).not.toBeNull();
   fireEvent.click(frame.querySelector('[title="Delete this Box from the Notebook"]') as HTMLElement);
 
+  // Trash asks first; confirming deletes and the watcher loops back.
+  fireEvent.click(container.querySelector('.box-delete-confirm-delete') as HTMLElement);
+
   await waitFor(() => expect(container.querySelector('.tour--title')?.textContent).toBe('Add a box'));
   expect(container.querySelectorAll('.box-frame').length).toBe(0);
 });
@@ -295,6 +298,7 @@ test('deleting early on the explainer loops back through next', async () => {
 
   const frame = container.querySelector('.box-frame:has(.markDownBox)') as HTMLElement;
   fireEvent.click(frame.querySelector('[title="Delete this Box from the Notebook"]') as HTMLElement);
+  fireEvent.click(container.querySelector('.box-delete-confirm-delete') as HTMLElement);
   fireEvent.click(nextBtn());
 
   await waitFor(() => expect(title()).toBe('Add a box'));

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -244,16 +244,29 @@ export default class App extends Component<{}, AppState> {
         const strategy : string | null = urlSearchParams.get('strategy')
         const SDE : string | null = urlSearchParams.get('SDE')
         const SLI : string | null = urlSearchParams.get('SLI')
-        
         if (source === null || macros == null || subtype === null || strategy === null || SDE === null || SLI === null) {
           return false
         }
+
+        // Newer settings params are optional: years-old links predate
+        // them and fall back to the defaults instead of failing.
+        const ETA : string | null = urlSearchParams.get('ETA')
+        const expandStandalones : string | null = urlSearchParams.get('expandStandalones')
+        const collapseOldSteps : string | null = urlSearchParams.get('collapseOldSteps')
 
         const strat : EvaluationStrategy = EvaluationStrategy.NORMAL === strategy ? EvaluationStrategy.NORMAL : EvaluationStrategy.APPLICATIVE
 
         const sli : boolean = SLI === 'true' ? true : false
 
-        const settings : UntypedLambdaSettings = { ...defaultSettings, strategy : strat, SDE : SDE === 'true' ? true : false, SLI : sli }
+        const settings : UntypedLambdaSettings = {
+          ...defaultSettings,
+          strategy : strat,
+          SDE : SDE === 'true' ? true : false,
+          SLI : sli,
+          ETA : ETA === null ? defaultSettings.ETA : ETA === 'true',
+          expandStandalones : expandStandalones === null ? defaultSettings.expandStandalones : expandStandalones === 'true',
+          collapseOldSteps : collapseOldSteps === null ? defaultSettings.collapseOldSteps : collapseOldSteps === 'true',
+        }
 
         const sub : UntypedLambdaType = subtype === UntypedLambdaType.EMPTY ?
             UntypedLambdaType.EMPTY
@@ -294,7 +307,6 @@ export default class App extends Component<{}, AppState> {
         }
       }
       break
-        
       default:
         break;
     }
@@ -482,7 +494,7 @@ export default class App extends Component<{}, AppState> {
   }
 
   addNotebook () : void {
-    const { notebooks } = this.state
+    const { notebooks, activeNotebookIndex } = this.state
     const names = notebooks.map((notebook : NotebookState) => notebook.name)
 
     let name : string = 'Notebook'
@@ -492,12 +504,25 @@ export default class App extends Component<{}, AppState> {
       counter++
     }
 
-    const newNotebooks = [ ...notebooks, createEmptyNotebook(name) ]
+    // Zen is uninterrupted focus: a new notebook opened from inside it
+    // stays in it instead of dropping the user out without warning.
+    const fresh : NotebookState = createEmptyNotebook(name)
+    if (notebooks[activeNotebookIndex]?.zenMode === true) {
+      fresh.zenMode = true
+    }
+
+    const newNotebooks = [ ...notebooks, fresh ]
 
     this.setState({
       notebooks : newNotebooks,
       activeNotebookIndex : newNotebooks.length - 1,
     })
+
+    // A fresh notebook is a new document: park the page at the top.
+    // Without this the previous notebook's scroll position carries
+    // over and clamps into the short new content, hiding the title
+    // one line up. Instant: there is no travel to glide through.
+    window.scrollTo({ top : 0, behavior : 'auto' })
 
     updateAppStateToStorage({
       ...this.state,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,6 +43,7 @@ export default class App extends Component<{}, AppState> {
     this.previewAccent = this.previewAccent.bind(this)
     this.previewBoxStyle = this.previewBoxStyle.bind(this)
     this.updateBoxStyle = this.updateBoxStyle.bind(this)
+    this.updateConfirmBoxDelete = this.updateConfirmBoxDelete.bind(this)
     this.toggleTheme = this.toggleTheme.bind(this)
     this.selectNotebook = this.selectNotebook.bind(this)
     this.addNotebook = this.addNotebook.bind(this)
@@ -319,7 +320,7 @@ export default class App extends Component<{}, AppState> {
 
   // NOTE: render is OK
   render () {
-    const { notebooks, activeNotebookIndex, theme, accent, boxStyle } = this.state
+    const { notebooks, activeNotebookIndex, theme, accent, boxStyle, confirmBoxDelete } = this.state
     const notebook : NotebookState = notebooks[activeNotebookIndex]
     const { settings } = notebook
 
@@ -339,6 +340,8 @@ export default class App extends Component<{}, AppState> {
               theme={ theme }
               accent={ accent }
               boxStyle={ boxStyle }
+              confirmBoxDelete={ confirmBoxDelete ?? true }
+              onConfirmBoxDeleteChange={ this.updateConfirmBoxDelete }
               settings={ settings }
               onAccentChange={ this.updateAccent }
               onAccentPreview={ this.previewAccent }
@@ -356,7 +359,12 @@ export default class App extends Component<{}, AppState> {
               onTourOpen={ this.openTour }
             />
 
-            <Notebook state={ notebook } updateNotebook={ this.updateNotebook } />
+            <Notebook
+              state={ notebook }
+              updateNotebook={ this.updateNotebook }
+              confirmBoxDelete={ confirmBoxDelete ?? true }
+              onConfirmBoxDeleteChange={ this.updateConfirmBoxDelete }
+            />
 
             {
               this.tourOpen ?
@@ -545,6 +553,11 @@ export default class App extends Component<{}, AppState> {
     this.boxStylePreview = null
     this.setState({ boxStyle })
     updateAppStateToStorage({ ...this.state, boxStyle })
+  }
+
+  updateConfirmBoxDelete (confirmBoxDelete : boolean) : void {
+    this.setState({ confirmBoxDelete })
+    updateAppStateToStorage({ ...this.state, confirmBoxDelete })
   }
 
 }

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -106,6 +106,7 @@ export function createDefaultAppState () : AppState {
     theme : preferredTheme(),
     accent : 'emerald',
     boxStyle : 'cards',
+    confirmBoxDelete : true,
   }
 }
 
@@ -204,6 +205,7 @@ export function decode (state : AppState) : AppState | never {
       theme : state.theme ?? Theme.Dark,
       accent : 'emerald',
       boxStyle : 'cards',
+      confirmBoxDelete : true,
     }
   }
 
@@ -236,6 +238,8 @@ export function decode (state : AppState) : AppState | never {
     activeNotebookIndex,
     accent,
     boxStyle,
+    // Asking defaults to on: only an explicit false opts out.
+    confirmBoxDelete : legacy.confirmBoxDelete !== false,
   }
 }
 

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -251,7 +251,6 @@ export function decodeNotebook (notebook : NotebookState) : NotebookState | neve
       }
 
       //TODO: implement for other Box Types
-    
       default:
         return box
     }

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -64,5 +64,6 @@ export interface AppState {
   activeNotebookIndex : number,
   theme : Theme,
   accent : Accent,
-  boxStyle : BoxStyle
+  boxStyle : BoxStyle,
+  confirmBoxDelete : boolean
 }

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -11,7 +11,7 @@ export enum BoxType {
 export interface AbstractBoxState {
   type : BoxType,
   __key : string,
-  title : String,
+  title : string,
   minimized : boolean,
   settingsOpen : boolean,
   readOnly ?: boolean

--- a/src/components/BoxContainer.test.tsx
+++ b/src/components/BoxContainer.test.tsx
@@ -53,14 +53,14 @@ test('bare top-bar click seats and focuses the box', () => {
   }
 });
 
-function rect (top : number) : DOMRect {
+function rect (top : number, height : number = 0) : DOMRect {
   return {
     top,
     left : 0,
-    bottom : top,
+    bottom : top + height,
     right : 0,
     width : 0,
-    height : 0,
+    height,
     x : 0,
     y : 0,
     toJSON : () => ({}),
@@ -79,18 +79,48 @@ test('resize pinning glues the box across plain resizes but steps aside across z
   const { container, rerender, unmount } = render(<BoxContainer { ...props(false) } />);
   try {
     const root = container.firstElementChild as HTMLElement;
-    let tops = [ 100, 140 ];
-    root.getBoundingClientRect = () => rect(tops.length > 0 ? (tops.shift() as number) : 140);
+    let frames : Array<[number, number]> = [ [ 100, 200 ], [ 140, 260 ] ];
+    root.getBoundingClientRect = () => {
+      const [ top, height ] = frames.length > 0 ? (frames.shift() as [number, number]) : [ 140, 260 ];
+      return rect(top, height);
+    };
 
-    // Plain resize with the same props: the 40px drift scrolls along.
+    // Plain resize with the same props: the box grew and drifted 40px,
+    // so the page scrolls along to keep it glued.
     rerender(<BoxContainer { ...props(false) } />);
     expect(scrollBy).toHaveBeenCalledTimes(1);
     expect(scrollBy).toHaveBeenCalledWith({ top : 40, behavior : 'auto' });
 
     // Zen flip with the same drift: no pinning, the flip owns scroll.
-    tops = [ 100, 140 ];
+    frames = [ [ 100, 200 ], [ 140, 260 ] ];
     rerender(<BoxContainer { ...props(true) } />);
     expect(scrollBy).toHaveBeenCalledTimes(1);
+  }
+  finally {
+    unmount();
+    window.scrollBy = originalScrollBy;
+  }
+});
+
+test('sibling displacement without self-resize pins nothing', () => {
+  // A sibling's new step line pushes this box down without resizing
+  // it: pinning here scrolled once per box below the change, fighting
+  // the browser's scroll anchoring as a per-step jitter. The native
+  // compensation owns this case, so the pin must stay quiet.
+  const originalScrollBy = window.scrollBy;
+  const scrollBy = vi.fn();
+  window.scrollBy = scrollBy;
+  const { container, rerender, unmount } = render(<BoxContainer { ...props(false) } />);
+  try {
+    const root = container.firstElementChild as HTMLElement;
+    let frames : Array<[number, number]> = [ [ 100, 200 ], [ 140, 200 ] ];
+    root.getBoundingClientRect = () => {
+      const [ top, height ] = frames.length > 0 ? (frames.shift() as [number, number]) : [ 140, 200 ];
+      return rect(top, height);
+    };
+
+    rerender(<BoxContainer { ...props(false) } />);
+    expect(scrollBy).not.toHaveBeenCalled();
   }
   finally {
     unmount();

--- a/src/components/BoxContainer.tsx
+++ b/src/components/BoxContainer.tsx
@@ -109,11 +109,8 @@ export class BoxContainer extends Component<Props, State> {
       addBoxAfter,
       removeBox,
     } : Props = this.props
-  
     const { modalOpen } = this.state
-  
     const boxTypeClassName : string = mapBoxTypeToStr(box.type)
-  
     return (
       <div ref={ this.rootRef }>
         <div

--- a/src/components/BoxContainer.tsx
+++ b/src/components/BoxContainer.tsx
@@ -44,7 +44,7 @@ export class BoxContainer extends Component<Props, State> {
     }
   }
 
-  getSnapshotBeforeUpdate (prevProps : Props) : number | null {
+  getSnapshotBeforeUpdate (prevProps : Props) : { top : number, height : number } | null {
     // Focus transitions own the page scroll (Notebook seats the newly
     // focused box), so only glue the viewport across plain resizes.
     if (prevProps.isFocusedBox !== this.props.isFocusedBox) {
@@ -60,23 +60,34 @@ export class BoxContainer extends Component<Props, State> {
     }
 
     const el : HTMLDivElement | null = this.rootRef.current
-    return el === null ? null : el.getBoundingClientRect().top
+    if (el === null) {
+      return null
+    }
+    const rect : DOMRect = el.getBoundingClientRect()
+    return { top : rect.top, height : rect.height }
   }
 
-  componentDidUpdate (_prevProps : Props, prevState : State, snapshot : number | null) : void {
+  componentDidUpdate (_prevProps : Props, prevState : State, snapshot : { top : number, height : number } | null) : void {
     // The add-box dialog opens below the button; nudge the page just
     // enough to bring the whole dialog into view.
     if ( ! prevState.modalOpen && this.state.modalOpen && this.modalRef.current !== null) {
       this.modalRef.current.scrollIntoView?.({ block : 'nearest', behavior : 'smooth' })
     }
 
-    // Pin the box where it was on screen: when this box resizes itself
-    // (a settings toggle collapsing the history!), the page would
-    // otherwise jump as clamping and anchoring kick in.
+    // Pin the box where it was on screen, but only across its own
+    // resize (a settings toggle collapsing the history!). Displacement
+    // by content above -- a sibling's new step line pushing this box
+    // down -- belongs to the browser's scroll anchoring: pinning here
+    // would scroll once per box below the change, fighting the native
+    // compensation as a per-step jitter.
     if (snapshot !== null) {
       const el : HTMLDivElement | null = this.rootRef.current
       if (el !== null) {
-        const drift : number = el.getBoundingClientRect().top - snapshot
+        const rect : DOMRect = el.getBoundingClientRect()
+        if (Math.abs(rect.height - snapshot.height) < 0.5) {
+          return
+        }
+        const drift : number = rect.top - snapshot.top
         if (Math.abs(drift) > 0.5) {
           window.scrollBy({ top : drift, behavior : 'auto' })
         }

--- a/src/components/BoxTitleBar.tsx
+++ b/src/components/BoxTitleBar.tsx
@@ -9,8 +9,42 @@ import { NoteState } from '../markdown-integration/AppTypes'
 import EmptyBTB from '../empty-integration/BoxTopBar'
 
 import '../styles/BoxTopBar.css'
-import { resetUntypedLambdaBox, SETTINGS_OPENED_EVENT } from '../untyped-lambda-integration/Constants'
+import { defaultSettings, resetUntypedLambdaBox, SETTINGS_OPENED_EVENT } from '../untyped-lambda-integration/Constants'
 
+
+// Shareable links carry the box's local settings as query params, named
+// exactly like the settings fields. New params stay optional for the
+// parser: years-old links without them fall back to the defaults, so
+// course material keeps working. Zen mode is deliberately not shared:
+// it is a personal preference, not part of the box.
+export function buildBoxShareURL (state : BoxState) : string {
+  const searchParams : URLSearchParams = new URL(window.document.location.toString()).searchParams
+
+  searchParams.set('type', state.type)
+
+  if (state.type === BoxType.UNTYPED_LAMBDA) {
+    const box : UntypedLambdaState = state as UntypedLambdaState
+    const macros = encodeURI(JSON.stringify(box.macrotable))
+    searchParams.set('source', encodeURI(box.ast?.toString() || box.editor.content))
+    searchParams.set('macros', macros)
+  }
+  else {
+    searchParams.set('source', encodeURI((state as any).editor.content)) // todo: fix that `as any`
+  }
+
+  if (state.type === BoxType.UNTYPED_LAMBDA) {
+    const box : UntypedLambdaState = state as UntypedLambdaState
+    searchParams.set('subtype', box.subtype)
+    searchParams.set('strategy', box.strategy)
+    searchParams.set('SDE', box.SDE.toString())
+    searchParams.set('SLI', box.SLI.toString())
+    searchParams.set('ETA', (box.ETA ?? defaultSettings.ETA).toString())
+    searchParams.set('expandStandalones', (box.expandStandalones ?? defaultSettings.expandStandalones).toString())
+    searchParams.set('collapseOldSteps', (box.collapseOldSteps ?? defaultSettings.collapseOldSteps).toString())
+  }
+
+  return window.location.host + '?' + searchParams.toString()
+}
 
 type BoxPlace = 'before' | 'after'
 
@@ -146,7 +180,6 @@ export default class BoxTitleBar extends Component<Props, State> {
                 <Trash2 size={ 15 } strokeWidth={ 1.75 } />
               </div>
           }
-          
           {
             type !== BoxType.MARKDOWN ?
             <div
@@ -199,29 +232,8 @@ export default class BoxTitleBar extends Component<Props, State> {
             onClick={ (e) => {
               e.stopPropagation()
               this.setState({ shareLinkOpen : true })
-              const searchParams : URLSearchParams = new URL(window.document.location.toString()).searchParams
 
-              searchParams.set('type', state.type)
-
-              if (state.type === BoxType.UNTYPED_LAMBDA) {
-                const macros = encodeURI(JSON.stringify((state as UntypedLambdaState).macrotable))
-                searchParams.set('source', encodeURI((state as UntypedLambdaState).ast?.toString() || (state as UntypedLambdaState).editor.content))
-                searchParams.set('macros', macros)
-              }
-              else {
-                searchParams.set('source', encodeURI((state as any).editor.content)) // todo: fix that `as any`
-              }
-
-              if (state.type === BoxType.UNTYPED_LAMBDA) {
-                searchParams.set('subtype', (state as UntypedLambdaState).subtype)
-                searchParams.set('strategy', (state as UntypedLambdaState).strategy)
-                searchParams.set('SDE', (state as UntypedLambdaState).SDE.toString())
-                searchParams.set('SLI', (state as UntypedLambdaState).SLI.toString())
-              }
-
-              const url : string = window.location.host + '?' + searchParams.toString()
-
-              navigator.clipboard.writeText(url)
+              navigator.clipboard.writeText(buildBoxShareURL(state))
 
               setTimeout(() => this.setState({ shareLinkOpen : false, menuOpen : false }), 1500)
 

--- a/src/components/CreateBox.tsx
+++ b/src/components/CreateBox.tsx
@@ -28,7 +28,6 @@ export default class CreateBox extends Component <Props, State> {
   render () : JSX.Element {
     const { addNew } : Props = this.props
     const { modalOpen } = this.state
-   
     if (this.state.modalOpen === false) {
       return (
         <div className='create-box-plus' onClick={ () => this.setState({ modalOpen : ! modalOpen }) } >
@@ -49,4 +48,3 @@ export default class CreateBox extends Component <Props, State> {
     }
   }
 }
-  

--- a/src/components/DebugControls.tsx
+++ b/src/components/DebugControls.tsx
@@ -55,7 +55,6 @@ export default class DebugControls extends PureComponent<Props> {
 
   render () {
     const { isRunning, onStep, onRun } : Props = this.props
-  
     const runMessage : string =
       isRunning ? 'Stop the Evaluation (Press F9)' :  'Evaluate the Expression (Press F9)'
 
@@ -76,8 +75,6 @@ export default class DebugControls extends PureComponent<Props> {
             { isRunning ? <Square size={ 13 } strokeWidth={ 1.75 } /> : <Play size={ 13 } strokeWidth={ 1.75 } /> }
           </button>
         }
-        
-        
         <button
           title='Evaluate Next Step (Press F8)'
           type="button"

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -37,7 +37,6 @@ interface EditorProperties {
   syntaxError : Error | null
   submitOnEnter : boolean
   shouldReplaceLambda : boolean
-  
   onContent (content : string) : void
   onShiftEnter () : void
   onCtrlEnter () : void
@@ -66,7 +65,6 @@ export default function Editor (props : EditorProperties) : JSX.Element {
   // TODO: Editor should not decide that - it should only implement onEnter onShiftEnter onCtrlEnter
   const onKeyDown = (event : KeyboardEvent<HTMLDivElement>) => {
     if ( ! event.shiftKey && ! event.ctrlKey && event.key === 'Enter') {
-      
       if (submitOnEnter) {
         event.stopPropagation()
         event.preventDefault()

--- a/src/components/PickBoxTypeModal.tsx
+++ b/src/components/PickBoxTypeModal.tsx
@@ -18,13 +18,11 @@ interface Props {
 export default function PickBoxTypeModal (props : Props) : JSX.Element {
   const { addNew } : Props = props
 
-  
   const addLambdaBox = (
     <SettingsContext.Consumer>
       {
         settings => {
           const untLSettings : UntypedLambdaSettings = settings[UNTYPED_CODE_NAME] as UntypedLambdaState
-          
           return  <div className='add-box--group'
                     onClick={ (e) => {
                       e.stopPropagation()

--- a/src/components/TopBar.test.tsx
+++ b/src/components/TopBar.test.tsx
@@ -299,7 +299,9 @@ test('deletion toggle reflects the setting and reports unchecking', () => {
   const toggle = container.querySelector('#top-bar--confirm-delete') as HTMLElement;
   expect(toggle.getAttribute('aria-pressed')).toBe('true');
   expect(toggle.className).toMatch(/untyped-lambda-settings--toggle-on/);
-  expect(container.querySelector('.top-bar--delete-confirm label')?.textContent).toBe('Confirm before deleting a box');
+  const rowLabel = container.querySelector('.top-bar--delete-confirm label');
+  expect(rowLabel?.textContent).toBe('Confirm before deleting a box');
+  expect(rowLabel?.className).toMatch(/untyped-lambda-settings-label/);
 
   fireEvent.click(toggle);
   expect(onConfirmBoxDeleteChange).toHaveBeenCalledWith(false);

--- a/src/components/TopBar.test.tsx
+++ b/src/components/TopBar.test.tsx
@@ -295,10 +295,10 @@ test('deletion toggle reflects the setting and reports unchecking', () => {
     <TopBar { ...baseProps(() => void 0) } confirmBoxDelete={ true } onConfirmBoxDeleteChange={ onConfirmBoxDeleteChange } />
   );
 
-  fireEvent.click(container.querySelector('[title="Accent theme"]') as HTMLElement);
+  fireEvent.click(container.querySelector('[title="Notebook settings"]') as HTMLElement);
   const checkbox = container.querySelector('#top-bar--confirm-delete') as HTMLInputElement;
   expect(checkbox.checked).toBe(true);
-  expect(container.querySelector('.top-bar--delete-confirm label')?.textContent).toBe('Ask before deleting a box');
+  expect(container.querySelector('.top-bar--delete-confirm label')?.textContent).toBe('Confirm before deleting a box');
 
   fireEvent.click(checkbox);
   expect(onConfirmBoxDeleteChange).toHaveBeenCalledWith(false);
@@ -309,6 +309,6 @@ test('deletion toggle renders unchecked when asking is off', () => {
     <TopBar { ...baseProps(() => void 0) } confirmBoxDelete={ false } onConfirmBoxDeleteChange={ () => void 0 } />
   );
 
-  fireEvent.click(container.querySelector('[title="Accent theme"]') as HTMLElement);
+  fireEvent.click(container.querySelector('[title="Notebook settings"]') as HTMLElement);
   expect((container.querySelector('#top-bar--confirm-delete') as HTMLInputElement).checked).toBe(false);
 });

--- a/src/components/TopBar.test.tsx
+++ b/src/components/TopBar.test.tsx
@@ -28,11 +28,13 @@ function baseProps (onZenModeChange : (zenMode : boolean) => void) {
     theme : Theme.Dark,
     accent : 'emerald' as const,
     boxStyle : 'cards' as const,
+    confirmBoxDelete : true,
     settings : {},
     onAccentChange : () => void 0,
     onAccentPreview : () => void 0,
     onBoxStyleChange : () => void 0,
     onBoxStylePreview : () => void 0,
+    onConfirmBoxDeleteChange : () => void 0,
     onNotebookSelect : () => void 0,
     onNotebookAdd : () => void 0,
     onNotebookRemove : () => void 0,
@@ -285,4 +287,28 @@ test('box style section stands off from the accent section', () => {
   // The checked tile rings in accent.
   const picked = css.match(/\.top-bar--boxpreview-option input\[type='radio'\]:checked \+ \.top-bar--boxpreview-tile\s*\{[^}]*\}/)?.[0] ?? '';
   expect(picked).toMatch(/border-color\s*:\s*var\(--accent\)/);
+});
+
+test('deletion toggle reflects the setting and reports unchecking', () => {
+  const onConfirmBoxDeleteChange = vi.fn();
+  const { container } = render(
+    <TopBar { ...baseProps(() => void 0) } confirmBoxDelete={ true } onConfirmBoxDeleteChange={ onConfirmBoxDeleteChange } />
+  );
+
+  fireEvent.click(container.querySelector('[title="Accent theme"]') as HTMLElement);
+  const checkbox = container.querySelector('#top-bar--confirm-delete') as HTMLInputElement;
+  expect(checkbox.checked).toBe(true);
+  expect(container.querySelector('.top-bar--delete-confirm label')?.textContent).toBe('Ask before deleting a box');
+
+  fireEvent.click(checkbox);
+  expect(onConfirmBoxDeleteChange).toHaveBeenCalledWith(false);
+});
+
+test('deletion toggle renders unchecked when asking is off', () => {
+  const { container } = render(
+    <TopBar { ...baseProps(() => void 0) } confirmBoxDelete={ false } onConfirmBoxDeleteChange={ () => void 0 } />
+  );
+
+  fireEvent.click(container.querySelector('[title="Accent theme"]') as HTMLElement);
+  expect((container.querySelector('#top-bar--confirm-delete') as HTMLInputElement).checked).toBe(false);
 });

--- a/src/components/TopBar.test.tsx
+++ b/src/components/TopBar.test.tsx
@@ -296,19 +296,22 @@ test('deletion toggle reflects the setting and reports unchecking', () => {
   );
 
   fireEvent.click(container.querySelector('[title="Notebook settings"]') as HTMLElement);
-  const checkbox = container.querySelector('#top-bar--confirm-delete') as HTMLInputElement;
-  expect(checkbox.checked).toBe(true);
+  const toggle = container.querySelector('#top-bar--confirm-delete') as HTMLElement;
+  expect(toggle.getAttribute('aria-pressed')).toBe('true');
+  expect(toggle.className).toMatch(/untyped-lambda-settings--toggle-on/);
   expect(container.querySelector('.top-bar--delete-confirm label')?.textContent).toBe('Confirm before deleting a box');
 
-  fireEvent.click(checkbox);
+  fireEvent.click(toggle);
   expect(onConfirmBoxDeleteChange).toHaveBeenCalledWith(false);
 });
 
-test('deletion toggle renders unchecked when asking is off', () => {
+test('deletion toggle renders off when asking is off', () => {
   const { container } = render(
     <TopBar { ...baseProps(() => void 0) } confirmBoxDelete={ false } onConfirmBoxDeleteChange={ () => void 0 } />
   );
 
   fireEvent.click(container.querySelector('[title="Notebook settings"]') as HTMLElement);
-  expect((container.querySelector('#top-bar--confirm-delete') as HTMLInputElement).checked).toBe(false);
+  const toggle = container.querySelector('#top-bar--confirm-delete') as HTMLElement;
+  expect(toggle.getAttribute('aria-pressed')).toBe('false');
+  expect(toggle.className).toMatch(/untyped-lambda-settings--toggle-off/);
 });

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -267,7 +267,7 @@ export default function TopBar (props : Props) : JSX.Element {
                   >
                     <span className='untyped-lambda-settings--toggle-thumb' />
                   </button>
-                  <label htmlFor='top-bar--confirm-delete'>
+                  <label className='untyped-lambda-settings-label' htmlFor='top-bar--confirm-delete'>
                     Confirm before deleting a box
                   </label>
                 </span>

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -259,12 +259,14 @@ export default function TopBar (props : Props) : JSX.Element {
                 />
                 <p className='top-bar--settings-title'>Deletion</p>
                 <span className='top-bar--delete-confirm'>
-                  <input
+                  <button
                     id='top-bar--confirm-delete'
-                    type='checkbox'
-                    checked={ confirmBoxDelete }
-                    onChange={ (e) => onConfirmBoxDeleteChange(e.target.checked) }
-                  />
+                    className={ `untyped-lambda-settings--toggle ${confirmBoxDelete ? 'untyped-lambda-settings--toggle-on' : 'untyped-lambda-settings--toggle-off'}` }
+                    aria-pressed={ confirmBoxDelete }
+                    onClick={ () => onConfirmBoxDeleteChange(! confirmBoxDelete) }
+                  >
+                    <span className='untyped-lambda-settings--toggle-thumb' />
+                  </button>
                   <label htmlFor='top-bar--confirm-delete'>
                     Confirm before deleting a box
                   </label>

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -257,6 +257,18 @@ export default function TopBar (props : Props) : JSX.Element {
                     }
                   }
                 />
+                <p className='top-bar--settings-title'>Deletion</p>
+                <span className='top-bar--delete-confirm'>
+                  <input
+                    id='top-bar--confirm-delete'
+                    type='checkbox'
+                    checked={ confirmBoxDelete }
+                    onChange={ (e) => onConfirmBoxDeleteChange(e.target.checked) }
+                  />
+                  <label htmlFor='top-bar--confirm-delete'>
+                    Confirm before deleting a box
+                  </label>
+                </span>
               </div>
             </React.Fragment>
           :
@@ -358,18 +370,6 @@ export default function TopBar (props : Props) : JSX.Element {
                     )
                   }
                 </div>
-                <p className='top-bar--settings-title'>Deletion</p>
-                <span className='top-bar--delete-confirm'>
-                  <input
-                    id='top-bar--confirm-delete'
-                    type='checkbox'
-                    checked={ confirmBoxDelete }
-                    onChange={ (e) => onConfirmBoxDeleteChange(e.target.checked) }
-                  />
-                  <label htmlFor='top-bar--confirm-delete'>
-                    Ask before deleting a box
-                  </label>
-                </span>
               </div>
             </React.Fragment>
           :

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -21,11 +21,13 @@ interface Props {
   theme : Theme
   accent : Accent
   boxStyle : BoxStyle
+  confirmBoxDelete : boolean
   settings : GlobalSettings
   onAccentChange (accent : Accent) : void
   onAccentPreview (accent : Accent | null) : void
   onBoxStyleChange (boxStyle : BoxStyle) : void
   onBoxStylePreview (boxStyle : BoxStyle | null) : void
+  onConfirmBoxDeleteChange (confirm : boolean) : void
   onNotebookSelect (index : number) : void
   onNotebookAdd () : void
   onNotebookRemove (index : number) : void
@@ -45,11 +47,13 @@ export default function TopBar (props : Props) : JSX.Element {
     theme,
     accent,
     boxStyle,
+    confirmBoxDelete,
     settings,
     onAccentChange,
     onAccentPreview,
     onBoxStyleChange,
     onBoxStylePreview,
+    onConfirmBoxDeleteChange,
     onNotebookSelect,
     onNotebookAdd,
     onNotebookRemove,
@@ -354,6 +358,18 @@ export default function TopBar (props : Props) : JSX.Element {
                     )
                   }
                 </div>
+                <p className='top-bar--settings-title'>Deletion</p>
+                <span className='top-bar--delete-confirm'>
+                  <input
+                    id='top-bar--confirm-delete'
+                    type='checkbox'
+                    checked={ confirmBoxDelete }
+                    onChange={ (e) => onConfirmBoxDeleteChange(e.target.checked) }
+                  />
+                  <label htmlFor='top-bar--confirm-delete'>
+                    Ask before deleting a box
+                  </label>
+                </span>
               </div>
             </React.Fragment>
           :

--- a/src/markdown-integration/AppTypes.test.tsx
+++ b/src/markdown-integration/AppTypes.test.tsx
@@ -1,3 +1,4 @@
+import { readFileSync } from 'fs';
 import { test, expect, afterEach } from 'vitest';
 import { render, fireEvent, cleanup } from '@testing-library/react';
 import { createNewMarkdown, onMarkDownBlur, NoteState } from './AppTypes';
@@ -51,4 +52,15 @@ test('preview toggle submits the heading as title', () => {
   expect(updated.length).toBe(1);
   expect(updated[0].isEditing).toBe(false);
   expect(updated[0].title).toBe('Hi');
+});
+
+test('dark code blocks keep light text on the dark surface', () => {
+  // github-markdown-light pins pre text to near-black; the dark
+  // overrides must repaint the text, not just the background.
+  const css = readFileSync('src/styles/Markdown.css', 'utf8');
+  const pre = css.match(/\.dark \.markdown-body pre\s*\{[^}]*\}/)?.[0] ?? '';
+  expect(pre).toMatch(/background-color\s*:\s*var\(--raised\)/);
+  expect(pre).toMatch(/color\s*:\s*var\(--text\)/);
+  const code = css.match(/\.dark \.markdown-body code,[\s\S]*?\}/)?.[0] ?? '';
+  expect(code).toMatch(/color\s*:\s*var\(--text\)/);
 });

--- a/src/markdown-integration/BoxTopBar.tsx
+++ b/src/markdown-integration/BoxTopBar.tsx
@@ -26,7 +26,6 @@ export default function BoxTopBar (props : Props) : JSX.Element {
   return (
     <div className=''>
       <div className='markdown-controls' title='Edit as Markdown'>
-        
         {/* This will be separated into it's own component */}
         <div className='markdown-editing'>
           <span

--- a/src/markdown-integration/Note.tsx
+++ b/src/markdown-integration/Note.tsx
@@ -28,7 +28,6 @@ export default function Note (props : NoteProperties) : JSX.Element {
     isActive,
     setBoxState,
   } = props
-  
   const onContent = (content : string) => {
     setBoxState({
       ...props.state,
@@ -51,7 +50,6 @@ export default function Note (props : NoteProperties) : JSX.Element {
           syntaxError={ syntaxError } // data
           submitOnEnter={ false } // data
           shouldReplaceLambda={ false }
-          
           onContent={ onContent } // fn
           onEnter={ () => void 0 } // fn
           onCtrlEnter={ () => void 0 }

--- a/src/screens/Notebook.test.tsx
+++ b/src/screens/Notebook.test.tsx
@@ -1321,3 +1321,101 @@ test('scrollable history sits back slightly, focused step comes forward', () => 
   const block = css.match(/\.box-history-scroll \.inactiveStep\s*\{[^}]*\}/)?.[0] ?? '';
   expect(block).toMatch(/opacity\s*:\s*0\.8/);
 });
+
+function deleteNotebook (onPatch : (patch : Partial<NotebookState>) => void, confirmBoxDelete : boolean = true, onConfirm : (confirm : boolean) => void = () => void 0) {
+  const state : NotebookState = {
+    name : 'Test',
+    boxList : [ noteBox('first', 'a'), noteBox('second', 'b') ],
+    activeBoxIndex : 0,
+    focusedBoxIndex : 0,
+    menuOpen : false,
+    settings : {},
+    __key : 'nb',
+  };
+  return render(
+    <Notebook
+      state={ state }
+      updateNotebook={ onPatch }
+      confirmBoxDelete={ confirmBoxDelete }
+      onConfirmBoxDeleteChange={ onConfirm }
+    />
+  );
+}
+
+const TRASH = '[title="Delete this Box from the Notebook"]';
+
+function clickFirstTrash (container : HTMLElement) : void {
+  fireEvent.click(container.querySelectorAll(TRASH)[0] as HTMLElement);
+}
+
+test('trash with asking on parks a dialog and deletes nothing', () => {
+  const patches : Array<Partial<NotebookState>> = [];
+  const { container, unmount } = deleteNotebook((patch) => { patches.push(patch); });
+  try {
+    clickFirstTrash(container);
+    expect(patches.length).toBe(0);
+    expect(container.querySelector('.box-delete-confirm')).not.toBeNull();
+  }
+  finally {
+    unmount();
+  }
+});
+
+test('dialog delete removes the box, cancel keeps it', () => {
+  const patches : Array<Partial<NotebookState>> = [];
+  const { container, unmount } = deleteNotebook((patch) => { patches.push(patch); });
+  try {
+    clickFirstTrash(container);
+    fireEvent.click(container.querySelector('.box-delete-confirm-cancel') as HTMLElement);
+    expect(patches.length).toBe(0);
+    expect(container.querySelector('.box-delete-confirm')).toBeNull();
+
+    clickFirstTrash(container);
+    fireEvent.click(container.querySelector('.box-delete-confirm-delete') as HTMLElement);
+    expect(patches.length).toBe(1);
+    expect(patches[0].boxList?.length).toBe(1);
+    expect(container.querySelector('.box-delete-confirm')).toBeNull();
+  }
+  finally {
+    unmount();
+  }
+});
+
+test('dont-ask-again applies on either button', () => {
+  const seen : Array<boolean> = [];
+  const patches : Array<Partial<NotebookState>> = [];
+  const { container, unmount } = deleteNotebook((patch) => { patches.push(patch); }, true, (confirm) => { seen.push(confirm); });
+  try {
+    // Cancel with the box checked: kept, but asking turns off.
+    clickFirstTrash(container);
+    fireEvent.click(container.querySelector('.box-delete-confirm-again input') as HTMLElement);
+    fireEvent.click(container.querySelector('.box-delete-confirm-cancel') as HTMLElement);
+    expect(patches.length).toBe(0);
+    expect(seen).toEqual([ false ]);
+
+    // Delete with the box checked: removed, asking turns off.
+    clickFirstTrash(container);
+    fireEvent.click(container.querySelector('.box-delete-confirm-again input') as HTMLElement);
+    fireEvent.click(container.querySelector('.box-delete-confirm-delete') as HTMLElement);
+    expect(patches.length).toBe(1);
+    expect(patches[0].boxList?.length).toBe(1);
+    expect(seen).toEqual([ false, false ]);
+  }
+  finally {
+    unmount();
+  }
+});
+
+test('trash with asking off deletes outright', () => {
+  const patches : Array<Partial<NotebookState>> = [];
+  const { container, unmount } = deleteNotebook((patch) => { patches.push(patch); }, false);
+  try {
+    clickFirstTrash(container);
+    expect(container.querySelector('.box-delete-confirm')).toBeNull();
+    expect(patches.length).toBe(1);
+    expect(patches[0].boxList?.length).toBe(1);
+  }
+  finally {
+    unmount();
+  }
+});

--- a/src/screens/Notebook.tsx
+++ b/src/screens/Notebook.tsx
@@ -11,6 +11,10 @@ interface Props {
   state : NotebookState
 
   updateNotebook (notebook : Partial<NotebookState>) : void
+
+  // App-wide delete confirmation (absent call sites keep asking).
+  confirmBoxDelete? : boolean
+  onConfirmBoxDeleteChange? : (confirm : boolean) => void
 }
 
 // The prime line sits in the upper third of the view: the box owning
@@ -174,9 +178,11 @@ export function mapBoxLabel (box : BoxState) : string {
 interface State {
   mapAtTop : boolean
   mapAtBottom : boolean
+  confirmDeleteIndex : number | null
 }
 
 export default class Notebook extends PureComponent<Props, State> {
+  private dontAskRef : React.RefObject<HTMLInputElement>
   private boxRefs : Array<HTMLLIElement | null>
   private mapListRef : React.RefObject<HTMLDivElement>
   private seatRequested : number | null
@@ -204,6 +210,7 @@ export default class Notebook extends PureComponent<Props, State> {
   constructor (props : Props) {
     super(props)
 
+    this.dontAskRef = React.createRef<HTMLInputElement>()
     this.boxRefs = []
     this.mapListRef = React.createRef<HTMLDivElement>()
     this.seatRequested = null
@@ -227,11 +234,14 @@ export default class Notebook extends PureComponent<Props, State> {
     this.zenWheelCapTimer = null
     this.zenTouchY = null
     this.zenTouchListTop = null
-    this.state = { mapAtTop : true, mapAtBottom : true }
+    this.state = { mapAtTop : true, mapAtBottom : true, confirmDeleteIndex : null }
 
     this.insertBefore = this.insertBefore.bind(this)
     this.insertAfter = this.insertAfter.bind(this)
     this.removeBox = this.removeBox.bind(this)
+    this.requestRemoveBox = this.requestRemoveBox.bind(this)
+    this.confirmDeleteBox = this.confirmDeleteBox.bind(this)
+    this.cancelDeleteBox = this.cancelDeleteBox.bind(this)
     this.updateBoxState = this.updateBoxState.bind(this)
     this.makeActive = this.makeActive.bind(this)
     this.onBlur = this.onBlur.bind(this)
@@ -689,7 +699,7 @@ export default class Notebook extends PureComponent<Props, State> {
                 addBoxBefore={ (box : BoxState) => this.insertBefore(i, box) }
                 addBoxAfter={ (box : BoxState) => this.insertAfter(i, box) }
                 makeActive={ () => this.makeActive(i) }
-                removeBox={ () => this.removeBox(i) }
+                removeBox={ () => this.requestRemoveBox(i) }
                 updateBoxState={ (box : BoxState) => this.updateBoxState(i, box) }
                 onBlur={ () => this.onBlur(i) }
               />
@@ -834,6 +844,39 @@ export default class Notebook extends PureComponent<Props, State> {
           :
             null
         }
+        {
+          // Delete confirmation for the trash icon. A stale parked index
+          // (the list changed under the open dialog) dismisses itself.
+          this.state.confirmDeleteIndex !== null && boxList[this.state.confirmDeleteIndex] !== undefined ?
+            <div className='box-delete-confirm'>
+              <div className='box-delete-confirm-backdrop' onClick={ () => this.cancelDeleteBox() } />
+              <div className='box-delete-confirm-card' role='alertdialog' aria-label='Delete this box?'>
+                <p className='box-delete-confirm-title'>
+                  Delete this box?
+                </p>
+                <label className='box-delete-confirm-again'>
+                  <input type='checkbox' ref={ this.dontAskRef } />
+                  Don&apos;t ask me this again
+                </label>
+                <div className='box-delete-confirm-actions'>
+                  <button
+                    className='box-delete-confirm-cancel'
+                    onClick={ () => this.cancelDeleteBox() }
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    className='box-delete-confirm-delete'
+                    onClick={ () => this.confirmDeleteBox() }
+                  >
+                    Delete
+                  </button>
+                </div>
+              </div>
+            </div>
+          :
+            null
+        }
       </div>
     )
   }
@@ -856,6 +899,38 @@ export default class Notebook extends PureComponent<Props, State> {
     boxList.splice(index + 1, 0, box)
     this.props.updateNotebook({ boxList : syncDocksToFocus(boxList, index + 1, this.props.state.zenMode), activeBoxIndex : index + 1, focusedBoxIndex : index + 1})
     this.seatRequested = index + 1
+  }
+
+  // The trash icon lands here: with asking on, the index parks in the
+  // confirm dialog instead of deleting outright.
+  requestRemoveBox (index : number) : void {
+    if ((this.props.confirmBoxDelete ?? true) === true) {
+      this.setState({ confirmDeleteIndex : index })
+    }
+    else {
+      this.removeBox(index)
+    }
+  }
+
+  // "Don't ask me again" applies on either button; only Delete removes.
+  applyDontAskAgain () : void {
+    if (this.dontAskRef.current !== null && this.dontAskRef.current.checked) {
+      this.props.onConfirmBoxDeleteChange?.(false)
+    }
+  }
+
+  confirmDeleteBox () : void {
+    const index : number | null = this.state.confirmDeleteIndex
+    this.applyDontAskAgain()
+    this.setState({ confirmDeleteIndex : null })
+    if (index !== null) {
+      this.removeBox(index)
+    }
+  }
+
+  cancelDeleteBox () : void {
+    this.applyDontAskAgain()
+    this.setState({ confirmDeleteIndex : null })
   }
 
   removeBox (index : number) : void {

--- a/src/screens/Notebook.tsx
+++ b/src/screens/Notebook.tsx
@@ -935,7 +935,6 @@ export default class Notebook extends PureComponent<Props, State> {
 
   removeBox (index : number) : void {
     const { boxList, activeBoxIndex } = this.props.state
-    
     const nearestValidIndex = (i : number) => {
       if (i < activeBoxIndex) return activeBoxIndex - 1
       if (i > activeBoxIndex) return activeBoxIndex
@@ -967,7 +966,6 @@ export default class Notebook extends PureComponent<Props, State> {
       case BoxType.UNTYPED_LAMBDA:
         // boxList[activeBoxIndex] = onUntypedLambdaBlur(boxList[activeBoxIndex])
         break
-      
       case BoxType.MARKDOWN: {
         boxList[activeBoxIndex] = onMarkDownBlur(boxList[activeBoxIndex] as NoteState)
         break
@@ -991,7 +989,6 @@ export default class Notebook extends PureComponent<Props, State> {
             ...patch,
           }
           break
-          
         default:
           boxList[index] = {
             ...boxList[index],
@@ -1094,7 +1091,6 @@ export default class Notebook extends PureComponent<Props, State> {
       case BoxType.UNTYPED_LAMBDA:
         // boxList[activeBoxIndex] = onUntypedLambdaBlur(boxList[activeBoxIndex])
         break
-      
       case BoxType.MARKDOWN:
         boxList[index] = onMarkDownBlur(boxList[index] as NoteState)
         // return // TODO: just for now

--- a/src/styles/Markdown.css
+++ b/src/styles/Markdown.css
@@ -31,10 +31,12 @@
 .dark .markdown-body code,
 .dark .markdown-body tt {
   background-color: var(--raised);
+  color: var(--text);
 }
 
 .dark .markdown-body pre {
   background-color: var(--raised);
+  color: var(--text);
 }
 
 .dark .markdown-body table tr {

--- a/src/styles/TopBar.css
+++ b/src/styles/TopBar.css
@@ -526,3 +526,11 @@
   position: absolute;
   z-index: -1;
 }
+
+/* Deletion confirmation toggle: plain checkbox row under its title. */
+.top-bar--delete-confirm {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+}

--- a/src/untyped-lambda-integration/Constants.test.ts
+++ b/src/untyped-lambda-integration/Constants.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from 'vitest';
 import { tokenize, parse, None, NormalEvaluator } from '@lambdulus/core';
-import { createNewUntypedLambdaExpression, defaultSettings, findSimplifiedReduction, strategyToEvaluator, toMacroMap } from './Constants';
+import { createNewUntypedLambdaExpression, defaultSettings, findSimplifiedReduction, strategyToEvaluator, toMacroMap, coreErrorMessage } from './Constants';
 import { TreeComparator } from './TreeComparator';
 import { EvaluationStrategy, UntypedLambdaSettings } from './Types';
 
@@ -54,4 +54,9 @@ test('/ 4 2 simplified run terminates with 2', () => {
     ast = perform(probe);
   }
   expect.unreachable('simplified evaluation did not terminate');
+});
+
+test('coreErrorMessage unwraps objects and passes strings through', () => {
+  expect(coreErrorMessage(new Error('typed boom'))).toBe('typed boom');
+  expect(coreErrorMessage('legacy string boom')).toBe('legacy string boom');
 });

--- a/src/untyped-lambda-integration/Constants.ts
+++ b/src/untyped-lambda-integration/Constants.ts
@@ -112,6 +112,12 @@ export function createNewUntypedLambdaExpression (settings : UntypedLambdaSettin
 //   }, {})
 // }
 
+// Core throws typed errors; extract the human message either way
+// (strings answer .toString natively, Error objects carry .message).
+export function coreErrorMessage (exception : unknown) : string {
+  return exception instanceof Error ? exception.message : String(exception)
+}
+
 export function toMacroMap (definitions : Array<string>, SLI : boolean) : MacroMap {
   /**
    * This might seem like something really wrong

--- a/src/untyped-lambda-integration/Constants.ts
+++ b/src/untyped-lambda-integration/Constants.ts
@@ -87,7 +87,6 @@ export function createNewUntypedLambdaExpression (settings : UntypedLambdaSettin
     breakpoints : [],
     timeoutID : undefined,
     timeout : 5,
-    
     // strategy : EvaluationStrategy.NORMAL,
     // singleLetterNames : false,
     // standalones : false,
@@ -95,7 +94,6 @@ export function createNewUntypedLambdaExpression (settings : UntypedLambdaSettin
     macrolistOpen : false,
     macrotable : { },
 
-    
     editor : {
       placeholder : "placeholder",
       content : "",
@@ -143,7 +141,6 @@ export function toMacroMap (definitions : Array<string>, SLI : boolean) : MacroM
     // variables (chained definitions never resolved at validation time).
     return { ...acc, [name.trim()] : '' }
   }, {})
-  
   return definitions.reduce((acc : MacroMap, def) => {
     const [name, body] = def.split(':=')
 
@@ -186,15 +183,11 @@ export function createNewUntypedLambdaBoxFromSource (source : string, defaultSet
       breakpoints : [],
       timeoutID : undefined,
       timeout : 5,
-      
       // strategy : EvaluationStrategy.NORMAL,
       // singleLetterNames : false,
       // standalones : false,
-  
       macrolistOpen : false,
       macrotable, // ...UNTYPED_LAMBDA_INTEGRATION_STATE.macrotable
-  
-      
       editor : {
         placeholder : "placeholder",
         content : source,
@@ -215,12 +208,9 @@ function createNewUntypedLambdaBoxFromSource2 (source : string, defaultSettings 
   const expression = `${macros}${macros.length ? ';\n' : ''}${source}`
 
   const macromap : MacroMap = macrotable // toMacroMap(definitions, SLI)
-  
   try {
     const tokens : Array<Token> = tokenize(source, { lambdaLetters : ['λ'], singleLetterVars : SLI, macromap })
     const ast : AST = parse(tokens, macromap) // macroTable
-    
-    
     let message : StepMessage = { validity : StepValidity.CORRECT, userInput : expression, message : '' }
     let isNormal = false
 
@@ -231,12 +221,11 @@ function createNewUntypedLambdaBoxFromSource2 (source : string, defaultSettings 
         return findSimplifiedReduction(astCopy, strategy, macromap)[0]
       }
       else {
-        const evaluator : Evaluator = new (strategyToEvaluator(strategy) as any)(astCopy)
+        const evaluator : Evaluator = new (strategyToEvaluator(strategy))(astCopy)
         return evaluator.nextReduction
       }
     })()
 
-    
     if (nextReduction instanceof None) {
       isNormal = true
       message.message = 'Expression is in normal form.'
@@ -295,11 +284,9 @@ export function resetUntypedLambdaBox (state : UntypedLambdaState) : UntypedLamb
     breakpoints : [],
     timeoutID : undefined,
     timeout : 5,
-    
     macrolistOpen : false,
     macrotable : { },
 
-    
     editor : {
       placeholder : "placeholder",
       content : "",
@@ -318,7 +305,6 @@ function decodeUntypedLambdaExpression (box : UntypedLambdaState) : UntypedLambd
   if (untypedLambdaBox.expression === '') {
     return untypedLambdaBox
   }
-  
   const decodedFirst : AST | null = decodeUntypedLambdaFast(untypedLambdaBox.ast)
 
   if (decodedFirst === null) {
@@ -371,7 +357,12 @@ type PerformEvaluation = (ast : AST) => AST
 
 
 export function findSimplifiedReduction (ast : AST, strategy : EvaluationStrategy, macrotable : MacroTable) : [ASTReduction, PerformEvaluation] {
-  const evaluator : Evaluator =  new (strategyToEvaluator(strategy) as any)(ast) // new NormalEvaluator(ast) // TODO: get evaluator dipending on the strategy in the future
+  // NOTE (load-bearing assumptions -- do not refactor lightly):
+  // 1. Performer closures may consume shared reduction state (MacroBeta.parents is
+  //    shift()ed while performing) -- assume each returned performer runs at most once.
+  // 2. Rules III/IV match reductions to tree nodes by AST identifier -- the input AST
+  //    is mutated in place, so identifiers must stay stable across clone()/perform().
+  const evaluator : Evaluator = new (strategyToEvaluator(strategy))(ast)
   const nextReduction = evaluator.nextReduction
 
   // nothing to do
@@ -390,8 +381,6 @@ export function findSimplifiedReduction (ast : AST, strategy : EvaluationStrateg
     // uvnitr celeho stromu hledam dalsi REDEX
     //
     const [newreduction] = findSimplifiedReduction(newAst, strategy, macrotable)
-
-    // return [nextReduction, (ast) => newAst]
 
     if (newreduction instanceof None) {
       //
@@ -419,10 +408,7 @@ export function findSimplifiedReduction (ast : AST, strategy : EvaluationStrateg
   }
 
   if (nextReduction instanceof Expansion && nextReduction.target instanceof Macro) {
-    // debugger
-    
     const { parent, treeSide, target } : Expansion = nextReduction
-    
     const M : Macro = target.clone()
 
     {
@@ -432,11 +418,11 @@ export function findSimplifiedReduction (ast : AST, strategy : EvaluationStrateg
 
       {
         const evaluator : Evaluator =
-          new (strategyToEvaluator(strategy) as any)(clone) // new NormalEvaluator(ast) // TODO: get evaluator dipending on the strategy in the future
+          new (strategyToEvaluator(strategy))(clone)
         newAst = evaluator.perform()
       }
 
-      const _evaluator : Evaluator = new (strategyToEvaluator(strategy) as any)(newAst) // new NormalEvaluator(ast) // TODO: get evaluator dipending on the strategy in the future
+      const _evaluator : Evaluator = new (strategyToEvaluator(strategy))(newAst)
       const nextReduction = _evaluator.nextReduction
 
       if (nextReduction instanceof Expansion) {
@@ -473,9 +459,6 @@ export function findSimplifiedReduction (ast : AST, strategy : EvaluationStrateg
       ([newreduction, newperformevaluation] = findSimplifiedReduction(newAst, strategy, macrotable))
     }
 
-    // debugger
-    // node : AST = parent === null ? newAst
-    //                                                     (to co jsme expandovali)
     if (parent !== null && treeSide !== null && findRedexIn(expanded, newreduction)) {
       // REDEX is completely bounded by expanded M Macro expression
       return [nextReduction, (_) => evaluator.perform()]
@@ -491,22 +474,13 @@ export function findSimplifiedReduction (ast : AST, strategy : EvaluationStrateg
         && newreduction.type === ASTReductionType.BETA
         && parent.identifier === beta.redex.identifier) {
       // rule IV.
-
-      // if ( ! macroIsSingleStep(M)) {
-      //   return [newreduction, newperformevaluation]
-      // }
-
-
       const expanded : Lambda = parent[treeSide] as Lambda
-      // const [fnArgNames, fnBody] = splitLambdaFn(expanded)
-      // const fnBody : AST = getFnBody(expanded)
       const fnArgNames : Array<string> = getFnArgNames(expanded)
       let arity : number = fnArgNames.length
       const arit : number | null = getArityOfKnownMacro(M.name())
       if (arit !== null && arit <= arity) {
         arity = arit
       }
-      // const arity : number = getArity(expanded)
       // --> get arity of expression X which was expanded from macro M
       // it should be simple -- just go to the right for the lambda and as long as it's right side is also lambda count +1
 
@@ -521,21 +495,14 @@ export function findSimplifiedReduction (ast : AST, strategy : EvaluationStrateg
             continue
           }
           else {
-            // debugger
             // we previously expanded our M in the ast
             // recursive findSimplifiedReduction then works with that
             // so current app containes M as expanded Expression
             // we need to take that back
-            
             return [argreduction, (ast : AST) => {
-              // const newast : AST = argperformevaluation(ast) // original line
               app.right = argperformevaluation(app.right)
 
               parent[treeSide] = M
-              // if (newast.identifier !== app.identifier) {
-              //   app.right = newast
-              //   // this is ugly hack but just checking if it works -- it doesn't
-              // }
               return ast
             }]
           }
@@ -555,7 +522,6 @@ export function findSimplifiedReduction (ast : AST, strategy : EvaluationStrateg
       // also the TOP context needs to check the arity - not just me OK
       // the performer is just some foreach on the array of betas OK
 
-      
       // let fnBody : AST = expanded.right
       // let fn : AST = expanded
       // const getFnBody = () => (fn as Lambda).right
@@ -576,20 +542,15 @@ export function findSimplifiedReduction (ast : AST, strategy : EvaluationStrateg
         let lastapp : AST | null = null
         let lastparent : Binary | null = null
 
-        // debugger
-        
         // budu muset projit kazdou aplikaci v poli
         // vytvorit pro ni beta redukci pro vyraz ktery vznikl v predchozi iteraci - proto nejde udelat pole beta redukci dopredu
         // a provest je - na konci vratim vysledny AST
         for (const app of macroAppRedex.applications) {
           let appParent : Binary | undefined | null = macroAppRedex.parents.shift() as Binary
           let treeSide : Child | null = appParent === undefined ? null : appParent.left.identifier === app.identifier ? Child.Left : Child.Right
-          
-          
 
-          
 
-          const evaluator : Evaluator = new (strategyToEvaluator(strategy) as any)(app) // new NormalEvaluator(app)
+          const evaluator : Evaluator = new (strategyToEvaluator(strategy))(app) // new NormalEvaluator(app)
           evaluator.reducer.perform()
           const reduced : AST = evaluator.reducer.tree
 
@@ -608,32 +569,6 @@ export function findSimplifiedReduction (ast : AST, strategy : EvaluationStrateg
           }
 
           lastparent = appParent // because I am lazy and don't want to use ifs before the for loop
-
-
-          // let appParent : Binary | undefined | null = macroAppRedex.parents.shift() as Binary
-          // let treeSide : Child | null = appParent === undefined ? null : appParent.left.identifier === app.identifier ? Child.Left : Child.Right
-          
-          // if (appParent === undefined) {
-          //   appParent = null
-          //   treeSide = null
-          // }
-
-          // lastparent = appParent // because I am lazy and don't want to use ifs before the for loop
-          
-          // const argName : string = fnArgNames.shift() as string
-
-          // // if ((app.left as Binary).right === undefined) {
-          // //   debugger
-          // // }
-
-          // const beta : Beta = new Beta(app, appParent as Binary, treeSide, (app.left as Lambda).body , argName, app.right) // getFnBody()
-
-          // // fnBody = (fnBody as Application).right
-          // // setFn(getFnBody())
-
-          // const reducer : BetaReducer = new BetaReducer(beta, ast)
-          // reducer.perform()
-          // ast = reducer.tree
         }
 
         if (macroIsSingleStep(M)) {
@@ -641,16 +576,13 @@ export function findSimplifiedReduction (ast : AST, strategy : EvaluationStrateg
             throw Error("This is bad, real bad.")
             // NOTE LATER: not sure what does that mean?
           }
-  
           if (lastparent === null) {
             // normalize the whole tree
             // top-most APP or ABS a result of the Macro-Beta
-  
             let wholeTreeIterations : number = 0
             while (true) {
               const [nextReduction, evaluateReduction] : [ASTReduction, any] =
                 findSimplifiedReduction(ast, strategy, macrotable)
-              
               if (nextReduction instanceof None) {
                 return tryMacroContraction(ast, macrotable)
               }
@@ -668,13 +600,11 @@ export function findSimplifiedReduction (ast : AST, strategy : EvaluationStrateg
           }
           else {
             const treeSide : Child = lastparent.left.identifier === lastapp.identifier ? Child.Left : Child.Right
-  
             // debugger
             let subTreeIterations : number = 0
             while (true) {
               const [nextReduction, evaluateReduction] : [ASTReduction, any] =
                 findSimplifiedReduction(lastapp as AST, strategy, macrotable)
-  
               if (nextReduction instanceof None) {
                 lastparent[treeSide] = tryMacroContraction(lastapp as AST, macrotable)
                 return ast
@@ -694,56 +624,27 @@ export function findSimplifiedReduction (ast : AST, strategy : EvaluationStrateg
             }
           }
         }
-        
         return ast // it it's not single-step Macro --> then no contraction I guess
       }]
     }
 
-    // THIS IS WRONG --> IT'S NOT NEEDED -- INSTEAD I FIXED RULE III AND IT SHOULD BE ENOUGH
-    // if (newreduction instanceof Expansion) {
-    //   // Expansion inside Expansion
-    //   // this is for cases --> when one macro needs to expanded because what it expands to is expression ->
-    //   // which leads to another expansion --> because there is some Macro M2 which contains redex for example
-    //   // which means - I need to actually expand 
-    //   return [nextReduction, (_) => newAst]
-    // }
-
-    // if (parent !== null && treeSide !== null && ( ! findRedexIn(parent[treeSide], newreduction)))
     // this is fallbacking action
     // redex was found - but does not concern previously expanded macro - so the expansions is unnecessary
-    // eslint-disable-next-line
-    {
 
-      // REDEX is NOT inside expanded M -- NOT rule III.
-      // expanded Macro is also not part of the REDEX -- NOT rule IV
-      // --> not expanding M just perform the second reduction but on original tree
-      return [newreduction, (ast) => {
-        const resAST = newperformevaluation(newAst)
-        const p = parent as AST
-        const ts = treeSide as String
+    // REDEX is NOT inside expanded M -- NOT rule III.
+    // expanded Macro is also not part of the REDEX -- NOT rule IV
+    // --> not expanding M just perform the second reduction but on original tree
+    return [newreduction, (ast) => {
+      const resAST = newperformevaluation(newAst)
+      const p = parent as AST
+      const ts = treeSide as string
 
-        // if (p === null || ts === null) {
-        //   debugger
-        // }
+      if (p !== null && ts !== null) {
+        (p as any)[ts as any] = M
+      }
 
-        if (p !== null && ts !== null) {
-          (p as any)[ts as any] = M
-        }
-
-        // // parent should be not-null
-        // // because if there was a Macro which we were able to Expand
-        // // and then there has been found Redex which is not part of the newly expanded sub-tree
-        // // the new Redex simply has to be in different part of the tree --> which means - M (original Macro) is not the root
-        // //
-        // // this is aparenlty not true
-        // // A := + 1 2; B := A; B
-        // // probably because there are two levels of macro expansion and this leads to parent possibly being null
-        // // after the last change -- anchor #1
-        // // this should once again be true - but just to be sure - I will leave it inside the if
-
-        return resAST
-      }]
-    }
+      return resAST
+    }]
   }
   else {
     return [nextReduction, (ast) => evaluator.perform()]
@@ -767,7 +668,6 @@ export function tryMacroContraction (ast : AST, macrotable : MacroTable) : AST {
 
     return parse(tokenize(`${n}`, { lambdaLetters : ['λ'], singleLetterVars : false, macromap : macrotable }), macrotable)
   }
-  
   for (const [name, definition] of [ ...Object.entries(builtinMacros), ...Object.entries(macrotable) ]) {
     // parse the definition
     const tokens : Array<Token> = tokenize(definition, { lambdaLetters : ['λ'], singleLetterVars : false, macromap : macrotable })
@@ -778,8 +678,6 @@ export function tryMacroContraction (ast : AST, macrotable : MacroTable) : AST {
     if (comparator.equals) {
       const macroNameAst : AST = parse(tokenize(name, { lambdaLetters : ['λ'], singleLetterVars : false, macromap : macrotable }), macrotable)
 
-
-      // const virtualToken : Token = new Token((macroNameAst as Macro).token.type, name, BLANK_POSITION)
       return macroNameAst // this is dirty-fix -- because the following line somehow produces macro which
       // expand incorrectly to `undefined` value
       // return new Macro(virtualToken, macrotable)
@@ -787,8 +685,6 @@ export function tryMacroContraction (ast : AST, macrotable : MacroTable) : AST {
   }
 
   return ast
-
-  // for (const macro : )
 }
 
 function isChurchNumeral (ast : AST) : boolean {
@@ -836,12 +732,15 @@ function peanoToNumber (ast : AST, s : string, z : string) : number {
 }
 
 
+const BINARY_MACROS : Array<string> = [ "*", "+", "/", "-", "^", "DELTA", "=", ">", "<", ">=", "<=", "AND", "OR" ]
+const UNARY_MACROS : Array<string> = [ "ZERO", "NOT", "SUC", "PRED" ]
+
 function getArityOfKnownMacro (macroname : string) : number | null {
-  if ([ "*", "+", "/", "-", "^", "DELTA", "=", ">", "<", ">=", "<=", "AND", "OR" ].includes(macroname)) {
+  if (BINARY_MACROS.includes(macroname)) {
     return 2
   }
 
-  if ([ "ZERO", "NOT", "SUC", "PRED" ].includes(macroname)) {
+  if (UNARY_MACROS.includes(macroname)) {
     return 1
   }
 
@@ -852,7 +751,7 @@ function getArityOfKnownMacro (macroname : string) : number | null {
  * Decides if the result of the application of the macro M to its arguments should evaluate to the normal form
  */
 function macroIsSingleStep (macro : Macro) : boolean {
-  if ([ "*", "+", "/", "-", "^", "DELTA", "=", ">", "<", ">=", "<=", "ZERO", "NOT", "AND", "OR", "PRED", "SUC" ].includes(macro.name())) {
+  if ([ ...BINARY_MACROS, ...UNARY_MACROS ].includes(macro.name())) {
     return true
   }
 
@@ -886,7 +785,6 @@ function findRedexIn (tree : AST, reduction : ASTReduction) : boolean {
     }
   }
   else if (reduction.type === ASTReductionType.EXPANSION) {
-    // debugger
     const expansion : Expansion = reduction as Expansion
     if (tree.identifier === expansion.target.identifier) {
       return true
@@ -906,25 +804,6 @@ function findRedexIn (tree : AST, reduction : ASTReduction) : boolean {
     return false
   }
 }
-
-// function getArity (ast : AST) : number { 
-//   if (ast instanceof Lambda) {
-//     return 1 + getArity(ast.right)
-//   }
-//   else {
-//     return 0
-//   }
-// }
-
-// function splitLambdaFn (ast : AST) : [Array<string>, AST] {
-//   if (ast instanceof Lambda) {
-//     const [args, body] = splitLambdaFn(ast.right)
-//     return [[ast.left.name(), ...args], body]
-//   }
-//   else {
-//     return [[], ast]
-//   }
-// }
 
 function getFnArgNames (ast : AST) : Array<string> {
   if (ast instanceof Lambda) {
@@ -1023,31 +902,28 @@ export class NormalMacroRedexExtender extends ASTVisitor {
 
 function hasApplicativeOverride (macro : Macro) : boolean {
   // TODO: implement later
-  return ["*", "+", "/", "-", "^", "DELTA", "=", ">", "<", ">=", "<=", "ZERO", "NOT", "PRED", "SUC"].includes(macro.name())
-  
-  //  "T", "F"
-  // "AND", "OR"
-  // return false
+  // NOTE: AND and OR are intentionally excluded
+  return [ ...BINARY_MACROS.filter((name) => name !== "AND" && name !== "OR"), ...UNARY_MACROS ].includes(macro.name())
 }
 
-export function strategyToEvaluator (strategy : EvaluationStrategy) : Evaluator {
+export function strategyToEvaluator (strategy : EvaluationStrategy) : new (ast : AST) => Evaluator {
   switch (strategy) {
     case EvaluationStrategy.NORMAL:
-      return NormalEvaluator as any
- 
+      return NormalEvaluator
+
     case EvaluationStrategy.APPLICATIVE:
-      return ApplicativeEvaluator as any
+      return ApplicativeEvaluator
 
     case EvaluationStrategy.OPTIMISATION:
-      return OptimizeEvaluator as any
+      return OptimizeEvaluator
 
     case EvaluationStrategy.ABSTRACTION: // this will be removed
-      return NormalAbstractionEvaluator as any // this will be removed
+      return NormalAbstractionEvaluator // this will be removed
 
     default:
       // Unknown strategy (e.g. a corrupt or future value from old storage):
       // fall back to normal evaluation instead of handing undefined back
       // to `new`, which reads as a syntax error on a healthy expression.
-      return NormalEvaluator as any
+      return NormalEvaluator
   }
 }

--- a/src/untyped-lambda-integration/Constants.ts
+++ b/src/untyped-lambda-integration/Constants.ts
@@ -31,6 +31,7 @@ import  { ASTReduction
         , Token
         , tokenize
         , parse
+        , parseMacroDefinition
         , ApplicativeEvaluator
         , OptimizeEvaluator
         , NormalAbstractionEvaluator
@@ -131,7 +132,10 @@ export function toMacroMap (definitions : Array<string>, SLI : boolean) : MacroM
       throw Error("Invalid Macro definition. Possibly empty Macro definition?")
     }
 
-    return { ...acc, [name] : '' }
+    // NOTE: the key must be trimmed -- the lexer matches macro names
+    // exactly, and untrimmed keys silently lex body references as free
+    // variables (chained definitions never resolved at validation time).
+    return { ...acc, [name.trim()] : '' }
   }, {})
   
   return definitions.reduce((acc : MacroMap, def) => {
@@ -146,7 +150,9 @@ export function toMacroMap (definitions : Array<string>, SLI : boolean) : MacroM
     // I just need it to parse and then serialize the body of the macro
     // that's it!
     const tokens : Array<Token> = tokenize(body.trim(), { lambdaLetters : ['λ'], singleLetterVars : SLI, macromap : mNames })
-    const ast : AST = parse(tokens, mNames) // macroTable
+    // Core parses the body and rejects open definitions with
+    // OpenMacroDefinition (macro name + free variables).
+    const ast : AST = parseMacroDefinition(name.trim(), tokens, mNames)
 
     return { ...acc, [name.trim()] : ast.toString() }
   }, {})

--- a/src/untyped-lambda-integration/EmptyExpression.tsx
+++ b/src/untyped-lambda-integration/EmptyExpression.tsx
@@ -74,7 +74,6 @@ export default function EmptyExpression(props : EmptyExpressionProps) : JSX.Elem
                     Debug
                   </span>
                 </button>
-                
                 <button
                   title='Exercise this Expression Yourself (Shift + Enter)'
                   type="button"
@@ -83,7 +82,6 @@ export default function EmptyExpression(props : EmptyExpressionProps) : JSX.Elem
                 >
                   <span className='untyped-lambda--submit-expression--btn-label'>Exercise</span>
                 </button>
-                
               </div>
             </div>
           )

--- a/src/untyped-lambda-integration/ExerciseBox.tsx
+++ b/src/untyped-lambda-integration/ExerciseBox.tsx
@@ -98,7 +98,6 @@ export default class ExerciseBox extends PureComponent<EvaluationProperties> {
           strategy={ this.props.state.strategy }
           SDE={ SDE }
           macrotable={ macrotable }
-          
           createBoxFrom={ this.createBoxFrom }
         />
       )
@@ -209,15 +208,13 @@ export default class ExerciseBox extends PureComponent<EvaluationProperties> {
       // const expression : string = definitions.pop() || ""
       // const macromap : MacroMap = toMacroMap(definitions, SLI)
       // const newMacrotable : MacroMap = { ...macrotable, ...macromap } // the local macromap has a higher priority
-      
       const ast : AST = this.parseExpression(content, macrotable)
 
       let message : StepMessage = { validity : StepValidity.CORRECT, userInput : content, message : '' }
       let isNormal = false
 
       const astCopy : AST = ast.clone()
-      const evaluator : Evaluator = new (strategyToEvaluator(strategy) as any)(astCopy)
-      
+      const evaluator : Evaluator = new (strategyToEvaluator(strategy))(astCopy)
       if (evaluator.nextReduction instanceof None) {
         isNormal = true
         message.message = 'Expression is in normal form.'
@@ -253,7 +250,6 @@ export default class ExerciseBox extends PureComponent<EvaluationProperties> {
       if (content.match(/\s*;\s*$/g)) {
         errorMessage = "There's a semicolon at the end."
       }
-      
       setBoxState({
         ...state,
         editor : {
@@ -273,7 +269,6 @@ export default class ExerciseBox extends PureComponent<EvaluationProperties> {
       const expression : string = definitions.pop() || ""
       const macromap : MacroMap = toMacroMap(definitions, SLI)
       const newMacrotable : MacroMap = { ...macrotable, ...macromap } // the local macromap has a higher priority
-      
 
       const userAst : AST = this.parseExpression(expression, newMacrotable)
       const stepRecord : StepRecord = history[history.length - 1]
@@ -293,12 +288,8 @@ export default class ExerciseBox extends PureComponent<EvaluationProperties> {
 
         return
       }
-    
       const newast : AST = ast.clone()
       let [nextReduction, evaluateReduction] : [ASTReduction, (ast : AST) => AST] = findSimplifiedReduction(newast, strategy, macrotable)
-      // const normal : Evaluator = new (strategyToEvaluator(strategy) as any)(ast)
-      // lastReduction = normal.nextReduction
-    
       if (nextReduction instanceof None) {
         const etaEvaluator : Evaluator = new OptimizeEvaluator(newast)
 
@@ -307,7 +298,6 @@ export default class ExerciseBox extends PureComponent<EvaluationProperties> {
           // TODO: say user it is in normal form and they are mistaken
           stepRecord.isNormalForm = true
           stepRecord.message.message = 'Expression is already in normal form.'
-          
           setBoxState({
             ...state,
           })
@@ -328,9 +318,6 @@ export default class ExerciseBox extends PureComponent<EvaluationProperties> {
 
         const astCopy : AST = ast.clone()
         const [nextReduction] : [ASTReduction, (ast : AST) => AST] = findSimplifiedReduction(astCopy, strategy, macrotable)
-        // const astCopy : AST = ast.clone()
-        // const evaluator : Evaluator = new (strategyToEvaluator(strategy) as any)(astCopy)
-        
         if (nextReduction instanceof None) {
           const etaEvaluator : Evaluator = new OptimizeEvaluator(astCopy)
 
@@ -339,7 +326,6 @@ export default class ExerciseBox extends PureComponent<EvaluationProperties> {
           }
         }
       }
-    
       let message : StepMessage = { validity : StepValidity.CORRECT, userInput : content, message : '' }
       const comparator : TreeComparator = new TreeComparator([ userAst, ast ], [ newMacrotable, macrotable ])
 
@@ -383,7 +369,6 @@ export default class ExerciseBox extends PureComponent<EvaluationProperties> {
   onExerciseStep () {
     const { state, setBoxState } = this.props
     const { strategy, history, editor : { content }, SDE, macrotable, SLI, ETA } = state
-    
     if (SDE === true) {
       this.onSimplifiedExerciseStep()
       return
@@ -395,7 +380,6 @@ export default class ExerciseBox extends PureComponent<EvaluationProperties> {
       const expression : string = definitions.pop() || ""
       const macromap : MacroMap = toMacroMap(definitions, SLI)
       const newMacrotable : MacroMap = { ...macrotable, ...macromap } // the local macromap has a higher priority
-      
 
       const userAst : AST = this.parseExpression(expression, newMacrotable)
       // HERE
@@ -416,10 +400,8 @@ export default class ExerciseBox extends PureComponent<EvaluationProperties> {
 
         return
       }
-    
-      let evaluator : Evaluator = new (strategyToEvaluator(strategy) as any)(ast)
+      let evaluator : Evaluator = new (strategyToEvaluator(strategy))(ast)
       lastReduction = evaluator.nextReduction
-    
       if (evaluator.nextReduction instanceof None) {
         const etaEvaluator : Evaluator = new OptimizeEvaluator(ast)
 
@@ -428,11 +410,9 @@ export default class ExerciseBox extends PureComponent<EvaluationProperties> {
           // TODO: say user it is in normal form and they are mistaken
           stepRecord.isNormalForm = true
           stepRecord.message.message = 'Expression is already in normal form.'
-          
           setBoxState({
             ...state,
           })
-            
           return
         }
 
@@ -440,15 +420,13 @@ export default class ExerciseBox extends PureComponent<EvaluationProperties> {
         lastReduction = etaEvaluator.nextReduction
 
       }
-    
       ast = evaluator.perform()
 
       let isNormal = false
 
       {
         const astCopy : AST = ast.clone()
-        const evaluator : Evaluator = new (strategyToEvaluator(strategy) as any)(astCopy)
-        
+        const evaluator : Evaluator = new (strategyToEvaluator(strategy))(astCopy)
         if (evaluator.nextReduction instanceof None) {
           const etaEvaluator : Evaluator = new OptimizeEvaluator(astCopy)
 
@@ -457,7 +435,6 @@ export default class ExerciseBox extends PureComponent<EvaluationProperties> {
           }
         }
       }
-    
       let message : StepMessage = { validity : StepValidity.CORRECT, userInput : content, message : '' }
       const comparator : TreeComparator = new TreeComparator([ userAst, ast ], [ newMacrotable, macrotable ])
 
@@ -512,7 +489,6 @@ export default class ExerciseBox extends PureComponent<EvaluationProperties> {
 
     //                                                    fix this part please
     let [nextReduction, evaluateReduction] : [ASTReduction, (ast : AST) => AST] = findSimplifiedReduction(ast, strategy, macrotable)
-    
     let message : StepMessage = { validity : StepValidity.CORRECT, userInput : content, message : '' }
     let isNowNormalForm = false
 
@@ -538,7 +514,6 @@ export default class ExerciseBox extends PureComponent<EvaluationProperties> {
         // this is what happens when ::single-step
         //
         newast = evaluateReduction(newast)
-        // debugger
 
         // if we are not ::single-step --> findSimplifiedReduction won't return MacroBeta -- instead
         // it will return the first redex --> first beta reduction in the list and then it's not macro reduction problem anymore
@@ -568,8 +543,6 @@ export default class ExerciseBox extends PureComponent<EvaluationProperties> {
     {
       const astCopy : AST = newast.clone()
       const [nextReduction] : [ASTReduction, (ast : AST) => AST] = findSimplifiedReduction(astCopy, strategy, macrotable)
-      // const evaluator : Evaluator = new (strategyToEvaluator(strategy) as any)(astCopy)
-      
       if (nextReduction instanceof None) {
         const etaEvaluator : Evaluator = new OptimizeEvaluator(astCopy)
 
@@ -599,9 +572,7 @@ export default class ExerciseBox extends PureComponent<EvaluationProperties> {
     const { isNormalForm, step } = stepRecord
     let { ast, lastReduction } = stepRecord
     ast = ast.clone()
-  
     if (isNormalForm) {
-      
       return
     }
 
@@ -611,16 +582,14 @@ export default class ExerciseBox extends PureComponent<EvaluationProperties> {
     }
 
 
-    let evaluator : Evaluator = new (strategyToEvaluator(strategy) as any)(ast)
+    let evaluator : Evaluator = new (strategyToEvaluator(strategy))(ast)
     lastReduction = evaluator.nextReduction
-  
     if (evaluator.nextReduction instanceof None) {
       const etaEvaluator : Evaluator = new OptimizeEvaluator(ast)
 
       if (etaEvaluator.nextReduction instanceof None || ! ETA) {
         stepRecord.isNormalForm = true
         stepRecord.message.message = 'Expression is in normal form.'
-        
         setBoxState({
           ...state,
         })
@@ -631,7 +600,6 @@ export default class ExerciseBox extends PureComponent<EvaluationProperties> {
       evaluator = etaEvaluator
       lastReduction = etaEvaluator.nextReduction
     }
-  
     ast = evaluator.perform()
 
     let message : StepMessage = { message : 'Evaluating One Step for You', validity : StepValidity.CORRECT, userInput : '' }
@@ -639,8 +607,7 @@ export default class ExerciseBox extends PureComponent<EvaluationProperties> {
 
     {
       const astCopy : AST = ast.clone()
-      const evaluator : Evaluator = new (strategyToEvaluator(strategy) as any)(astCopy)
-      
+      const evaluator : Evaluator = new (strategyToEvaluator(strategy))(astCopy)
       if (evaluator.nextReduction instanceof None) {
         const etaEvaluator : Evaluator = new OptimizeEvaluator(ast)
 
@@ -664,7 +631,6 @@ export default class ExerciseBox extends PureComponent<EvaluationProperties> {
 
     //   reportEvent('Evaluation Step', 'Step Normal Form Reached with Number or Macro', ast.toString())
     // }
-  
     setBoxState({
       ...state,
       editor : {
@@ -707,7 +673,6 @@ export default class ExerciseBox extends PureComponent<EvaluationProperties> {
     // ) {
     //   return true
     // }
-  
     return false
   }
 

--- a/src/untyped-lambda-integration/ExerciseBox.tsx
+++ b/src/untyped-lambda-integration/ExerciseBox.tsx
@@ -10,6 +10,7 @@ import {
   parse,
   OptimizeEvaluator,
   MacroMap,
+  OpenMacroDefinition,
 } from "@lambdulus/core"
 
 import './styles/EvaluatorBox.css'
@@ -34,7 +35,13 @@ export interface EvaluationProperties {
 
 // The exercise-step submitter reports parse failures locally, through
 // the editor error — same shape as the expression submitter above.
-function exerciseSyntaxError (content : string) : Error {
+function exerciseSyntaxError (content : string, exception : unknown = null) : Error {
+  // Core reports open macro definitions as a typed error carrying
+  // the macro name and its free variables -- show it as is.
+  if (exception instanceof OpenMacroDefinition) {
+    return Error(exception.message)
+  }
+
   let errorMessage : string = "Something is wrong with your expression. Please inspect it closely."
 
   if (content.match(/:=/g)?.length !== content.match(/;/g)?.length) {
@@ -232,7 +239,9 @@ export default class ExerciseBox extends PureComponent<EvaluationProperties> {
         }
       })
     } catch (exception) {
-      let errorMessage : string = "Something is wrong with your expression. Please inspect it closely."
+      let errorMessage : string = exception instanceof OpenMacroDefinition
+        ? exception.message
+        : "Something is wrong with your expression. Please inspect it closely."
       console.error((exception as Error).toString())
 
       if (content.match(/:=/g)?.length !== content.match(/;/g)?.length) {
@@ -359,7 +368,7 @@ export default class ExerciseBox extends PureComponent<EvaluationProperties> {
         ...state,
         editor : {
           ...state.editor,
-          syntaxError : exerciseSyntaxError(content),
+          syntaxError : exerciseSyntaxError(content, exception),
         }
       })
     }
@@ -477,7 +486,7 @@ export default class ExerciseBox extends PureComponent<EvaluationProperties> {
         ...state,
         editor : {
           ...state.editor,
-          syntaxError : exerciseSyntaxError(content),
+          syntaxError : exerciseSyntaxError(content, exception),
         }
       })
     }

--- a/src/untyped-lambda-integration/ExerciseBox.tsx
+++ b/src/untyped-lambda-integration/ExerciseBox.tsx
@@ -21,7 +21,7 @@ import { TreeComparator } from './TreeComparator'
 import InactiveEvaluator from './InactiveExpression'
 import Expression from './Expression'
 import { PromptPlaceholder, UntypedLambdaState, Evaluator, StepRecord, Breakpoint, UntypedLambdaType, StepMessage, StepValidity } from './Types'
-import { strategyToEvaluator, findSimplifiedReduction, MacroBeta, toMacroMap, tryMacroContraction } from './Constants'
+import { strategyToEvaluator, findSimplifiedReduction, MacroBeta, toMacroMap, tryMacroContraction, coreErrorMessage } from './Constants'
 
 
 export interface EvaluationProperties {
@@ -42,7 +42,10 @@ function exerciseSyntaxError (content : string, exception : unknown = null) : Er
     return Error(exception.message)
   }
 
-  let errorMessage : string = "Something is wrong with your expression. Please inspect it closely."
+  // Anything else falls back to core's own message.
+  let errorMessage : string = exception !== null && exception !== undefined
+    ? coreErrorMessage(exception)
+    : "Something is wrong with your expression. Please inspect it closely."
 
   if (content.match(/:=/g)?.length !== content.match(/;/g)?.length) {
     errorMessage = "Did you forget to write a semicolon after the Macro definition?"
@@ -241,8 +244,8 @@ export default class ExerciseBox extends PureComponent<EvaluationProperties> {
     } catch (exception) {
       let errorMessage : string = exception instanceof OpenMacroDefinition
         ? exception.message
-        : "Something is wrong with your expression. Please inspect it closely."
-      console.error((exception as Error).toString())
+        : coreErrorMessage(exception)
+      console.error(coreErrorMessage(exception))
 
       if (content.match(/:=/g)?.length !== content.match(/;/g)?.length) {
         errorMessage = "Did you forget to write a semicolon after the Macro definition?"
@@ -362,7 +365,7 @@ export default class ExerciseBox extends PureComponent<EvaluationProperties> {
         }
       })
     } catch (exception) {
-      console.error((exception as Error).toString())
+      console.error(coreErrorMessage(exception))
 
       setBoxState({
         ...state,
@@ -480,7 +483,7 @@ export default class ExerciseBox extends PureComponent<EvaluationProperties> {
         }
       })
     } catch (exception) {
-      console.error((exception as Error).toString())
+      console.error(coreErrorMessage(exception))
 
       setBoxState({
         ...state,

--- a/src/untyped-lambda-integration/ExpressionBox.tsx
+++ b/src/untyped-lambda-integration/ExpressionBox.tsx
@@ -78,7 +78,6 @@ export default class ExpressionBox extends PureComponent<EvaluationProperties> {
           strategy={ this.props.state.strategy }
           SDE={ SDE }
           macrotable={ macrotable }
-          
           createBoxFrom={ this.createBoxFrom }
         />
       )
@@ -216,7 +215,6 @@ export default class ExpressionBox extends PureComponent<EvaluationProperties> {
 
     //                                                    fix this part please
     let [nextReduction, evaluateReduction] : [ASTReduction, (ast : AST) => AST] = findSimplifiedReduction(ast, strategy, macrotable)
-    
     let message : StepMessage = { validity : StepValidity.CORRECT, userInput : '', message : '' }
     let isNowNormalForm = false
 
@@ -242,7 +240,6 @@ export default class ExpressionBox extends PureComponent<EvaluationProperties> {
         // this is what happens when ::single-step
         //
         newast = evaluateReduction(newast)
-        // debugger
 
         // if we are not ::single-step --> findSimplifiedReduction won't return MacroBeta -- instead
         // it will return the first redex --> first beta reduction in the list and then it's not macro reduction problem anymore
@@ -274,8 +271,7 @@ export default class ExpressionBox extends PureComponent<EvaluationProperties> {
     {
       const astCopy : AST = newast.clone()
       const [nextReduction] : [ASTReduction, (ast : AST) => AST] = findSimplifiedReduction(astCopy, strategy, macrotable)
-      // const evaluator : Evaluator = new (strategyToEvaluator(strategy) as any)(astCopy)
-      
+      // const evaluator : Evaluator = new (strategyToEvaluator(strategy))(astCopy)
       if (nextReduction instanceof None) {
         const etaEvaluator : Evaluator = new OptimizeEvaluator(astCopy)
         if (etaEvaluator.nextReduction instanceof None || ! ETA) {
@@ -291,68 +287,6 @@ export default class ExpressionBox extends PureComponent<EvaluationProperties> {
     })
 
     return
-    
-    // {
-    //   // None
-    //   // console.log("_________________________________ NONE")
-    //   // stepRecord.isNormalForm = true
-    //   // stepRecord.message = 'Expression is in normal form.'
-      
-    //   // setBoxState({
-    //   //   ...state,
-    //   // })
-      
-    //   // reportEvent('Evaluation Step', 'Step Normal Form Reached', ast.toString())
-
-    //   // return
-    // }
-    // {
-    //   // Expansion -> then None
-    //   // stepRecord.lastReduction = newreduction
-    //   // stepRecord.isNormalForm = true
-    //   // stepRecord.message = 'Expression is in normal form.'
-      
-    //   // setBoxState({
-    //   //   ...state,
-    //   // })
-      
-    //   // reportEvent('Evaluation Step', 'Step Normal Form Reached', ast.toString())
-
-    //   // return
-    // }
-    // {
-    //   // Expandion -> then Any ASTReduction inside the expanded Macro --> need to Expand first
-    //   // ast = newAst
-
-    //   // let message = ''
-    //   // let isNormal = false
-
-    //   // setBoxState({
-    //   //   ...state,
-    //   //   history : [ ...history, { ast, lastReduction, step : step + 1, message, isNormalForm : isNormal } ]
-    //   // })
-    //   // return
-    // }
-    // {
-    //   // Expansion -> then Any ASTReduction completely outside of Macro --> skip the Expansion and do the next thing instead
-    //   // ast = newevaluator.perform()
-    //   // const p = parent as AST
-    //   // const ts = treeSide as String
-    //   // (p as any)[ts as any] = M
-    //   // // parent should be not-null
-    //   // // because if there was a Macro which we were able to Expand
-    //   // // and then there has been found Redex which is not part of the newly expanded sub-tree
-    //   // // the new Redex simply has to be in different part of the tree --> which means - M (original Macro) is not the root
-
-    //   // let message = ''
-    //   // let isNormal = false
-
-    //   // setBoxState({
-    //   //   ...state,
-    //   //   history : [ ...history, { ast, lastReduction, step : step + 1, message, isNormalForm : isNormal } ]
-    //   // })
-    //   // return
-    // }
   }
 
   onStep () : void {
@@ -370,32 +304,27 @@ export default class ExpressionBox extends PureComponent<EvaluationProperties> {
     let { ast, lastReduction } = stepRecord
     ast = ast.clone()
 
-  
     if (isNormalForm) {
       return
     }
 
-    let evaluator : Evaluator = new (strategyToEvaluator(strategy) as any)(ast)
+    let evaluator : Evaluator = new (strategyToEvaluator(strategy))(ast)
     lastReduction = evaluator.nextReduction
-  
     if (evaluator.nextReduction instanceof None) {
       const etaEvaluator : Evaluator = new OptimizeEvaluator(ast)
 
       if (etaEvaluator.nextReduction instanceof None || ! ETA) {
         stepRecord.isNormalForm = true
         stepRecord.message.message = 'Expression is in normal form.'
-        
         setBoxState({
           ...state,
         })
-  
         return
       }
 
       evaluator = etaEvaluator
       lastReduction = etaEvaluator.nextReduction
     }
-  
     ast = evaluator.perform()
 
     let message : StepMessage = { validity : StepValidity.CORRECT, userInput : '', message : '' }
@@ -403,8 +332,7 @@ export default class ExpressionBox extends PureComponent<EvaluationProperties> {
 
     {
       const astCopy : AST = ast.clone()
-      const evaluator : Evaluator = new (strategyToEvaluator(strategy) as any)(astCopy)
-      
+      const evaluator : Evaluator = new (strategyToEvaluator(strategy))(astCopy)
       if (evaluator.nextReduction instanceof None) {
         const etaEvaluator : Evaluator = new OptimizeEvaluator(astCopy)
 
@@ -420,15 +348,6 @@ export default class ExpressionBox extends PureComponent<EvaluationProperties> {
     // TODO: Investigate more - and fix the functionality
     // it probably should check if the current AST Root is a Macro and next Reduction is Expansion of exactly this AST
     // then it can say - it is in the Normal Form - if some settings enables it - not by default though
-    //
-    // if (ast instanceof Macro || ast instanceof ChurchNumeral) {
-
-    //   stepRecord.isNormalForm = true
-    //   stepRecord.message = 'Expression is in normal form.'
-
-    //   reportEvent('Evaluation Step', 'Step Normal Form Reached with Number or Macro', ast.toString())
-    // }
-  
     setBoxState({
       ...state,
       history : [ ...history, { ast, lastReduction, step : step + 1, message, isNormalForm : isNormal, exerciseStep : false } ],
@@ -446,11 +365,9 @@ export default class ExpressionBox extends PureComponent<EvaluationProperties> {
     else {
       const { timeout, history } = state
       const stepRecord = history[history.length - 1]
-  
       if (stepRecord.isNormalForm) {
         return
       }
-      
       const { ast, step, lastReduction, isNormalForm } = stepRecord
       let msg : StepMessage = { validity : StepValidity.CORRECT, userInput : '', message : 'Skipping some steps...' }
       history.push(history[history.length - 1])
@@ -491,7 +408,6 @@ export default class ExpressionBox extends PureComponent<EvaluationProperties> {
         isRunning : false,
         timeoutID : undefined,
       })
-  
       return
     }
 
@@ -500,9 +416,8 @@ export default class ExpressionBox extends PureComponent<EvaluationProperties> {
     const [nextReduction, evaluateReduction] : [ASTReduction, (ast : AST) => AST] = findSimplifiedReduction(newast, strategy, macrotable)
 
 /////////////////////////////////////////////////////////////////////////////////////////
-    // const normal : Evaluator = new (strategyToEvaluator(strategy) as any)(ast)
+    // const normal : Evaluator = new (strategyToEvaluator(strategy))(ast)
     lastReduction = nextReduction
-    
     if (nextReduction instanceof None) {
       // #18: the simplified search is eta-blind -- before declaring normal
       // form, ask OptimizeEvaluator, mirroring onSimplifiedStep. If eta
@@ -533,20 +448,17 @@ export default class ExpressionBox extends PureComponent<EvaluationProperties> {
         isNormalForm : true,
         exerciseStep : false,
       })
-  
       setBoxState({
         ...state,
         isRunning : false,
         timeoutID : undefined,
       })
-  
       return
     }
 
     const arityBreakpoint : Breakpoint | undefined = breakpoints.find((brk : Breakpoint) => brk.type === ASTReductionType.GAMA && ! brk.broken.has((nextReduction as MacroBeta).applications[0]))
     if (nextReduction instanceof MacroBeta && nextReduction.arity !== nextReduction.applications.length && arityBreakpoint === undefined) {
       stepRecord.message.message = `Macro ${tryMacroContraction(nextReduction.applications[0].left, macrotable)} is given too few arguments.`
-    
       // completely same code as in breakpoint section -- TODO: refactor and unify pls
       window.clearTimeout(timeoutID)
 
@@ -561,7 +473,6 @@ export default class ExpressionBox extends PureComponent<EvaluationProperties> {
 
       return
     }
-  
     // TODO: maybe refactor a little
     const breakpoint : Breakpoint | undefined = breakpoints.find(
       (breakpoint : Breakpoint) =>
@@ -587,18 +498,10 @@ export default class ExpressionBox extends PureComponent<EvaluationProperties> {
 
       return
     }
-  
     ast = evaluateReduction(newast)
 
     history[history.length - 1] = { ast, lastReduction, step : step + 1, message : { validity : StepValidity.CORRECT, userInput : '', message : '' }, isNormalForm, exerciseStep : false }
 
-    // NOTE: Same thing as #0023
-    // if (ast instanceof Macro || ast instanceof ChurchNumeral) {
-    //   history[history.length - 1] = { ast, lastReduction, step : step + 1, message : 'Expression is in normal form.', isNormalForm : true }
-
-    //   reportEvent('Evaluation Run Ended', 'Step Normal Form Reached with Number or Macro', ast.toString())
-    // }
-    
     setBoxState({
       ...state,
       timeoutID : window.setTimeout(this.onSimplifiedRun, timeout)
@@ -616,21 +519,17 @@ export default class ExpressionBox extends PureComponent<EvaluationProperties> {
     if ( ! isRunning) {
       return
     }
-    
     if (isNormalForm) {
       setBoxState({
         ...state,
         isRunning : false,
         timeoutID : undefined,
       })
-  
       return
     }
-  
     let { ast } = stepRecord
-    let normal : Evaluator = new (strategyToEvaluator(strategy) as any)(ast)
+    let normal : Evaluator = new (strategyToEvaluator(strategy))(ast)
     lastReduction = normal.nextReduction
-    
     if (normal.nextReduction instanceof None) {
       // #18: the strategy search is eta-blind -- mirror onStep: continue
       // with a pending eta conversion instead of stopping.
@@ -660,7 +559,6 @@ export default class ExpressionBox extends PureComponent<EvaluationProperties> {
       normal = etaEvaluator
       lastReduction = etaEvaluator.nextReduction
     }
-  
     // TODO: maybe refactor a little
     const breakpoint : Breakpoint | undefined = breakpoints.find(
       (breakpoint : Breakpoint) =>
@@ -686,18 +584,10 @@ export default class ExpressionBox extends PureComponent<EvaluationProperties> {
 
       return
     }
-  
     ast = normal.perform()
 
     history[history.length - 1] = { ast, lastReduction, step : step + 1, message : { validity : StepValidity.CORRECT, userInput : '', message : '' }, isNormalForm, exerciseStep : false }
 
-    // NOTE: Same thing as #0023
-    // if (ast instanceof Macro || ast instanceof ChurchNumeral) {
-    //   history[history.length - 1] = { ast, lastReduction, step : step + 1, message : 'Expression is in normal form.', isNormalForm : true }
-
-    //   reportEvent('Evaluation Run Ended', 'Step Normal Form Reached with Number or Macro', ast.toString())
-    // }
-    
     setBoxState({
       ...state,
       timeoutID : window.setTimeout(this.onRun, timeout)
@@ -707,9 +597,7 @@ export default class ExpressionBox extends PureComponent<EvaluationProperties> {
   onStop () : void {
     const { state, setBoxState } = this.props
     const { timeoutID } = state
-  
     window.clearTimeout(timeoutID)
-  
     setBoxState({
       ...state,
       isRunning : false,
@@ -749,7 +637,6 @@ export default class ExpressionBox extends PureComponent<EvaluationProperties> {
     ) {
       return true
     }
-  
     return false
   }
 

--- a/src/untyped-lambda-integration/ReactPrinter.tsx
+++ b/src/untyped-lambda-integration/ReactPrinter.tsx
@@ -93,7 +93,6 @@ export default class ReactPrinter extends ASTVisitor {
           </span>
         </span>
       )
-      
       this.printMultiLambda(lambda.body, args)
       if (set === true) {
         this.argument = null
@@ -162,7 +161,6 @@ export default class ReactPrinter extends ASTVisitor {
       //   redexFoundFlag = true
       //   debugger
       // }
-      
       //  === 1 && 
       if (this.redexesFound < this.reduction.arity && this.reduction.applications.some((app : Application) => app.identifier === application.identifier)) {
         if (application.left instanceof Macro) {
@@ -170,7 +168,6 @@ export default class ReactPrinter extends ASTVisitor {
         }
 
         this.redexesFound++
-        
         rightClassName += ' extended-redex'
       }
     }
@@ -238,7 +235,6 @@ export default class ReactPrinter extends ASTVisitor {
       </span>
     }
   }
-  
   // TODO: little bit refactored, maybe keep going
   onLambda (lambda: Lambda) : void {
     // TODO: this also seems not so elegant and clean
@@ -295,7 +291,6 @@ export default class ReactPrinter extends ASTVisitor {
       const context : Variable = lambda.argument
 
       // lambda.argument.visit(this)
-      
       // const args : JSX.Element | null = this.rendered
 
       lambda.body.visit(this)
@@ -358,7 +353,6 @@ export default class ReactPrinter extends ASTVisitor {
       this.argument = argument
     }
   }
-  
   // TODO: little bit refactored, maybe keep going
   onChurchNumeral (churchNumber: ChurchNumeral) : void {
     let className : string = 'churchnumeral'
@@ -427,7 +421,6 @@ export default class ReactPrinter extends ASTVisitor {
     }
 
     if (this.reduction instanceof MacroBeta) {
-      
       if (macro.identifier === this.reduction.applications[0].left.identifier) {
         className += ' abstraction'
       }
@@ -463,7 +456,6 @@ export default class ReactPrinter extends ASTVisitor {
       </span>
     )
   }
-  
   onVariable (variable: Variable): void {
     // TODO: same here - not so clean
     let className : string = 'variable'

--- a/src/untyped-lambda-integration/ReductionMessage.tsx
+++ b/src/untyped-lambda-integration/ReductionMessage.tsx
@@ -56,5 +56,4 @@ export default function ReductionMessage (props : ReductionMessageProperties) : 
   else {
     return null as any
   }
-  
 }

--- a/src/untyped-lambda-integration/Settings.test.tsx
+++ b/src/untyped-lambda-integration/Settings.test.tsx
@@ -113,3 +113,11 @@ test('toggle labels nudge up to the track center', () => {
   const label = css.match(/\.untyped-lambda-settings-label\s*\{[^}]*\}/)?.[0] ?? '';
   expect(label).toMatch(/transform\s*:\s*translateY\(-1px\)/);
 });
+
+test('strategy pills ignore the label nudge', () => {
+  // The shared label lift would unseat the active pill inside its
+  // segment; symmetric pills opt back out of it.
+  const css = readFileSync('src/untyped-lambda-integration/styles/Settings.css', 'utf8');
+  const pill = css.match(/\.untyped-lambda-settings--strategy-radio-wrapper \.untyped-lambda-settings-label\s*\{[^}]*\}/)?.[0] ?? '';
+  expect(pill).toMatch(/transform\s*:\s*none/);
+});

--- a/src/untyped-lambda-integration/Settings.test.tsx
+++ b/src/untyped-lambda-integration/Settings.test.tsx
@@ -85,6 +85,9 @@ test('restart offer stands alone with breathing room', () => {
   expect(button).toMatch(/font-size\s*:\s*0\.9em/);
   expect(button).toMatch(/border\s*:[^;]*var\(--accent\)/);
   expect(button).not.toMatch(/background-color\s*:\s*var\(--accent\)/);
+  const hover = css.match(/\.untyped-lambda-settings-restart-button:hover\s*\{[^}]*\}/)?.[0] ?? '';
+  expect(hover).toMatch(/background-color\s*:\s*var\(--accent\)/);
+  expect(hover).toMatch(/color\s*:\s*var\(--accent-ink\)/);
 });
 
 test('switch toggles have track, thumb, and on paint', () => {

--- a/src/untyped-lambda-integration/Settings.test.tsx
+++ b/src/untyped-lambda-integration/Settings.test.tsx
@@ -80,9 +80,25 @@ test('restart offer stands alone with breathing room', () => {
   const css = readFileSync('src/untyped-lambda-integration/styles/Settings.css', 'utf8');
   const row = css.match(/\.untyped-lambda-settings-restart-row\s*\{[^}]*\}/)?.[0] ?? '';
   expect(row).toMatch(/justify-content\s*:\s*flex-end/);
-  expect(row).toMatch(/margin\s*:\s*12px 8px 0 0/);
+  expect(row).toMatch(/margin\s*:\s*40px 8px 0 0/);
   const button = css.match(/\.untyped-lambda-settings-restart-button\s*\{[^}]*\}/)?.[0] ?? '';
   expect(button).toMatch(/font-size\s*:\s*0\.9em/);
   expect(button).toMatch(/border\s*:[^;]*var\(--accent\)/);
   expect(button).not.toMatch(/background-color\s*:\s*var\(--accent\)/);
+});
+
+test('switch toggles have track, thumb, and on paint', () => {
+  // The button toggles (Simplified, global delete confirmation) share
+  // these classes; without paint they render as bare browser buttons.
+  // Geometry matches the painted checkbox switches (34x20 track).
+  const css = readFileSync('src/untyped-lambda-integration/styles/Settings.css', 'utf8');
+  const track = css.match(/\.untyped-lambda-settings--toggle\s*\{[^}]*\}/)?.[0] ?? '';
+  expect(track).toMatch(/width\s*:\s*34px/);
+  expect(track).toMatch(/height\s*:\s*20px/);
+  expect(track).toMatch(/border-radius\s*:\s*999px/);
+  const on = css.match(/\.untyped-lambda-settings--toggle-on\s*\{[^}]*\}/)?.[0] ?? '';
+  expect(on).toMatch(/background-color\s*:\s*var\(--accent\)/);
+  const thumb = css.match(/\.untyped-lambda-settings--toggle-thumb\s*\{[^}]*\}/)?.[0] ?? '';
+  expect(thumb).toMatch(/border-radius\s*:\s*50%/);
+  expect(thumb).toMatch(/background-color\s*:\s*var\(--muted\)/);
 });

--- a/src/untyped-lambda-integration/Settings.test.tsx
+++ b/src/untyped-lambda-integration/Settings.test.tsx
@@ -74,17 +74,15 @@ test('eta toggle reflects the setting and reports turning it on', () => {
   expect(change).toHaveBeenCalledWith({ ...baseSettings, ETA : true });
 });
 
-test('restart offer sits inline in the panel type scale', () => {
-  // One row with the strategy radios: muted label beside an outlined
-  // button, everything at the 0.9em label size, no filled accent.
+test('restart offer stands alone with breathing room', () => {
+  // One wide outlined button on its own right-aligned row below the
+  // strategies: headroom above, air from the panel edge, no fill.
   const css = readFileSync('src/untyped-lambda-integration/styles/Settings.css', 'utf8');
-  const row = css.match(/\.untyped-lambda-settings-restart\s*\{[^}]*\}/)?.[0] ?? '';
-  expect(row).not.toMatch(/flex-direction\s*:\s*column/);
-  expect(row).toMatch(/align-items\s*:\s*center/);
-  const label = css.match(/\.untyped-lambda-settings-restart-label\s*\{[^}]*\}/)?.[0] ?? '';
-  expect(label).toMatch(/font-size\s*:\s*0\.9em/);
+  const row = css.match(/\.untyped-lambda-settings-restart-row\s*\{[^}]*\}/)?.[0] ?? '';
+  expect(row).toMatch(/justify-content\s*:\s*flex-end/);
+  expect(row).toMatch(/margin\s*:\s*12px 8px 0 0/);
   const button = css.match(/\.untyped-lambda-settings-restart-button\s*\{[^}]*\}/)?.[0] ?? '';
-  expect(button).toMatch(/font-size\s*:\s*0\.8em/);
+  expect(button).toMatch(/font-size\s*:\s*0\.9em/);
   expect(button).toMatch(/border\s*:[^;]*var\(--accent\)/);
   expect(button).not.toMatch(/background-color\s*:\s*var\(--accent\)/);
 });

--- a/src/untyped-lambda-integration/Settings.test.tsx
+++ b/src/untyped-lambda-integration/Settings.test.tsx
@@ -105,3 +105,11 @@ test('switch toggles have track, thumb, and on paint', () => {
   expect(thumb).toMatch(/border-radius\s*:\s*50%/);
   expect(thumb).toMatch(/background-color\s*:\s*var\(--muted\)/);
 });
+
+test('toggle labels nudge up to the track center', () => {
+  // The font metrics sit glyphs a hair below the flex-given center
+  // next to the 20px switches; the shared label class compensates.
+  const css = readFileSync('src/untyped-lambda-integration/styles/Settings.css', 'utf8');
+  const label = css.match(/\.untyped-lambda-settings-label\s*\{[^}]*\}/)?.[0] ?? '';
+  expect(label).toMatch(/transform\s*:\s*translateY\(-1px\)/);
+});

--- a/src/untyped-lambda-integration/Settings.test.tsx
+++ b/src/untyped-lambda-integration/Settings.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { readFileSync } from 'fs';
 import { test, expect, vi, afterEach } from 'vitest';
 import { render, fireEvent, cleanup } from '@testing-library/react';
 import Settings from './Settings';
@@ -71,4 +72,19 @@ test('eta toggle reflects the setting and reports turning it on', () => {
 
   fireEvent.click(checkbox);
   expect(change).toHaveBeenCalledWith({ ...baseSettings, ETA : true });
+});
+
+test('restart offer sits inline in the panel type scale', () => {
+  // One row with the strategy radios: muted label beside an outlined
+  // button, everything at the 0.9em label size, no filled accent.
+  const css = readFileSync('src/untyped-lambda-integration/styles/Settings.css', 'utf8');
+  const row = css.match(/\.untyped-lambda-settings-restart\s*\{[^}]*\}/)?.[0] ?? '';
+  expect(row).not.toMatch(/flex-direction\s*:\s*column/);
+  expect(row).toMatch(/align-items\s*:\s*center/);
+  const label = css.match(/\.untyped-lambda-settings-restart-label\s*\{[^}]*\}/)?.[0] ?? '';
+  expect(label).toMatch(/font-size\s*:\s*0\.9em/);
+  const button = css.match(/\.untyped-lambda-settings-restart-button\s*\{[^}]*\}/)?.[0] ?? '';
+  expect(button).toMatch(/font-size\s*:\s*0\.9em/);
+  expect(button).toMatch(/border\s*:[^;]*var\(--accent\)/);
+  expect(button).not.toMatch(/background-color\s*:\s*var\(--accent\)/);
 });

--- a/src/untyped-lambda-integration/Settings.test.tsx
+++ b/src/untyped-lambda-integration/Settings.test.tsx
@@ -84,7 +84,7 @@ test('restart offer sits inline in the panel type scale', () => {
   const label = css.match(/\.untyped-lambda-settings-restart-label\s*\{[^}]*\}/)?.[0] ?? '';
   expect(label).toMatch(/font-size\s*:\s*0\.9em/);
   const button = css.match(/\.untyped-lambda-settings-restart-button\s*\{[^}]*\}/)?.[0] ?? '';
-  expect(button).toMatch(/font-size\s*:\s*0\.9em/);
+  expect(button).toMatch(/font-size\s*:\s*0\.8em/);
   expect(button).toMatch(/border\s*:[^;]*var\(--accent\)/);
   expect(button).not.toMatch(/background-color\s*:\s*var\(--accent\)/);
 });

--- a/src/untyped-lambda-integration/Settings.tsx
+++ b/src/untyped-lambda-integration/Settings.tsx
@@ -43,7 +43,6 @@ export default function Settings (props : Props) : JSX.Element {
               checked={ SLI }
               disabled={ false } // TODO: tohle bude rozhodne chtit prepsat
               // shape="fill"
-              
               onChange={
                 (e : ChangeEvent<HTMLInputElement>) => // tady nejakej destructuring
                   change({ ...settings, SLI : e.target.checked })
@@ -67,7 +66,6 @@ export default function Settings (props : Props) : JSX.Element {
             checked={ SDE }
             disabled={ false }
             // shape="fill"
-            
             onChange={
               (e : ChangeEvent<HTMLInputElement>) => // tady nejakej destructuring
                 change({ ...settings, SDE : e.target.checked })
@@ -131,7 +129,6 @@ export default function Settings (props : Props) : JSX.Element {
               type='checkbox'
               checked={ expandStandalones }
               disabled={ false } // TODO: tohle bude rozhodne chtit prepsat
-              
               onChange={
                 (e : ChangeEvent<HTMLInputElement>) => {
                   // tady nejakej destructuring
@@ -180,7 +177,6 @@ export default function Settings (props : Props) : JSX.Element {
                 checked={
                   strategy === EvaluationStrategy.APPLICATIVE
                 }
-                
                 onChange={
                   () => change({ ...settings, strategy : EvaluationStrategy.APPLICATIVE })
                 }

--- a/src/untyped-lambda-integration/Settings.tsx
+++ b/src/untyped-lambda-integration/Settings.tsx
@@ -149,6 +149,7 @@ export default function Settings (props : Props) : JSX.Element {
 
       {
         strat_E ?
+          <React.Fragment>
           <div className='untyped-lambda-settings-strategies'>
             <p className='stratsLabel'>Evaluation Strategies:</p>
 
@@ -189,25 +190,24 @@ export default function Settings (props : Props) : JSX.Element {
               </label>
             </span>
             </span>
-            {
-              // The session was stepped under different settings: offer
-              // to reparse and resubmit from scratch with the current ones.
-              restartNeeded === true && onRestart !== undefined ?
-                <span className='untyped-lambda-settings-restart'>
-                  <span className='untyped-lambda-settings-restart-label'>
-                    Settings changed
-                  </span>
-                  <button
-                    className='untyped-lambda-settings-restart-button'
-                    onClick={ onRestart }
-                  >
-                    Restart?
-                  </button>
-                </span>
-              :
-                null
-            }
           </div>
+          {
+            // The session was stepped under different settings: one wide
+            // button on its own breathing-room row to reparse and
+            // resubmit from scratch with the current ones.
+            restartNeeded === true && onRestart !== undefined ?
+              <div className='untyped-lambda-settings-restart-row'>
+                <button
+                  className='untyped-lambda-settings-restart-button'
+                  onClick={ onRestart }
+                >
+                  Settings changed, restart?
+                </button>
+              </div>
+            :
+              null
+          }
+          </React.Fragment>
         :
           null
     }

--- a/src/untyped-lambda-integration/Settings.tsx
+++ b/src/untyped-lambda-integration/Settings.tsx
@@ -7,12 +7,14 @@ import './styles/Settings.css'
 interface Props {
   settings : UntypedLambdaSettings
   settingsEnabled : SettingsEnabled
+  restartNeeded? : boolean
 
   change : (settings : UntypedLambdaSettings) => void
+  onRestart? : () => void
 }
 
 export default function Settings (props : Props) : JSX.Element {
-  const { settings, change, settingsEnabled } : Props = props
+  const { settings, change, settingsEnabled, restartNeeded, onRestart } : Props = props
   const { SLI, expandStandalones, strategy, SDE, ETA, collapseOldSteps } : UntypedLambdaSettings = settings
   const { SLI : SLI_E, expandStandalones : expSt_E, strategy : strat_E } : SettingsEnabled = settingsEnabled
 
@@ -187,6 +189,24 @@ export default function Settings (props : Props) : JSX.Element {
               </label>
             </span>
             </span>
+            {
+              // The session was stepped under different settings: offer
+              // to reparse and resubmit from scratch with the current ones.
+              restartNeeded === true && onRestart !== undefined ?
+                <span className='untyped-lambda-settings-restart'>
+                  <span className='untyped-lambda-settings-restart-label'>
+                    Settings changed
+                  </span>
+                  <button
+                    className='untyped-lambda-settings-restart-button'
+                    onClick={ onRestart }
+                  >
+                    Restart?
+                  </button>
+                </span>
+              :
+                null
+            }
           </div>
         :
           null

--- a/src/untyped-lambda-integration/Step.tsx
+++ b/src/untyped-lambda-integration/Step.tsx
@@ -56,7 +56,7 @@ function Step (props : StepProperties) : JSX.Element | null {
       return findSimplifiedReduction(newast, strategy, macrotable)[0]
     }
     else {
-      const evaluator : Evaluator = new (strategyToEvaluator(strategy) as any)(tree)
+      const evaluator : Evaluator = new (strategyToEvaluator(strategy))(tree)
       return evaluator.nextReduction
     }
   })()
@@ -75,7 +75,7 @@ function Step (props : StepProperties) : JSX.Element | null {
     // if it's the normal stuff --> then the tree I used to identify the redex is not the same tree as I am giving to the ReactPrinter
     // for this reason I have to use redex finder which does not mutate the tree under my hands at least until I rewrite
     // the findSimplifiedReduction
-    const evaluator : Evaluator = new (strategyToEvaluator(strategy) as any)(tree)
+    const evaluator : Evaluator = new (strategyToEvaluator(strategy))(tree)
     nextReduction = evaluator.nextReduction
     // TODO: read carefully
     // this definitely needs to be fixed

--- a/src/untyped-lambda-integration/TreeComparator.ts
+++ b/src/untyped-lambda-integration/TreeComparator.ts
@@ -37,7 +37,6 @@ export class TreeComparator {
     it will also have implemented query methods,
     probably wont be many of them, just few
     **/
-    
     const [ left, right ] : Pair<AST> = this.context
 
     if (left instanceof Lambda && right instanceof Lambda) {

--- a/src/untyped-lambda-integration/Types.ts
+++ b/src/untyped-lambda-integration/Types.ts
@@ -50,6 +50,17 @@ export enum EvaluationStrategy {
   ABSTRACTION = 'Abstraction / Simplified Evaluation'
 }
 
+// The evaluation settings a session was submitted with. A submitted box
+// whose current strategy/SLI/SDE differ was stepped under different
+// rules, so the panel offers a restart. ETA is recorded but never
+// dirties: it has its own at-normal-form behavior.
+export interface SubmittedSettings {
+  strategy : EvaluationStrategy
+  SLI : boolean
+  SDE : boolean
+  ETA : boolean
+}
+
 export interface UntypedLambdaState extends AbstractBoxState {
   __key : string
   type : BoxType
@@ -69,6 +80,7 @@ export interface UntypedLambdaState extends AbstractBoxState {
   SLI : boolean
   expandStandalones : boolean
   collapseOldSteps : boolean
+  submittedWith? : SubmittedSettings
 
   macrolistOpen : boolean
   // The dock the user asked for: set by the dock head and the tour, never

--- a/src/untyped-lambda-integration/Types.ts
+++ b/src/untyped-lambda-integration/Types.ts
@@ -1,5 +1,6 @@
 import { AbstractSettings, BoxType, AbstractBoxState } from "../Types"
-import { AST, ASTReduction, ASTReductionType, NormalEvaluator, ApplicativeEvaluator, OptimizeEvaluator, MacroMap } from "@lambdulus/core"
+import { AST, ASTReduction, ASTReductionType, MacroMap } from "@lambdulus/core"
+export type { Evaluator } from "@lambdulus/core"
 
 
 export enum PromptPlaceholder {
@@ -73,7 +74,6 @@ export interface UntypedLambdaState extends AbstractBoxState {
   breakpoints : Array<Breakpoint>
   timeoutID : number | undefined
   timeout : number
-  
   strategy : EvaluationStrategy
   SDE : boolean // Semantics Drive Evaluation (Strategy) -- formerly called Simplified Strategy
   ETA : boolean // Eta conversion as the final evaluation step (opt-in, off by default)
@@ -89,7 +89,6 @@ export interface UntypedLambdaState extends AbstractBoxState {
   // shut across refocus, and old notebooks (field absent) stay shut too.
   macrolistWanted? : boolean
   macrotable : MacroMap
-  
   editor : {
     placeholder : string
     content : string
@@ -112,4 +111,4 @@ export type SettingsEnabled = {
   strategy : boolean
 }
 
-export type Evaluator = NormalEvaluator | ApplicativeEvaluator | OptimizeEvaluator
+

--- a/src/untyped-lambda-integration/UntypedLambdaBox.test.tsx
+++ b/src/untyped-lambda-integration/UntypedLambdaBox.test.tsx
@@ -491,3 +491,31 @@ test('eta toggle before normal form just applies', () => {
     unmount();
   }
 });
+
+test('unbalanced input surfaces core paren messages', () => {
+  const missing = createNewUntypedLambdaExpression(defaultSettings);
+  missing.editor.content = '((x)';
+  const first = render(<Harness initial={ missing } />);
+  try {
+    fireEvent.click(first.container.querySelector('.open-as-debug') as HTMLElement);
+    expect(lastState().editor.syntaxError?.message).toBe(
+      'It seems like you forgot to write one or more closing parentheses.'
+    );
+  }
+  finally {
+    first.unmount();
+  }
+
+  const stray = createNewUntypedLambdaExpression(defaultSettings);
+  stray.editor.content = 'x )';
+  const second = render(<Harness initial={ stray } />);
+  try {
+    fireEvent.click(second.container.querySelector('.open-as-debug') as HTMLElement);
+    expect(lastState().editor.syntaxError?.message).toBe(
+      'It seems you have one or more closing parenthesis not matching.'
+    );
+  }
+  finally {
+    second.unmount();
+  }
+});

--- a/src/untyped-lambda-integration/UntypedLambdaBox.test.tsx
+++ b/src/untyped-lambda-integration/UntypedLambdaBox.test.tsx
@@ -4,7 +4,7 @@ import { act, render, fireEvent, cleanup } from '@testing-library/react';
 import { tokenize, parse, None } from '@lambdulus/core';
 import UntypedLambdaBox from './UntypedLambdaBox';
 import { createNewUntypedLambdaExpression, defaultSettings, CODE_NAME as UNTYPED_CODE_NAME, SETTINGS_OPENED_EVENT } from './Constants';
-import { UntypedLambdaState, UntypedLambdaType, StepValidity } from './Types';
+import { EvaluationStrategy, UntypedLambdaState, UntypedLambdaType, StepValidity } from './Types';
 
 afterEach(() => cleanup());
 
@@ -353,6 +353,140 @@ test('submitting closed macros still works, aliases included', () => {
     fireEvent.click(container.querySelector('.open-as-debug') as HTMLElement);
     expect(lastState().editor.syntaxError).toBeNull();
     expect(lastState().subtype).toBe(UntypedLambdaType.ORDINARY);
+  }
+  finally {
+    unmount();
+  }
+});
+
+function settingsHarness (initial : UntypedLambdaState) {
+  // Like Harness but with the settings panel openable mid-session: the
+  // state setter escapes so the test can open the panel and flip toggles.
+  let set : (state : UntypedLambdaState) => void = () => void 0;
+  function H () {
+    const [ state, setState ] = useState(initial);
+    set = setState;
+    (globalThis as { __lastState ?: UntypedLambdaState }).__lastState = state;
+    return (
+      <UntypedLambdaBox
+        state={ state }
+        isActive={ true }
+        isFocused={ true }
+        isAnchorBox={ true }
+        setBoxState={ setState }
+        addBox={ () => void 0 }
+      />
+    );
+  }
+  const utils = render(<H />);
+  return { ...utils, setState : (updater : (state : UntypedLambdaState) => UntypedLambdaState) => act(() => set(updater((globalThis as { __lastState ?: UntypedLambdaState }).__lastState as UntypedLambdaState))) };
+}
+
+test('strategy flip after submit offers restart, flip-back retracts it', () => {
+  const initial = createNewUntypedLambdaExpression(defaultSettings);
+  initial.editor.content = '+ 2 3';
+  const { container, unmount, setState, getByLabelText } = settingsHarness(initial);
+  try {
+    fireEvent.click(container.querySelector('.open-as-debug') as HTMLElement);
+    expect(lastState().editor.syntaxError).toBeNull();
+    expect(container.querySelector('.untyped-lambda-settings-restart')).toBeNull();
+
+    setState((s) => ({ ...s, settingsOpen : true }));
+    expect(container.querySelector('.untyped-lambda-settings-restart')).toBeNull();
+
+    fireEvent.click(getByLabelText('Applicative'));
+    const offer = container.querySelector('.untyped-lambda-settings-restart');
+    expect(offer).not.toBeNull();
+    expect(offer?.querySelector('.untyped-lambda-settings-restart-label')?.textContent).toBe('Settings changed');
+    expect(offer?.querySelector('.untyped-lambda-settings-restart-button')?.textContent).toBe('Restart?');
+
+    fireEvent.click(getByLabelText('Normal'));
+    expect(container.querySelector('.untyped-lambda-settings-restart')).toBeNull();
+  }
+  finally {
+    unmount();
+  }
+});
+
+test('restart resubmits from step zero with the current settings', () => {
+  const initial = createNewUntypedLambdaExpression(defaultSettings);
+  initial.editor.content = '+ 2 3';
+  const { container, unmount, setState, getByLabelText } = settingsHarness(initial);
+  try {
+    fireEvent.click(container.querySelector('.open-as-debug') as HTMLElement);
+    setState((s) => ({ ...s, settingsOpen : true }));
+    fireEvent.click(getByLabelText('Applicative'));
+    expect(container.querySelector('.untyped-lambda-settings-restart-button')).not.toBeNull();
+
+    fireEvent.click(container.querySelector('.untyped-lambda-settings-restart-button') as HTMLElement);
+    const restarted = lastState();
+    expect(restarted.history.length).toBe(1);
+    expect(restarted.history[0].step).toBe(0);
+    expect(restarted.submittedWith?.strategy).toBe(EvaluationStrategy.APPLICATIVE);
+    expect(container.querySelector('.untyped-lambda-settings-restart')).toBeNull();
+  }
+  finally {
+    unmount();
+  }
+});
+
+test('enabling eta at normal form reopens stepping without stepping', () => {
+  const initial = createNewUntypedLambdaExpression(defaultSettings);
+  initial.editor.content = '(λ x . y x)';
+  const { container, unmount, setState } = settingsHarness(initial);
+  try {
+    fireEvent.click(container.querySelector('.open-as-debug') as HTMLElement);
+    expect(lastState().history[0].isNormalForm).toBe(true);
+
+    setState((s) => ({ ...s, settingsOpen : true }));
+    fireEvent.click(container.querySelector('.untyped-lambda-settings-ETA input') as HTMLElement);
+
+    const reopened = lastState();
+    expect(reopened.ETA).toBe(true);
+    expect(reopened.history.length).toBe(1);
+    expect(reopened.history[0].isNormalForm).toBe(false);
+  }
+  finally {
+    unmount();
+  }
+});
+
+test('enabling eta at an eta-less normal form changes nothing', () => {
+  const initial = createNewUntypedLambdaExpression(defaultSettings);
+  initial.editor.content = '(λ x . x)';
+  const { container, unmount, setState } = settingsHarness(initial);
+  try {
+    fireEvent.click(container.querySelector('.open-as-debug') as HTMLElement);
+    expect(lastState().history[0].isNormalForm).toBe(true);
+
+    setState((s) => ({ ...s, settingsOpen : true }));
+    fireEvent.click(container.querySelector('.untyped-lambda-settings-ETA input') as HTMLElement);
+
+    const state = lastState();
+    expect(state.ETA).toBe(true);
+    expect(state.history.length).toBe(1);
+    expect(state.history[0].isNormalForm).toBe(true);
+  }
+  finally {
+    unmount();
+  }
+});
+
+test('eta toggle before normal form just applies', () => {
+  const initial = createNewUntypedLambdaExpression(defaultSettings);
+  initial.editor.content = '+ 1 2';
+  const { container, unmount, setState } = settingsHarness(initial);
+  try {
+    fireEvent.click(container.querySelector('.open-as-debug') as HTMLElement);
+    expect(lastState().history[0].isNormalForm).toBe(false);
+
+    setState((s) => ({ ...s, settingsOpen : true }));
+    fireEvent.click(container.querySelector('.untyped-lambda-settings-ETA input') as HTMLElement);
+
+    const state = lastState();
+    expect(state.ETA).toBe(true);
+    expect(state.history.length).toBe(1);
+    expect(state.history[0].isNormalForm).toBe(false);
   }
   finally {
     unmount();

--- a/src/untyped-lambda-integration/UntypedLambdaBox.test.tsx
+++ b/src/untyped-lambda-integration/UntypedLambdaBox.test.tsx
@@ -322,3 +322,39 @@ test('exercise created at an eta-redex is not marked normal', () => {
     unmount();
   }
 });
+
+test('submitting an open macro definition shows the core error', () => {
+  // TEST := x y would capture x under a lambda at the use site; core
+  // rejects the definition with OpenMacroDefinition (name + free vars)
+  // and the box surfaces that message instead of a generic hint.
+  const initial = createNewUntypedLambdaExpression(defaultSettings);
+  initial.editor.content = 'TEST := x y ; (λ x y . x y) TEST';
+
+  const { container, unmount } = render(<Harness initial={ initial } />);
+  try {
+    fireEvent.click(container.querySelector('.open-as-debug') as HTMLElement);
+    const error = lastState().editor.syntaxError;
+    expect(error).not.toBeNull();
+    expect(error?.message).toContain('"TEST"');
+    expect(error?.message).toContain('x, y');
+    expect(container.querySelector('.editorError')).not.toBeNull();
+  }
+  finally {
+    unmount();
+  }
+});
+
+test('submitting closed macros still works, aliases included', () => {
+  const initial = createNewUntypedLambdaExpression(defaultSettings);
+  initial.editor.content = 'ID := (λ x . x) ; ALSO := ID ; ALSO 5';
+
+  const { container, unmount } = render(<Harness initial={ initial } />);
+  try {
+    fireEvent.click(container.querySelector('.open-as-debug') as HTMLElement);
+    expect(lastState().editor.syntaxError).toBeNull();
+    expect(lastState().subtype).toBe(UntypedLambdaType.ORDINARY);
+  }
+  finally {
+    unmount();
+  }
+});

--- a/src/untyped-lambda-integration/UntypedLambdaBox.test.tsx
+++ b/src/untyped-lambda-integration/UntypedLambdaBox.test.tsx
@@ -389,19 +389,18 @@ test('strategy flip after submit offers restart, flip-back retracts it', () => {
   try {
     fireEvent.click(container.querySelector('.open-as-debug') as HTMLElement);
     expect(lastState().editor.syntaxError).toBeNull();
-    expect(container.querySelector('.untyped-lambda-settings-restart')).toBeNull();
+    expect(container.querySelector('.untyped-lambda-settings-restart-row')).toBeNull();
 
     setState((s) => ({ ...s, settingsOpen : true }));
-    expect(container.querySelector('.untyped-lambda-settings-restart')).toBeNull();
+    expect(container.querySelector('.untyped-lambda-settings-restart-row')).toBeNull();
 
     fireEvent.click(getByLabelText('Applicative'));
-    const offer = container.querySelector('.untyped-lambda-settings-restart');
+    const offer = container.querySelector('.untyped-lambda-settings-restart-row');
     expect(offer).not.toBeNull();
-    expect(offer?.querySelector('.untyped-lambda-settings-restart-label')?.textContent).toBe('Settings changed');
-    expect(offer?.querySelector('.untyped-lambda-settings-restart-button')?.textContent).toBe('Restart?');
+    expect(offer?.querySelector('.untyped-lambda-settings-restart-button')?.textContent).toBe('Settings changed, restart?');
 
     fireEvent.click(getByLabelText('Normal'));
-    expect(container.querySelector('.untyped-lambda-settings-restart')).toBeNull();
+    expect(container.querySelector('.untyped-lambda-settings-restart-row')).toBeNull();
   }
   finally {
     unmount();
@@ -423,7 +422,7 @@ test('restart resubmits from step zero with the current settings', () => {
     expect(restarted.history.length).toBe(1);
     expect(restarted.history[0].step).toBe(0);
     expect(restarted.submittedWith?.strategy).toBe(EvaluationStrategy.APPLICATIVE);
-    expect(container.querySelector('.untyped-lambda-settings-restart')).toBeNull();
+    expect(container.querySelector('.untyped-lambda-settings-restart-row')).toBeNull();
   }
   finally {
     unmount();

--- a/src/untyped-lambda-integration/UntypedLambdaBox.tsx
+++ b/src/untyped-lambda-integration/UntypedLambdaBox.tsx
@@ -9,7 +9,7 @@ import { GLOBAL_SETTINGS_ENABLER, strategyToEvaluator, findSimplifiedReduction, 
 import ExerciseBox from './ExerciseBox'
 import Settings from './Settings'
 import EmptyExpression from './EmptyExpression'
-import { None, Evaluator, Token, tokenize, parse, AST, OptimizeEvaluator, MacroMap } from '@lambdulus/core'
+import { None, Evaluator, Token, tokenize, parse, AST, OptimizeEvaluator, MacroMap, OpenMacroDefinition } from '@lambdulus/core'
 
 
 interface Props {
@@ -312,7 +312,11 @@ export default class UntypedLambdaBox extends PureComponent<Props, State> {
         }
       })
     } catch (exception) {
-      let errorMessage : string = "Something is wrong with your expression. Please inspect it closely."
+      // Core reports open macro definitions as a typed error carrying
+      // the macro name and its free variables -- show it as is.
+      let errorMessage : string = exception instanceof OpenMacroDefinition
+        ? exception.message
+        : "Something is wrong with your expression. Please inspect it closely."
       console.error((exception as Error).toString())
 
       // if (errorMessage === "Error") {

--- a/src/untyped-lambda-integration/UntypedLambdaBox.tsx
+++ b/src/untyped-lambda-integration/UntypedLambdaBox.tsx
@@ -137,7 +137,15 @@ export default class UntypedLambdaBox extends PureComponent<Props, State> {
 
   render () {
     const { state, isActive, isFocused, isAnchorBox, setBoxState, addBox, titleActionsHost } : Props = this.props
-    const { settingsOpen, subtype, macrolistOpen, SLI, expandStandalones, strategy, SDE, ETA, collapseOldSteps, editor, minimized } : UntypedLambdaState = state
+    const { settingsOpen, subtype, macrolistOpen, SLI, expandStandalones, strategy, SDE, ETA, collapseOldSteps, editor, minimized, history, submittedWith } : UntypedLambdaState = state
+
+    // A submitted session stepped under different strategy/SLI/SDE can
+    // restart from scratch with the current ones. ETA never dirties:
+    // it reopens stepping at normal form on its own.
+    const restartNeeded : boolean =
+      (history ?? []).length > 0
+      && submittedWith !== undefined
+      && (submittedWith.strategy !== strategy || submittedWith.SLI !== SLI || submittedWith.SDE !== SDE)
 
 
     const renderBoxContent = () => {
@@ -201,8 +209,32 @@ export default class UntypedLambdaBox extends PureComponent<Props, State> {
               <Settings
                 settings={ { type : BoxType.UNTYPED_LAMBDA, SLI, expandStandalones, strategy, SDE, ETA : ETA ?? false, collapseOldSteps : collapseOldSteps ?? true } }
                 settingsEnabled={ GLOBAL_SETTINGS_ENABLER }
+                restartNeeded={ restartNeeded }
+                onRestart={ () => this.onSubmitExpression(subtype) }
 
                 change={ (settings : UntypedLambdaSettings) => {
+                  // Enabling ETA at normal form reopens stepping when an
+                  // eta step is possible -- without performing it; the
+                  // user decides. Every other toggle just applies (pre
+                  // normal form the live setting takes effect on its own,
+                  // and disabling at normal form undoes nothing).
+                  if (settings.ETA === true && state.ETA !== true) {
+                    const last = state.history[state.history.length - 1]
+                    if (last !== undefined && last.ast !== null && last.isNormalForm === true) {
+                      const etaEvaluator : Evaluator = new OptimizeEvaluator(last.ast)
+                      if (! (etaEvaluator.nextReduction instanceof None)) {
+                        setBoxState({
+                          ...state,
+                          ...settings,
+                          history : [
+                            ...state.history.slice(0, -1),
+                            { ...last, isNormalForm : false, message : { ...last.message, message : '' } },
+                          ],
+                        })
+                        return
+                      }
+                    }
+                  }
                   setBoxState({
                     ...state,
                     ...settings
@@ -297,6 +329,7 @@ export default class UntypedLambdaBox extends PureComponent<Props, State> {
         subtype,
         expression : content,
         macrotable : macromap,
+        submittedWith : { strategy, SDE, ETA, SLI },
         history : [ {
           ast : ast.clone(),
           lastReduction : new None(),

--- a/src/untyped-lambda-integration/UntypedLambdaBox.tsx
+++ b/src/untyped-lambda-integration/UntypedLambdaBox.tsx
@@ -5,7 +5,7 @@ import { BoxType } from '../Types'
 import { UntypedLambdaState, UntypedLambdaType, UntypedLambdaSettings, PromptPlaceholder, StepMessage, StepValidity } from './Types'
 import ExpressionBox from './ExpressionBox'
 import MacroList from './MacroList'
-import { GLOBAL_SETTINGS_ENABLER, strategyToEvaluator, findSimplifiedReduction, toMacroMap, SETTINGS_OPENED_EVENT } from './Constants'
+import { GLOBAL_SETTINGS_ENABLER, strategyToEvaluator, findSimplifiedReduction, toMacroMap, SETTINGS_OPENED_EVENT, coreErrorMessage } from './Constants'
 import ExerciseBox from './ExerciseBox'
 import Settings from './Settings'
 import EmptyExpression from './EmptyExpression'
@@ -347,10 +347,11 @@ export default class UntypedLambdaBox extends PureComponent<Props, State> {
     } catch (exception) {
       // Core reports open macro definitions as a typed error carrying
       // the macro name and its free variables -- show it as is.
+      // Anything else falls back to core's own message.
       let errorMessage : string = exception instanceof OpenMacroDefinition
         ? exception.message
-        : "Something is wrong with your expression. Please inspect it closely."
-      console.error((exception as Error).toString())
+        : coreErrorMessage(exception)
+      console.error(coreErrorMessage(exception))
 
       // if (errorMessage === "Error") {
         if (content.match(/:=/g)?.length !== content.match(/;/g)?.length) {

--- a/src/untyped-lambda-integration/UntypedLambdaBox.tsx
+++ b/src/untyped-lambda-integration/UntypedLambdaBox.tsx
@@ -173,7 +173,6 @@ export default class UntypedLambdaBox extends PureComponent<Props, State> {
               setBoxState={ setBoxState }
             />
           )
-  
         case UntypedLambdaType.ORDINARY:
           return (
             <ExpressionBox
@@ -186,7 +185,6 @@ export default class UntypedLambdaBox extends PureComponent<Props, State> {
               titleActionsHost={ titleActionsHost }
             />
           )
-        
         case UntypedLambdaType.EXERCISE:
           return (
             <ExerciseBox
@@ -307,12 +305,11 @@ export default class UntypedLambdaBox extends PureComponent<Props, State> {
           return findSimplifiedReduction(astCopy, strategy, macromap)[0]
         }
         else {
-          const evaluator : Evaluator = new (strategyToEvaluator(strategy) as any)(astCopy)
+          const evaluator : Evaluator = new (strategyToEvaluator(strategy))(astCopy)
           return evaluator.nextReduction
         }
       })()
 
-      
       if (nextReduction instanceof None) {
         const etaEvaluator : Evaluator = new OptimizeEvaluator(ast)
 

--- a/src/untyped-lambda-integration/styles/Settings.css
+++ b/src/untyped-lambda-integration/styles/Settings.css
@@ -124,7 +124,7 @@
   border: 1px solid var(--accent);
   border-radius: 999px;
   padding: 2px 12px;
-  font-size: 0.9em;
+  font-size: 0.8em;
   cursor: pointer;
 }
 

--- a/src/untyped-lambda-integration/styles/Settings.css
+++ b/src/untyped-lambda-integration/styles/Settings.css
@@ -104,27 +104,27 @@
   border: 1px solid var(--border);
 }
 
-/* Restart offer: right-aligned stack, short label over an accent button. */
+/* Restart offer: right-aligned with the strategy row, short muted label
+   beside an outlined button, all in the panel's label type size. */
 .untyped-lambda-settings-restart {
   margin-left: auto;
   display: inline-flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 2px;
+  align-items: center;
+  gap: 8px;
 }
 
 .untyped-lambda-settings-restart-label {
-  font-size: 0.85em;
+  font-size: 0.9em;
   color: var(--muted);
 }
 
 .untyped-lambda-settings-restart-button {
-  background-color: var(--accent);
-  color: var(--accent-ink);
-  border: none;
+  background-color: transparent;
+  color: var(--text);
+  border: 1px solid var(--accent);
   border-radius: 999px;
-  padding: 3px 12px;
-  font-weight: 600;
+  padding: 2px 12px;
+  font-size: 0.9em;
   cursor: pointer;
 }
 

--- a/src/untyped-lambda-integration/styles/Settings.css
+++ b/src/untyped-lambda-integration/styles/Settings.css
@@ -24,6 +24,9 @@
 .untyped-lambda-settings-label {
   margin-left: 0;
   font-size: 0.9em;
+  /* Optical centering against the 20px switch tracks: the font metrics
+     sit the glyphs a hair below the line-box center flex gives them. */
+  transform: translateY(-1px);
 }
 
 .stratsLabel {

--- a/src/untyped-lambda-integration/styles/Settings.css
+++ b/src/untyped-lambda-integration/styles/Settings.css
@@ -105,12 +105,13 @@
 }
 
 /* Restart offer: one wide outlined button on its own row below the
-   strategies, right-aligned with headroom above and air from the
-   panel edge so the appearing control reads as its own thing. */
+   strategies, right-aligned with more than two line heights of air
+   above and room from the panel edge, so the appearing control reads
+   as its own thing instead of crowding the radios. */
 .untyped-lambda-settings-restart-row {
   display: flex;
   justify-content: flex-end;
-  margin: 12px 8px 0 0;
+  margin: 40px 8px 0 0;
 }
 
 .untyped-lambda-settings-restart-button {
@@ -121,6 +122,42 @@
   padding: 6px 18px;
   font-size: 0.9em;
   cursor: pointer;
+}
+
+/* Switch toggles (Simplified here, delete confirmation in the global
+   panel): track with a sliding thumb, accent when on. Until now these
+   classes had no paint at all and rendered as bare browser buttons. */
+.untyped-lambda-settings--toggle {
+  position: relative;
+  flex: 0 0 auto;
+  width: 34px;
+  height: 20px;
+  padding: 0;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background-color: var(--raised);
+  cursor: pointer;
+}
+
+.untyped-lambda-settings--toggle-on {
+  background-color: var(--accent);
+  border-color: var(--accent);
+}
+
+.untyped-lambda-settings--toggle-thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background-color: var(--muted);
+  transition: left .15s ease-in-out, background-color .15s ease-in-out;
+}
+
+.untyped-lambda-settings--toggle-on .untyped-lambda-settings--toggle-thumb {
+  left: 16px;
+  background-color: var(--accent-ink);
 }
 
 .untyped-lambda-settings--strategy-radio-wrapper {

--- a/src/untyped-lambda-integration/styles/Settings.css
+++ b/src/untyped-lambda-integration/styles/Settings.css
@@ -104,6 +104,30 @@
   border: 1px solid var(--border);
 }
 
+/* Restart offer: right-aligned stack, short label over an accent button. */
+.untyped-lambda-settings-restart {
+  margin-left: auto;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 2px;
+}
+
+.untyped-lambda-settings-restart-label {
+  font-size: 0.85em;
+  color: var(--muted);
+}
+
+.untyped-lambda-settings-restart-button {
+  background-color: var(--accent);
+  color: var(--accent-ink);
+  border: none;
+  border-radius: 999px;
+  padding: 3px 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
 .untyped-lambda-settings--strategy-radio-wrapper {
   margin-left: 0;
   padding: 0;

--- a/src/untyped-lambda-integration/styles/Settings.css
+++ b/src/untyped-lambda-integration/styles/Settings.css
@@ -196,6 +196,9 @@
   font-size: 0.85em;
   color: var(--muted);
   transition: color .15s ease-in-out, background-color .15s ease-in-out;
+  /* No label nudge here: these are symmetric pills, and lifting them
+     unseats the active one inside the segment. */
+  transform: none;
 }
 
 .untyped-lambda-settings--strategy-radio-wrapper input[type='radio']:checked + .untyped-lambda-settings-label {

--- a/src/untyped-lambda-integration/styles/Settings.css
+++ b/src/untyped-lambda-integration/styles/Settings.css
@@ -122,6 +122,13 @@
   padding: 6px 18px;
   font-size: 0.9em;
   cursor: pointer;
+  transition: background-color .15s ease-in-out, color .15s ease-in-out;
+}
+
+.untyped-lambda-settings-restart-button:hover {
+  background-color: var(--accent);
+  color: var(--accent-ink);
+  border-color: var(--accent);
 }
 
 /* Switch toggles (Simplified here, delete confirmation in the global

--- a/src/untyped-lambda-integration/styles/Settings.css
+++ b/src/untyped-lambda-integration/styles/Settings.css
@@ -104,18 +104,13 @@
   border: 1px solid var(--border);
 }
 
-/* Restart offer: right-aligned with the strategy row, short muted label
-   beside an outlined button, all in the panel's label type size. */
-.untyped-lambda-settings-restart {
-  margin-left: auto;
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.untyped-lambda-settings-restart-label {
-  font-size: 0.9em;
-  color: var(--muted);
+/* Restart offer: one wide outlined button on its own row below the
+   strategies, right-aligned with headroom above and air from the
+   panel edge so the appearing control reads as its own thing. */
+.untyped-lambda-settings-restart-row {
+  display: flex;
+  justify-content: flex-end;
+  margin: 12px 8px 0 0;
 }
 
 .untyped-lambda-settings-restart-button {
@@ -123,8 +118,8 @@
   color: var(--text);
   border: 1px solid var(--accent);
   border-radius: 999px;
-  padding: 2px 12px;
-  font-size: 0.8em;
+  padding: 6px 18px;
+  font-size: 0.9em;
   cursor: pointer;
 }
 


### PR DESCRIPTION
Ships the last 15 staging builds to production: safe cleanup pass (dead code, typed evaluator dispatch), new-notebook scroll park, sticky zen mode, full local settings in share links (old links unaffected), and the README production-sync status line with its bot. Staging has run all of this green.