### PR TITLE
Develop to master (easter egg + responsive narrow screens)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 | Production | [![Production deploy](https://github.com/lambdulus/frontend/actions/workflows/deploy.yml/badge.svg?branch=master)](https://github.com/lambdulus/frontend/actions/workflows/deploy.yml) | [![Production site](https://github.com/lambdulus/lambdulus.github.io/actions/workflows/handle-deploy.yml/badge.svg)](https://github.com/lambdulus/lambdulus.github.io/actions/workflows/handle-deploy.yml) |
 
 <!-- production-sync:start -->
-**Production status:** 2 builds behind staging ⚠️ — [compare](https://github.com/lambdulus/frontend/compare/master...develop)
+**Production status:** 6 builds behind staging ⚠️ — [compare](https://github.com/lambdulus/frontend/compare/master...develop)
 <!-- production-sync:end -->
 
 The web notebook for playing with lambda calculus (teaching at FIT CTU).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 | Production | [![Production deploy](https://github.com/lambdulus/frontend/actions/workflows/deploy.yml/badge.svg?branch=master)](https://github.com/lambdulus/frontend/actions/workflows/deploy.yml) | [![Production site](https://github.com/lambdulus/lambdulus.github.io/actions/workflows/handle-deploy.yml/badge.svg)](https://github.com/lambdulus/lambdulus.github.io/actions/workflows/handle-deploy.yml) |
 
 <!-- production-sync:start -->
-**Production status:** on the latest build ✅ (`240634a`)
+**Production status:** 1 build behind staging ⚠️ — [compare](https://github.com/lambdulus/frontend/compare/master...develop)
 <!-- production-sync:end -->
 
 The web notebook for playing with lambda calculus (teaching at FIT CTU).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 | Production | [![Production deploy](https://github.com/lambdulus/frontend/actions/workflows/deploy.yml/badge.svg?branch=master)](https://github.com/lambdulus/frontend/actions/workflows/deploy.yml) | [![Production site](https://github.com/lambdulus/lambdulus.github.io/actions/workflows/handle-deploy.yml/badge.svg)](https://github.com/lambdulus/lambdulus.github.io/actions/workflows/handle-deploy.yml) |
 
 <!-- production-sync:start -->
-**Production status:** 20 builds behind staging ⚠️ — [compare](https://github.com/lambdulus/frontend/compare/master...develop)
+**Production status:** on the latest build ✅ (`240634a`)
 <!-- production-sync:end -->
 
 The web notebook for playing with lambda calculus (teaching at FIT CTU).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 | Production | [![Production deploy](https://github.com/lambdulus/frontend/actions/workflows/deploy.yml/badge.svg?branch=master)](https://github.com/lambdulus/frontend/actions/workflows/deploy.yml) | [![Production site](https://github.com/lambdulus/lambdulus.github.io/actions/workflows/handle-deploy.yml/badge.svg)](https://github.com/lambdulus/lambdulus.github.io/actions/workflows/handle-deploy.yml) |
 
 <!-- production-sync:start -->
-**Production status:** 1 build behind staging ⚠️ — [compare](https://github.com/lambdulus/frontend/compare/master...develop)
+**Production status:** 2 builds behind staging ⚠️ — [compare](https://github.com/lambdulus/frontend/compare/master...develop)
 <!-- production-sync:end -->
 
 The web notebook for playing with lambda calculus (teaching at FIT CTU).

--- a/src/App.css
+++ b/src/App.css
@@ -23,25 +23,7 @@ body {
   min-height: 100vh;
 }
 
-#bad-screen-message {
-  display: none;
-  background-color: var(--surface);
-  color: var(--text);
-  height: 100vh;
-  width: 100vw;
-  position: fixed;
-  text-align: center;
-  font-size: 2em;
-  padding-top: 40vh;
-  z-index: 99999;
-}
 
-/* Maximum aspect ratio */
-@media screen and (max-width: 374px) {
-  #bad-screen-message {
-    display: block;
-  }
-}
 
 .boxContainer {
   position: relative;

--- a/src/App.css
+++ b/src/App.css
@@ -37,7 +37,7 @@ body {
 }
 
 /* Maximum aspect ratio */
-@media screen and (max-width: 899px) {
+@media screen and (max-width: 374px) {
   #bad-screen-message {
     display: block;
   }
@@ -367,6 +367,22 @@ body {
   z-index: 60;
 }
 
+/* The zen picker floats over box content, so its options carry the
+   card fill — transparent rows would let the box show through. A
+   theme-aware surface, not flat white, so dark-mode text stays
+   readable. */
+.zen-add .add-box--group {
+  background-color: var(--surface);
+}
+
+/* Below 480px the fixed right offset would push the capped button
+   past the left edge, so it docks to the page padding instead. */
+@media (max-width: 480px) {
+  .zen-add {
+    right: 12px;
+  }
+}
+
 /* Paging arrows flanking the anchor line: the same move as the arrow
    keys, sitting between the anchor and its neighbors, centered on
    the map lines. */
@@ -403,6 +419,26 @@ body {
 
   .macro-dock {
     left: calc(-1 * max(22px, (100vw - 850px) / 2 + 22px));
+  }
+}
+
+/* Below the width where even the half map still clears the slim
+   column (1372px), the map steps out entirely instead of shrinking
+   further: unreadable lines overlapping boxes help nobody. Keyboard
+   paging and plain scrolling keep working; zen loses only the map
+   way around, and the floating add-box stays put. */
+@media (max-width: 1371px) {
+  .box-map {
+    display: none;
+  }
+}
+
+/* Below the slim column's own outer width (850px) the fixed column
+   would overflow the viewport, so it goes fluid and the page padding
+   owns the gutters. */
+@media (max-width: 849px) {
+  .mainSpace {
+    max-width: none;
   }
 }
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -4,7 +4,8 @@ import { render, fireEvent, waitFor, cleanup } from '@testing-library/react';
 import App from './App';
 
 afterEach(() => cleanup());
-import { createDefaultAppState, preferredTheme, saveTourState, loadTourState } from './Constants';
+import { createDefaultAppState, preferredTheme, saveTourState, loadTourState, updateAppStateToStorage } from './Constants';
+import { createNewMarkdown } from './markdown-integration/AppTypes';
 import { TOUR_STEPS } from './components/Tour';
 import { defaultSettings, createNewUntypedLambdaExpression } from './untyped-lambda-integration/Constants';
 import { UntypedLambdaType } from './untyped-lambda-integration/Types';
@@ -14,7 +15,7 @@ import { Theme } from './contexts/Theme';
 test('renders the app shell (top-level smoke test)', () => {
   const { getByText } = render(<App />);
   // #bad-screen-message is always rendered by App, independent of screen state
-  const message = getByText(/Lambdulus only runs on screens at least 900 pixels wide\./i);
+  const message = getByText(/Lambdulus only runs on screens at least 375 pixels wide\./i);
   expect(message).toBeInTheDocument();
 });
 
@@ -195,14 +196,15 @@ test('the tour conducts a lambda box from + to evaluated', async () => {
   // plays out — remembered but never obstructing the clean box.
   await waitFor(() => expect(container.querySelector('.macro-dock--open')).toBeNull());
 
-  // The middle finale only shows: the clearing options open with both
-  // exits, and nothing is pressed behind the user's back.
-  await waitFor(() => expect(container.querySelector('[title="Erase all notebooks and start over with the defaults"]')).not.toBeNull());
+  // Step 11 shows just the button: no panel yet.
+  expect(container.querySelector('[title="Erase all notebooks except the Manual and start over with the defaults"]')).toBeNull();
   expect(container.querySelectorAll('.box-frame').length).toBe(1);
 
-  // The exits walk one by one, settings-cluster style — shown, never pressed.
+  // The exits walk one by one, settings-cluster style — the panel
+  // opens on arrival, shown, never pressed.
   fireEvent.click(nextBtn());
   expect(title()).toBe('Clear notebook');
+  await waitFor(() => expect(container.querySelector('[title="Erase all notebooks except the Manual and start over with the defaults"]')).not.toBeNull());
   expect(container.querySelector('.top-bar--clear-btn:not(.btn-danger)')).not.toBeNull();
   fireEvent.click(nextBtn());
   expect(title()).toBe('Clean entire workspace');
@@ -373,6 +375,37 @@ test('creating a notebook parks the page at the top', () => {
   }
   finally {
     window.scrollTo = originalScrollTo;
+  }
+});
+
+test('cleaning the workspace spares the protected Manual', () => {
+  // The Manual keeps every box the user made; all other notebooks
+  // start over with a fresh empty one.
+  window.localStorage.clear();
+  const fresh = createDefaultAppState();
+  const kept = createNewMarkdown();
+  kept.note = 'do not lose me';
+  kept.editor.content = 'do not lose me';
+  kept.isEditing = false;
+  const manual = { ...fresh.notebooks[0], boxList : [ ...fresh.notebooks[0].boxList, kept ] };
+  updateAppStateToStorage({ ...fresh, notebooks : [ manual, fresh.notebooks[1] ] });
+
+  const confirm = vi.spyOn(window, 'confirm').mockReturnValue(true);
+  try {
+    const { container } = render(<App />);
+    fireEvent.click(container.querySelector('[title="Clearing options"]') as HTMLElement);
+    fireEvent.click(container.querySelector('[title="Erase all notebooks except the Manual and start over with the defaults"]') as HTMLElement);
+
+    const stored = JSON.parse(window.localStorage.getItem('AppState') ?? '{}');
+    expect(stored.notebooks.length).toBe(2);
+    expect(stored.notebooks[0].locked).toBe(true);
+    expect(stored.notebooks[0].boxList.length).toBe(manual.boxList.length);
+    expect(stored.notebooks[0].boxList.some((box : { note?: unknown }) => box.note === 'do not lose me')).toBe(true);
+    expect(stored.notebooks[1].boxList).toEqual([]);
+    expect(stored.activeNotebookIndex).toBe(1);
+  }
+  finally {
+    confirm.mockRestore();
   }
 });
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,3 +1,4 @@
+import { readFileSync } from 'fs';
 import React from 'react';
 import { test, expect, afterEach, vi } from 'vitest';
 import { render, fireEvent, waitFor, cleanup } from '@testing-library/react';
@@ -13,10 +14,54 @@ import { buildBoxShareURL } from './components/BoxTitleBar';
 import { Theme } from './contexts/Theme';
 
 test('renders the app shell (top-level smoke test)', () => {
-  const { getByText } = render(<App />);
-  // #bad-screen-message is always rendered by App, independent of screen state
-  const message = getByText(/Lambdulus only runs on screens at least 375 pixels wide\./i);
-  expect(message).toBeInTheDocument();
+  const { container } = render(<App />);
+  // No screen gate anymore: narrow screens get the stripped mini mode.
+  expect(container.querySelector('#bad-screen-message')).toBeNull();
+  expect(container.querySelector('.top-bar')).not.toBeNull();
+});
+
+test('sub-375px screens get the stripped mini mode', () => {
+  // One box, no top bar, no way to add boxes — the experiment owns
+  // anything narrower than MINI_MODE_WIDTH.
+  const original = window.matchMedia;
+  window.matchMedia = (() => ({ matches : true })) as unknown as typeof window.matchMedia;
+  try {
+    window.localStorage.clear();
+    const { container } = render(<App />);
+    expect(container.querySelector('.mini-mode .mainSpace.zen')).not.toBeNull();
+    expect(container.querySelector('.top-bar')).toBeNull();
+
+    // First run down here: the walkme never opens, and the empty
+    // notebook grows its one box with the editor open.
+    expect(container.querySelector('.tour')).toBeNull();
+    expect(container.querySelectorAll('.mini-mode .box-frame').length).toBe(1);
+
+    // The add-box button stays mounted but stepped out by the mini CSS.
+    const css = readFileSync('src/styles/MiniMode.css', 'utf8');
+    expect(css).toMatch(/\.mini-mode \.zen-add\s*\{[^}]*display\s*:\s*none/);
+    expect(css).toMatch(/\.mini-mode \.mainSpace\s*\{[^}]*padding-top\s*:\s*20px/);
+
+    // No macro table down here: the whole dock steps out, and no
+    // icon replaces it anywhere.
+    expect(css).toMatch(/\.mini-mode \.macro-dock\s*\{[^}]*display\s*:\s*none/);
+    expect(css).not.toMatch(/macros-toggle/);
+
+    // Fluid smaller type, em-riding paddings, and Run-only: no
+    // stepping, no exercise boxes.
+    expect(css).toMatch(/\.mini-mode\s*\{[^}]*font-size\s*:\s*max\(10px, 3\.733vw\)/);
+    expect(css).toMatch(/\.mini-mode \.boxContainer\s*\{[^}]*padding\s*:\s*1em 0\.8em 1\.2em/);
+    expect(css).toMatch(/\.mini-mode \.mainSpace\.zen \.boxContainer\s*\{[^}]*height\s*:\s*calc\(100vh - 40px - 2\.2em - 2px\)/);
+    expect(css).toMatch(/padding-bottom\s*:\s*20px/);
+    expect(css).toMatch(/\.mini-mode \.debug-controls--step[\s\S]*?display\s*:\s*none/);
+    expect(css).toMatch(/\.mini-mode \.open-as-exercise[\s\S]*?display\s*:\s*none/);
+
+    // Three-line editor: the monaco wrapper section is pinned down,
+    // hammer included since the height prop rides inline.
+    expect(css).toMatch(/\.mini-mode \.editorContainer \.editor > div > section\s*\{[^}]*height\s*:\s*57px !important/);
+  }
+  finally {
+    window.matchMedia = original;
+  }
 });
 
 function mockMatchMedia (matches : boolean) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -344,7 +344,7 @@ export default class App extends Component<{}, AppState> {
 
           <div id='app' className={ darkmode ? 'dark' : 'light' } data-accent={ this.accentPreview ?? accent } data-box-style={ this.boxStylePreview ?? boxStyle }>
             <div id="bad-screen-message">
-              Lambdulus only runs on screens at least 900 pixels wide.
+              Lambdulus only runs on screens at least 375 pixels wide.
             </div>
             <TopBar
               notebooks={ notebooks }
@@ -463,7 +463,13 @@ export default class App extends Component<{}, AppState> {
 
   resetWorkspace () : void {
     if (window.confirm(RESET_WORKSPACE_CONFIRMATION)) {
-      const notebooks : Array<NotebookState> = [ createManualNotebook(), createEmptyNotebook('Notebook') ]
+      // The Manual is protected and special: cleaning the workspace
+      // never touches it — only everything else starts over. Locked
+      // notebooks cannot be deleted, so the Manual is always findable;
+      // a fresh one only fills the impossible gap of it missing.
+      const manual : NotebookState =
+        this.state.notebooks.find((notebook : NotebookState) => notebook.locked === true) ?? createManualNotebook()
+      const notebooks : Array<NotebookState> = [ manual, createEmptyNotebook('Notebook') ]
 
       this.setState({
         notebooks,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 
 import './App.css'
+import './styles/MiniMode.css'
 
 import  { loadAppStateFromStorage
         , updateAppStateToStorage
@@ -22,6 +23,19 @@ import { UntypedLambdaState, UntypedLambdaSettings, EvaluationStrategy, UntypedL
 import { MacroTable } from '@lambdulus/core'
 import { Theme, ThemeContext } from './contexts/Theme'
 import { SettingsContext } from './contexts/Settings'
+
+// Experiment (easter egg, uncommitted): viewport width below which the
+// app collapses to the stripped mini mode. The knob to tune while
+// playing with small screens; delete it with MiniMode.css and the
+// mini branch in render to revert.
+export const MINI_MODE_WIDTH : number = 375
+
+export function miniMode () : boolean {
+  if (typeof window.matchMedia !== 'function') {
+    return false
+  }
+  return window.matchMedia(`(max-width: ${MINI_MODE_WIDTH - 1}px)`).matches
+}
 
 
 export default class App extends Component<{}, AppState> {
@@ -220,6 +234,44 @@ export default class App extends Component<{}, AppState> {
 
   componentDidMount () : void {
     this.createNotebookFromURL()
+    window.addEventListener('resize', this.syncMiniMode)
+    this.ensureMiniBox()
+  }
+
+  componentWillUnmount () : void {
+    window.removeEventListener('resize', this.syncMiniMode)
+  }
+
+  // Mini mode follows the viewport live (rotating a phone can cross
+  // the line either way); instance field like the tour flag, never
+  // persisted.
+  private miniMode : boolean = miniMode()
+
+  private syncMiniMode = () : void => {
+    const mini : boolean = miniMode()
+
+    if (mini !== this.miniMode) {
+      this.miniMode = mini
+
+      if (mini) {
+        this.ensureMiniBox()
+      }
+
+      this.forceUpdate()
+    }
+  }
+
+  // Experiment: mini mode always has its box to show — whatever the
+  // notebook kept, or one fresh empty editor. Persisted like any other
+  // box, so it survives reloads.
+  private ensureMiniBox () : void {
+    const notebook : NotebookState | undefined = this.state.notebooks[this.state.activeNotebookIndex]
+
+    if (this.miniMode && notebook !== undefined && notebook.boxList.length === 0 && notebook.locked !== true) {
+      const settings : UntypedLambdaSettings =
+        (notebook.settings[UNTYPED_LAMBDA_CODE_NAME] as UntypedLambdaSettings | undefined) ?? defaultSettings
+      this.updateNotebook({ boxList : [ createNewUntypedLambdaExpression(settings) ], activeBoxIndex : 0 })
+    }
   }
 
   // TODO: all of this needs to be moved to more apropriate component
@@ -343,43 +395,61 @@ export default class App extends Component<{}, AppState> {
         <SettingsContext.Provider value={ settings }>
 
           <div id='app' className={ darkmode ? 'dark' : 'light' } data-accent={ this.accentPreview ?? accent } data-box-style={ this.boxStylePreview ?? boxStyle }>
-            <div id="bad-screen-message">
-              Lambdulus only runs on screens at least 375 pixels wide.
-            </div>
-            <TopBar
-              notebooks={ notebooks }
-              activeNotebookIndex={ activeNotebookIndex }
-              theme={ theme }
-              accent={ accent }
-              boxStyle={ boxStyle }
-              confirmBoxDelete={ confirmBoxDelete ?? true }
-              onConfirmBoxDeleteChange={ this.updateConfirmBoxDelete }
-              settings={ settings }
-              onAccentChange={ this.updateAccent }
-              onAccentPreview={ this.previewAccent }
-              onBoxStylePreview={ this.previewBoxStyle }
-              onBoxStyleChange={ this.updateBoxStyle }
-              onNotebookSelect={ this.selectNotebook }
-              onNotebookAdd={ this.addNotebook }
-              onNotebookRemove={ this.removeNotebook }
-              onImport={ this.importNotebook }
-              onClearNotebook={ this.clearNotebook }
-              onResetWorkspace={ this.resetWorkspace }
-              onDarkModeChange={ this.toggleTheme }
-              onSettingsChange={ this.updateSettings }
-              onZenModeChange={ this.setZenMode }
-              onTourOpen={ this.openTour }
-            />
+            {
+              // Experiment (easter egg, uncommitted): stripped mini mode —
+              // the active box in forced zen, no top bar, and (via
+              // MiniMode.css) no way to add boxes. Same state path as the
+              // real UI, so nothing here can rot the workspace.
+              this.miniMode ?
+                <div className='mini-mode'>
+                  <Notebook
+                    state={{ ...notebook, zenMode : true }}
+                    updateNotebook={ this.updateNotebook }
+                    confirmBoxDelete={ confirmBoxDelete ?? true }
+                    onConfirmBoxDeleteChange={ this.updateConfirmBoxDelete }
+                  />
+                </div>
+              :
+                <React.Fragment>
+                  <TopBar
+                    notebooks={ notebooks }
+                    activeNotebookIndex={ activeNotebookIndex }
+                    theme={ theme }
+                    accent={ accent }
+                    boxStyle={ boxStyle }
+                    confirmBoxDelete={ confirmBoxDelete ?? true }
+                    onConfirmBoxDeleteChange={ this.updateConfirmBoxDelete }
+                    settings={ settings }
+                    onAccentChange={ this.updateAccent }
+                    onAccentPreview={ this.previewAccent }
+                    onBoxStylePreview={ this.previewBoxStyle }
+                    onBoxStyleChange={ this.updateBoxStyle }
+                    onNotebookSelect={ this.selectNotebook }
+                    onNotebookAdd={ this.addNotebook }
+                    onNotebookRemove={ this.removeNotebook }
+                    onImport={ this.importNotebook }
+                    onClearNotebook={ this.clearNotebook }
+                    onResetWorkspace={ this.resetWorkspace }
+                    onDarkModeChange={ this.toggleTheme }
+                    onSettingsChange={ this.updateSettings }
+                    onZenModeChange={ this.setZenMode }
+                    onTourOpen={ this.openTour }
+                  />
 
-            <Notebook
-              state={ notebook }
-              updateNotebook={ this.updateNotebook }
-              confirmBoxDelete={ confirmBoxDelete ?? true }
-              onConfirmBoxDeleteChange={ this.updateConfirmBoxDelete }
-            />
+                  <Notebook
+                    state={ notebook }
+                    updateNotebook={ this.updateNotebook }
+                    confirmBoxDelete={ confirmBoxDelete ?? true }
+                    onConfirmBoxDeleteChange={ this.updateConfirmBoxDelete }
+                  />
+                </React.Fragment>
+            }
 
             {
-              this.tourOpen ?
+              // Experiment: the walkme never opens down here — skipped,
+              // not stopped, so the first-run state survives untouched
+              // for real widths.
+              this.tourOpen && ! this.miniMode ?
                 <Tour
                   initialStep={ loadTourState()?.step ?? 'welcome' }
                   onClose={ this.closeTour }

--- a/src/Constants.test.ts
+++ b/src/Constants.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, beforeEach } from 'vitest';
-import { decodeNotebook, loadTourState, saveTourState, defaultTourState } from './Constants';
+import { createManualNotebook, decodeNotebook, loadTourState, saveTourState, defaultTourState } from './Constants';
 import { CODE_NAME as UNTYPED_CODE_NAME } from './untyped-lambda-integration/Constants';
 import { EvaluationStrategy } from './untyped-lambda-integration/Types';
 import { NotebookState } from './Types';
@@ -54,4 +54,16 @@ test('tour storage starts empty, round-trips, rejects garbage', () => {
 
   window.localStorage.setItem('LambdulusTour', JSON.stringify({ step : '', done : true }));
   expect(loadTourState()).toBeNull();
+});
+
+test('the Manual carries a notes box besides the guide', () => {
+  // The protected notebook opens with room for the user's own notes;
+  // both boxes stay put through workspace cleaning (see App).
+  const manual = createManualNotebook();
+  expect(manual.name).toBe('Manual');
+  expect(manual.locked).toBe(true);
+  expect(manual.boxList.length).toBe(2);
+  expect(manual.boxList[0].title).toBe('Manual');
+  expect(manual.boxList[1].title).toBe('Your notes');
+  expect(String((manual.boxList[1] as unknown as { note : unknown }).note)).toMatch(/survive cleaning the entire workspace/);
 });

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -15,7 +15,8 @@ export const CLEAR_NOTEBOOK_CONFIRMATION : string =
                                           Are you sure?`
 
 export const RESET_WORKSPACE_CONFIRMATION : string =
-`This will erase all of your notebooks and start over with the defaults.
+`This will erase all of your notebooks except the protected Manual
+and start over with the defaults.
 
                                           Are you really sure?`
 
@@ -56,6 +57,13 @@ export function createEmptyNotebook (name : string) : NotebookState {
   }
 }
 
+const NOTES_BOX_CONTENT : string =
+`# Your own notes
+
+This Manual notebook is protected and special: it can never be deleted
+or cleared, and boxes you add here survive cleaning the entire workspace.
+Keep notes about features you discover — add more boxes with the + below.`
+
 export function createManualNotebook () : NotebookState {
   const manualBox : NoteState = {
     ...createNewMarkdown(),
@@ -71,10 +79,23 @@ export function createManualNotebook () : NotebookState {
     },
   }
 
+  const notesBox : NoteState = {
+    ...createNewMarkdown(),
+    title : 'Your notes',
+    note : NOTES_BOX_CONTENT,
+    isEditing : false,
+    editor : {
+      placeholder : '',
+      content : NOTES_BOX_CONTENT,
+      caretPosition : 0,
+      syntaxError : null,
+    },
+  }
+
   return {
     name : 'Manual',
     locked : true,
-    boxList : [ manualBox ],
+    boxList : [ manualBox, notesBox ],
     activeBoxIndex : 0,
     focusedBoxIndex : undefined,
     settings : createDefaultSettings(),

--- a/src/components/Box.tsx
+++ b/src/components/Box.tsx
@@ -20,11 +20,12 @@ interface BoxProperties {
 
   updateBoxState (box : BoxState) : void
   addBoxAfter (box : BoxState) : void
+  makeActive () : void
   titleActionsHost? : React.RefObject<HTMLSpanElement>
 }
 
 export default function Box (props : BoxProperties) : JSX.Element {
-  const { state, isActive, isFocused, isAnchorBox, updateBoxState, addBoxAfter, titleActionsHost } : BoxProperties = props
+  const { state, isActive, isFocused, isAnchorBox, updateBoxState, addBoxAfter, makeActive, titleActionsHost } : BoxProperties = props
   const { type } = state
 
   // const macroTable = useContext(MacroTableContext)
@@ -41,6 +42,7 @@ export default function Box (props : BoxProperties) : JSX.Element {
 
         setBoxState={ updateBoxState }
         addBox={ addBoxAfter }
+        makeActive={ makeActive }
         titleActionsHost={ titleActionsHost }
       />
     )

--- a/src/components/BoxContainer.tsx
+++ b/src/components/BoxContainer.tsx
@@ -156,6 +156,7 @@ export class BoxContainer extends Component<Props, State> {
               isAnchorBox={ isAnchorBox }
               updateBoxState={ updateBoxState }
               addBoxAfter={ addBoxAfter }
+              makeActive={ makeActive }
               titleActionsHost={ box.type === BoxType.UNTYPED_LAMBDA ? this.titleActionsRef : undefined }
             />
           </div>

--- a/src/components/BoxTitleBar.test.tsx
+++ b/src/components/BoxTitleBar.test.tsx
@@ -1,3 +1,4 @@
+import { readFileSync } from 'fs';
 import React from 'react';
 import { test, expect, afterEach } from 'vitest';
 import { render, fireEvent, cleanup } from '@testing-library/react';
@@ -107,4 +108,81 @@ test('closing settings from the gear broadcasts nothing', () => {
   finally {
     document.removeEventListener(SETTINGS_OPENED_EVENT, onOpened);
   }
+});
+
+test('compact box menu opens, closes on icon tap and outside tap', () => {
+  const { container } = bar(false, () => void 0);
+  const toggle = container.querySelector('[title="Open box actions"]') as HTMLElement;
+  const controls = container.querySelector('.box-top-bar-controls') as HTMLElement;
+
+  expect(controls.classList.contains('box-top-bar-controls--open')).toBe(false);
+
+  // The toggle opens the icon popup.
+  fireEvent.click(toggle);
+  expect(controls.classList.contains('box-top-bar-controls--open')).toBe(true);
+
+  // Tapping an icon closes it again, before the action itself runs.
+  fireEvent.click(container.querySelector('[title="Collapse this Box"]') as HTMLElement);
+  expect(controls.classList.contains('box-top-bar-controls--open')).toBe(false);
+
+  // Tapping anywhere else closes it too.
+  fireEvent.click(toggle);
+  fireEvent.mouseDown(document.body);
+  expect(controls.classList.contains('box-top-bar-controls--open')).toBe(false);
+});
+
+test('taps on the tour card leave the compact menu open', () => {
+  // Every Next tap would otherwise shut the menu a beat before the
+  // step sync re-opens it, flickering through each settings step.
+  const { container } = bar(false, () => void 0);
+  fireEvent.click(container.querySelector('[title="Open box actions"]') as HTMLElement);
+  const controls = container.querySelector('.box-top-bar-controls') as HTMLElement;
+  expect(controls.classList.contains('box-top-bar-controls--open')).toBe(true);
+
+  const tour = document.createElement('div');
+  tour.className = 'tour';
+  const next = document.createElement('button');
+  next.textContent = 'Next';
+  tour.appendChild(next);
+  document.body.appendChild(tour);
+  try {
+    fireEvent.mouseDown(next);
+    expect(controls.classList.contains('box-top-bar-controls--open')).toBe(true);
+    fireEvent.mouseDown(document.body);
+    expect(controls.classList.contains('box-top-bar-controls--open')).toBe(false);
+  }
+  finally {
+    tour.remove();
+  }
+});
+
+test('box settings float above the macro dock', () => {
+  // The panel opens over the pill's corner; the dock must never win
+  // their overlap.
+  const css = readFileSync('src/untyped-lambda-integration/styles/Settings.css', 'utf8');
+  const panel = css.match(/\.box-settings\s*\{[^}]*\}/)?.[0] ?? '';
+  expect(panel).toMatch(/z-index\s*:\s*60/);
+});
+
+test('below 430px the box settings pin to both sides', () => {
+  // The capped panel would spill past the left edge; uncapped with a
+  // fixed 8px gap left and right it always fits the box.
+  const css = readFileSync('src/untyped-lambda-integration/styles/Settings.css', 'utf8');
+  const start = css.search(/@media[^{]*max-width\s*:\s*429px/);
+  expect(start).toBeGreaterThan(-1);
+  const media = css.slice(start);
+  expect(media).toMatch(/\.box-settings\s*\{[^}]*width\s*:\s*auto/);
+  expect(media).toMatch(/\.box-settings\s*\{[^}]*left\s*:\s*8px/);
+});
+
+test('below 420px the box icons fold under a toggle', () => {
+  // The row hides, the hamburger shows, and the open node drops as a
+  // horizontal icon popup — morphing to an X, labels nowhere.
+  const css = readFileSync('src/styles/BoxTopBar.css', 'utf8');
+  const media = css.slice(css.search(/@media[^{]*max-width\s*:\s*419px/));
+  expect(media).toMatch(/\.box-top-bar-controls\s*\{[^}]*display\s*:\s*none/);
+  expect(media).toMatch(/\.box-top-bar-controls--open\s*\{[^}]*position\s*:\s*absolute/);
+  expect(media).toMatch(/\.box-top-bar-controls--open\s*\{[^}]*flex-direction\s*:\s*row/);
+  expect(css).toMatch(/\.box-top-bar--compact-toggle--open \.box-top-bar--compact-bar:nth-child\(1\)\s*\{[^}]*transform\s*:\s*rotate\(45deg\)/);
+  expect(css).not.toMatch(/box-top-bar--compact-toggle[\s\S]*top-bar--action-label/);
 });

--- a/src/components/BoxTitleBar.tsx
+++ b/src/components/BoxTitleBar.tsx
@@ -66,10 +66,14 @@ interface State {
   where : BoxPlace | null
   menuOpen : boolean
   shareLinkOpen : boolean
+  compactOpen : boolean
 }
 
 
 export default class BoxTitleBar extends Component<Props, State> {
+
+  private compactPopupRef : React.RefObject<HTMLDivElement>
+  private compactToggleRef : React.RefObject<HTMLDivElement>
 
   constructor (props : Props) {
     super(props)
@@ -78,6 +82,43 @@ export default class BoxTitleBar extends Component<Props, State> {
       where : null,
       menuOpen : false,
       shareLinkOpen : false,
+      compactOpen : false,
+    }
+
+    this.compactPopupRef = React.createRef<HTMLDivElement>()
+    this.compactToggleRef = React.createRef<HTMLDivElement>()
+    this.setCompact = this.setCompact.bind(this)
+  }
+
+  componentWillUnmount () : void {
+    document.removeEventListener('mousedown', this.onCompactOutside)
+  }
+
+  // Compact box menu (see the media query in BoxTopBar.css): tapping
+  // the toggle opens, tapping an icon or anywhere else closes.
+  setCompact (open : boolean) : void {
+    this.setState({ compactOpen : open })
+
+    if (open) {
+      document.addEventListener('mousedown', this.onCompactOutside)
+    }
+    else {
+      document.removeEventListener('mousedown', this.onCompactOutside)
+    }
+  }
+
+  onCompactOutside = (e : Event) : void => {
+    const target : EventTarget | null = e.target
+    const popup : HTMLDivElement | null = this.compactPopupRef.current
+    const toggle : HTMLDivElement | null = this.compactToggleRef.current
+
+    // Taps on the tour card never count as outside: every Next tap
+    // would otherwise shut the menu a beat before the step sync
+    // re-opens it, flickering through each settings step.
+    const inTour : boolean = target instanceof Element && target.closest('.tour') !== null
+
+    if (!inTour && target instanceof Node && popup !== null && !popup.contains(target) && (toggle === null || !toggle.contains(target))) {
+      this.setCompact(false)
     }
   }
 
@@ -85,7 +126,7 @@ export default class BoxTitleBar extends Component<Props, State> {
     const { state, isActive, updateBoxState, removeBox, seatBox, makeActive, hideTitle, titleActionsHost } : Props = this.props
     const { type, title, minimized } = state
 
-    const { shareLinkOpen } : State = this.state
+    const { shareLinkOpen, compactOpen } : State = this.state
 
     return (
       <div className='boxTopBar'
@@ -167,7 +208,13 @@ export default class BoxTitleBar extends Component<Props, State> {
 
             </div>
         }
-        <div className='box-top-bar-controls'>
+        <div
+          className={ compactOpen ? 'box-top-bar-controls box-top-bar-controls--open' : 'box-top-bar-controls' }
+          ref={ this.compactPopupRef }
+          // Capture, so the items' own stopPropagation never swallows
+          // it: the menu closes first, the tapped action runs after.
+          onClickCapture={ compactOpen ? () => this.setCompact(false) : undefined }
+        >
           {
             state.readOnly ?
               null
@@ -289,6 +336,23 @@ export default class BoxTitleBar extends Component<Props, State> {
                 <Pencil size={ 15 } strokeWidth={ 1.75 } />
               </div>
           }
+        </div>
+
+        { /* Compact box menu toggle: only the media query in
+             BoxTopBar.css ever shows it (below 420px), where the
+             controls above fold into its popup. */ }
+        <div
+          ref={ this.compactToggleRef }
+          className={ compactOpen ? 'box-top-bar--controls-item box-top-bar--compact-toggle box-top-bar--compact-toggle--open' : 'box-top-bar--controls-item box-top-bar--compact-toggle' }
+          title={ compactOpen ? 'Close box actions' : 'Open box actions' }
+          onClick={ (e) => {
+            e.stopPropagation()
+            this.setCompact(! compactOpen)
+          } }
+        >
+          <span className='box-top-bar--compact-bar' aria-hidden='true' />
+          <span className='box-top-bar--compact-bar' aria-hidden='true' />
+          <span className='box-top-bar--compact-bar' aria-hidden='true' />
         </div>
 
         {

--- a/src/components/TopBar.test.tsx
+++ b/src/components/TopBar.test.tsx
@@ -317,3 +317,71 @@ test('deletion toggle renders off when asking is off', () => {
   expect(toggle.getAttribute('aria-pressed')).toBe('false');
   expect(toggle.className).toMatch(/untyped-lambda-settings--toggle-off/);
 });
+
+test('narrow-screen menu folds the actions under a toggle', () => {
+  const { container } = render(<TopBar { ...baseProps(() => void 0) } />);
+  const toggle = container.querySelector('[aria-label="Menu"]') as HTMLElement;
+  const actions = container.querySelector('.top-bar--actions') as HTMLElement;
+
+  // Closed: the plain cluster, no dropdown, no backdrop.
+  expect(actions.classList.contains('top-bar--actions--open')).toBe(false);
+  expect(container.querySelector('.top-bar--backdrop')).toBeNull();
+
+  // Open: the same node drops down, backdrop catches outside clicks.
+  fireEvent.click(toggle);
+  expect(actions.classList.contains('top-bar--actions--open')).toBe(true);
+  expect(toggle.getAttribute('aria-expanded')).toBe('true');
+  expect(container.querySelector('.top-bar--backdrop')).not.toBeNull();
+
+  // Tabs stay in the bar either way.
+  expect(container.querySelector('.top-bar--tabs')).not.toBeNull();
+
+  // Taking an action closes the menu again...
+  fireEvent.click(container.querySelector('[title="Toggle the theme"]') as HTMLElement);
+  expect(actions.classList.contains('top-bar--actions--open')).toBe(false);
+
+  // ...and so does the backdrop.
+  fireEvent.click(toggle);
+  fireEvent.click(container.querySelector('.top-bar--backdrop') as HTMLElement);
+  expect(actions.classList.contains('top-bar--actions--open')).toBe(false);
+});
+
+test('reopening the menu dismisses an open panel', () => {
+  // The menu and the panels share the corner: opening one must never
+  // stack onto the other.
+  const { container } = render(<TopBar { ...baseProps(() => void 0) } />);
+  fireEvent.click(container.querySelector('[title="Notebook settings"]') as HTMLElement);
+  expect(container.querySelector('.top-bar--settings-panel')).not.toBeNull();
+  fireEvent.click(container.querySelector('[aria-label="Menu"]') as HTMLElement);
+  expect(container.querySelector('.top-bar--actions--open')).not.toBeNull();
+  expect(container.querySelector('.top-bar--settings-panel')).toBeNull();
+});
+
+test('menu rows name their icons', () => {
+  // Nine rows, each carrying a label the open menu shows.
+  const { container } = render(<TopBar { ...baseProps(() => void 0) } />);
+  const rows = container.querySelectorAll('.top-bar--actions .top-bar--action, .top-bar--actions .top-bar--zen');
+  expect(rows.length).toBe(9);
+  rows.forEach((row) => {
+    expect(row.querySelector('.top-bar--action-label')?.textContent).toMatch(/\S/);
+  });
+
+  // Hidden in the bar, shown in the open menu.
+  const css = readFileSync('src/styles/TopBar.css', 'utf8');
+  const label = css.match(/\.top-bar--action-label\s*\{[^}]*\}/)?.[0] ?? '';
+  expect(label).toMatch(/display\s*:\s*none/);
+  const media = css.slice(css.search(/@media[^{]*max-width\s*:\s*700px/));
+  expect(media).toMatch(/\.top-bar--actions--open \.top-bar--action-label\s*\{[^}]*display\s*:\s*inline/);
+});
+
+test('below 700px the actions fold under the toggle', () => {
+  // The cluster hides, the hamburger shows and morphs to an X, and
+  // the open node drops down — while the icons keep their size.
+  const css = readFileSync('src/styles/TopBar.css', 'utf8');
+  const media = css.slice(css.search(/@media[^{]*max-width\s*:\s*700px/));
+  expect(media).toMatch(/\.top-bar--menu-toggle\s*\{[^}]*display\s*:\s*inline-flex/);
+  expect(media).toMatch(/\.top-bar--actions\s*\{[^}]*display\s*:\s*none/);
+  expect(media).toMatch(/\.top-bar--actions--open\s*\{[^}]*position\s*:\s*absolute/);
+  expect(media).toMatch(/\.top-bar--actions--open \.top-bar--action[\s\S]*?min-height\s*:\s*40px/);
+  expect(css).toMatch(/\.top-bar--menu-toggle--open \.top-bar--menu-bar:nth-child\(1\)\s*\{[^}]*transform\s*:\s*rotate\(45deg\)/);
+});

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -69,7 +69,12 @@ export default function TopBar (props : Props) : JSX.Element {
   // A single open panel: switching icons swaps popovers in one click
   // instead of closing first and forgetting the click.
   const [ openPanel, setOpenPanel ] = useState<'settings' | 'clear' | 'themes' | null>(null)
+  // Narrow screens fold the whole action cluster under a menu toggle:
+  // tabs (and the + beside them) stay put, everything else rides in
+  // the dropdown. Any action taken closes it again.
+  const [ menuOpen, setMenuOpen ] = useState(false)
   const togglePanel = (panel : 'settings' | 'clear' | 'themes') => {
+    setMenuOpen(false)
     if (openPanel === panel) {
       setOpenPanel(null)
       // Closing panels drops any stuck hover preview with them.
@@ -159,21 +164,24 @@ export default function TopBar (props : Props) : JSX.Element {
           <Plus size={ 17 } strokeWidth={ 1.75 } />
         </button>
 
-        <div className='top-bar--actions'>
+        <div className={ menuOpen ? 'top-bar--actions top-bar--actions--open' : 'top-bar--actions' }>
           <a
             className='top-bar--action'
             href={ link }
             download={ fileName }
             title='Download this Notebook'
+            onClick={ () => setMenuOpen(false) }
           >
             <Download size={ 17 } strokeWidth={ 1.75 } />
+            <span className='top-bar--action-label'>Download</span>
           </a>
 
           <input type="file" accept=".lus" id="input"
             onChange={ (e) => onFiles(e, onImport) }
           />
-          <label htmlFor="input" className='top-bar--action' title='Import a Notebook from your computer'>
+          <label htmlFor="input" className='top-bar--action' title='Import a Notebook from your computer' onClick={ () => setMenuOpen(false) }>
             <Upload size={ 17 } strokeWidth={ 1.75 } />
+            <span className='top-bar--action-label'>Import</span>
           </label>
 
           <button
@@ -182,14 +190,19 @@ export default function TopBar (props : Props) : JSX.Element {
             onClick={ () => togglePanel('clear') }
           >
             <Eraser size={ 17 } strokeWidth={ 1.75 } />
+            <span className='top-bar--action-label'>Clearing options</span>
           </button>
 
           <button
             className='top-bar--action top-bar--theme-toggle'
             title='Toggle the theme'
-            onClick={ onDarkModeChange }
+            onClick={ () => {
+              setMenuOpen(false)
+              onDarkModeChange()
+            } }
           >
             { darkmode ? <Sun size={ 17 } strokeWidth={ 1.75 } /> : <Moon size={ 17 } strokeWidth={ 1.75 } /> }
+            <span className='top-bar--action-label'>Toggle theme</span>
           </button>
 
           <button
@@ -197,11 +210,15 @@ export default function TopBar (props : Props) : JSX.Element {
             aria-checked={ notebook.zenMode === true }
             className={ notebook.zenMode === true ? 'top-bar--zen top-bar--zen--on' : 'top-bar--zen' }
             title={ notebook.zenMode === true ? 'Exit zen mode: show all boxes' : 'Zen mode: one box at a time' }
-            onClick={ () => onZenModeChange(notebook.zenMode !== true) }
+            onClick={ () => {
+              setMenuOpen(false)
+              onZenModeChange(notebook.zenMode !== true)
+            } }
           >
             <span className='top-bar--zen-knob'>
               <Focus size={ 13 } strokeWidth={ 2 } />
             </span>
+            <span className='top-bar--action-label'>Zen mode</span>
           </button>
 
           <button
@@ -210,6 +227,7 @@ export default function TopBar (props : Props) : JSX.Element {
             onClick={ () => togglePanel('settings') }
           >
             <SettingsIcon size={ 17 } strokeWidth={ 1.75 } />
+            <span className='top-bar--action-label'>Notebook settings</span>
           </button>
 
           <button
@@ -218,6 +236,7 @@ export default function TopBar (props : Props) : JSX.Element {
             onClick={ () => togglePanel('themes') }
           >
             <Palette size={ 17 } strokeWidth={ 1.75 } />
+            <span className='top-bar--action-label'>Accent theme</span>
           </button>
 
           <button
@@ -225,10 +244,12 @@ export default function TopBar (props : Props) : JSX.Element {
             title='Guided tour'
             onClick={ () => {
               setOpenPanel(null)
+              setMenuOpen(false)
               onTourOpen()
             } }
           >
             <Footprints size={ 17 } strokeWidth={ 1.75 } />
+            <span className='top-bar--action-label'>Guided tour</span>
           </button>
 
           <a
@@ -237,10 +258,41 @@ export default function TopBar (props : Props) : JSX.Element {
             target="_blank"
             rel="noopener noreferrer"
             href='https://github.com/lambdulus/frontend/issues'
+            onClick={ () => setMenuOpen(false) }
           >
             <Bug size={ 17 } strokeWidth={ 1.75 } />
+            <span className='top-bar--action-label'>Report a bug</span>
           </a>
         </div>
+
+        {
+          // Narrow-screen menu: the same action cluster above, folded
+          // under a hamburger (see the media query in TopBar.css). Tabs
+          // and the + beside them stay in the bar either way.
+          menuOpen ?
+            <div className='top-bar--backdrop' onClick={ () => setMenuOpen(false) } />
+          :
+            null
+        }
+        <button
+          className={ menuOpen ? 'top-bar--action top-bar--menu-toggle top-bar--menu-toggle--open' : 'top-bar--action top-bar--menu-toggle' }
+          title={ menuOpen ? 'Close the menu' : 'Open the menu' }
+          aria-expanded={ menuOpen }
+          aria-label='Menu'
+          onClick={ () => {
+            // Re-opening the menu dismisses any open panel with it:
+            // the two dropdowns share the corner and would only
+            // overlap. Closing an already-shut panel is a no-op.
+            setOpenPanel(null)
+            onAccentPreview(null)
+            onBoxStylePreview(null)
+            setMenuOpen(! menuOpen)
+          } }
+        >
+          <span className='top-bar--menu-bar' aria-hidden='true' />
+          <span className='top-bar--menu-bar' aria-hidden='true' />
+          <span className='top-bar--menu-bar' aria-hidden='true' />
+        </button>
 
         {
           openPanel === 'settings' ?
@@ -398,7 +450,7 @@ export default function TopBar (props : Props) : JSX.Element {
                 <div className='top-bar--clear-divider' />
                 <button
                   className='btn btn-danger top-bar--clear-btn'
-                  title='Erase all notebooks and start over with the defaults'
+                  title='Erase all notebooks except the Manual and start over with the defaults'
                   onClick={ () => {
                     setOpenPanel(null)
                     onResetWorkspace()

--- a/src/components/Tour.test.tsx
+++ b/src/components/Tour.test.tsx
@@ -339,7 +339,8 @@ test('zen arrival steps open panels out of the way', () => {
   unmount();
 });
 
-test('cleaning arrival opens the clearing options but presses nothing', () => {
+test('cleaning arrival shows the button without opening', () => {
+  // Step 11 shows the eraser; only the exit sub-steps open the panel.
   const onEraser = vi.fn();
   const { container, unmount } = render(
     <div>
@@ -347,20 +348,50 @@ test('cleaning arrival opens the clearing options but presses nothing', () => {
       <Tour { ...props({ initialStep : 'cleaning' }) } />
     </div>
   );
-  // Shown, not done: the panel opens, and the step carries no clear
-  // callback to fire through.
-  expect(onEraser).toHaveBeenCalledTimes(1);
+  expect(onEraser).not.toHaveBeenCalled();
   expect(titleOf(container)).toBe('A clean slate');
   unmount();
 });
 
-test('cleaning arrival leaves an open clearing panel alone', () => {
+test('cleaning arrival closes an open clearing panel', () => {
+  // Backing in from an exit step: the button reads alone again.
+  const onEraser = vi.fn();
+  const onBackdrop = vi.fn();
+  const { unmount } = render(
+    <div>
+      <button title='Clearing options' onClick={ onEraser } />
+      <div className='top-bar--backdrop' onClick={ onBackdrop } />
+      <button title='Erase all notebooks except the Manual and start over with the defaults' />
+      <Tour { ...props({ initialStep : 'cleaning' }) } />
+    </div>
+  );
+  expect(onEraser).not.toHaveBeenCalled();
+  expect(onBackdrop).toHaveBeenCalledTimes(1);
+  unmount();
+});
+
+test('exit-step arrival opens the clearing options but presses nothing', () => {
+  const onEraser = vi.fn();
+  const { container, unmount } = render(
+    <div>
+      <button title='Clearing options' onClick={ onEraser } />
+      <Tour { ...props({ initialStep : 'clean-notebook' }) } />
+    </div>
+  );
+  // Shown, not done: the panel opens, and the step carries no clear
+  // callback to fire through.
+  expect(onEraser).toHaveBeenCalledTimes(1);
+  expect(titleOf(container)).toBe('Clear notebook');
+  unmount();
+});
+
+test('exit-step arrival leaves an open clearing panel alone', () => {
   const onEraser = vi.fn();
   const { unmount } = render(
     <div>
       <button title='Clearing options' onClick={ onEraser } />
-      <button title='Erase all notebooks and start over with the defaults' />
-      <Tour { ...props({ initialStep : 'cleaning' }) } />
+      <button title='Erase all notebooks except the Manual and start over with the defaults' />
+      <Tour { ...props({ initialStep : 'clean-workspace' }) } />
     </div>
   );
   expect(onEraser).not.toHaveBeenCalled();
@@ -475,5 +506,245 @@ test('a visible subject stays exactly where the user put it', () => {
     tabs.remove();
   } finally {
     window.scrollTo = original;
+  }
+});
+
+function mockMatchMedia (matches : boolean) {
+  return (() => ({ matches })) as unknown as typeof window.matchMedia;
+}
+
+test('the map step warns when the map is stepped out', () => {
+  // Narrow viewport: no pointing at a strip the user cannot see.
+  const original = window.matchMedia;
+  window.matchMedia = mockMatchMedia(true);
+  try {
+    const { container } = render(<Tour { ...props({ initialStep : 'boxmap' }) } />);
+    expect(titleOf(container)).toBe('The box map');
+    expect(container.querySelector('.tour--body')?.textContent).toMatch(/too narrow/);
+  }
+  finally {
+    window.matchMedia = original;
+  }
+});
+
+test('the map step stays plain on wide screens', () => {
+  const original = window.matchMedia;
+  window.matchMedia = mockMatchMedia(false);
+  try {
+    const { container } = render(<Tour { ...props({ initialStep : 'boxmap' }) } />);
+    expect(container.querySelector('.tour--body')?.textContent).not.toMatch(/too narrow/);
+  }
+  finally {
+    window.matchMedia = original;
+  }
+});
+
+// A folded top bar: closed action cluster holding the switch, plus a
+// working hamburger that really opens and closes it.
+function plantFoldedBar () : { actions : HTMLElement, cleanup : () => void } {
+  const actions = document.createElement('div');
+  actions.className = 'top-bar--actions';
+  const zen = document.createElement('button');
+  zen.className = 'top-bar--zen';
+  actions.appendChild(zen);
+  const toggle = document.createElement('button');
+  toggle.setAttribute('aria-label', 'Menu');
+  toggle.addEventListener('click', () => actions.classList.toggle('top-bar--actions--open'));
+  document.body.appendChild(actions);
+  document.body.appendChild(toggle);
+  return { actions, cleanup : () => { actions.remove(); toggle.remove(); } };
+}
+
+test('steps pointing into the folded bar open the menu', () => {
+  const original = window.matchMedia;
+  window.matchMedia = mockMatchMedia(true);
+  const bar = plantFoldedBar();
+  try {
+    render(<Tour { ...props({ initialStep : 'zen' }) } />);
+    expect(bar.actions.classList.contains('top-bar--actions--open')).toBe(true);
+  }
+  finally {
+    bar.cleanup();
+    window.matchMedia = original;
+  }
+});
+
+test('steps pointing elsewhere close the open menu', () => {
+  const original = window.matchMedia;
+  window.matchMedia = mockMatchMedia(true);
+  const bar = plantFoldedBar();
+  bar.actions.classList.add('top-bar--actions--open');
+  try {
+    render(<Tour { ...props({ initialStep : 'welcome' }) } />);
+    expect(bar.actions.classList.contains('top-bar--actions--open')).toBe(false);
+  }
+  finally {
+    bar.cleanup();
+    window.matchMedia = original;
+  }
+});
+
+test('the menu stays untouched on wide screens', () => {
+  const original = window.matchMedia;
+  window.matchMedia = mockMatchMedia(false);
+  const bar = plantFoldedBar();
+  try {
+    render(<Tour { ...props({ initialStep : 'zen' }) } />);
+    expect(bar.actions.classList.contains('top-bar--actions--open')).toBe(false);
+  }
+  finally {
+    bar.cleanup();
+    window.matchMedia = original;
+  }
+});
+
+// A folded box bar: closed icon row holding the gear, plus a working
+// hamburger that really opens and closes it.
+function plantBoxBar () : { controls : HTMLElement, cleanup : () => void } {
+  const bar = document.createElement('div');
+  bar.className = 'boxTopBar';
+  const controls = document.createElement('div');
+  controls.className = 'box-top-bar-controls';
+  const gear = document.createElement('div');
+  gear.setAttribute('title', "Open this Boxs' settings");
+  controls.appendChild(gear);
+  const toggle = document.createElement('div');
+  toggle.className = 'box-top-bar--compact-toggle';
+  toggle.addEventListener('click', () => controls.classList.toggle('box-top-bar-controls--open'));
+  bar.appendChild(controls);
+  bar.appendChild(toggle);
+  document.body.appendChild(bar);
+  return { controls, cleanup : () => bar.remove() };
+}
+
+test('settings steps open the folded box menu', () => {
+  // The gear hides under the hamburger, and every Next tap shuts it
+  // again — so each step explaining box settings re-opens it, whether
+  // its own subject is the gear or a panel row.
+  const original = window.matchMedia;
+  window.matchMedia = mockMatchMedia(true);
+  for (const step of [ 'settings', 'set-sli', 'set-strategy' ]) {
+    const bar = plantBoxBar();
+    try {
+      render(<Tour { ...props({ initialStep : step }) } />);
+      expect(bar.controls.classList.contains('box-top-bar-controls--open')).toBe(true);
+    }
+    finally {
+      bar.cleanup();
+    }
+  }
+  window.matchMedia = original;
+});
+
+test('other steps close the folded box menu', () => {
+  const original = window.matchMedia;
+  window.matchMedia = mockMatchMedia(true);
+  const bar = plantBoxBar();
+  bar.controls.classList.add('box-top-bar-controls--open');
+  try {
+    render(<Tour { ...props({ initialStep : 'macros' }) } />);
+    expect(bar.controls.classList.contains('box-top-bar-controls--open')).toBe(false);
+  }
+  finally {
+    bar.cleanup();
+    window.matchMedia = original;
+  }
+});
+
+test('panel steps keep the folded menu shut', () => {
+  // The panel has priority: opening the menu under it would only
+  // overlap, so steps opening a panel never unfold it — while the
+  // panel still opens through the hidden icon.
+  const original = window.matchMedia;
+  window.matchMedia = mockMatchMedia(true);
+  const onThemes = vi.fn();
+  const actions = document.createElement('div');
+  actions.className = 'top-bar--actions';
+  const themes = document.createElement('button');
+  themes.setAttribute('title', 'Accent theme');
+  themes.addEventListener('click', onThemes);
+  actions.appendChild(themes);
+  const toggle = document.createElement('button');
+  toggle.setAttribute('aria-label', 'Menu');
+  toggle.addEventListener('click', () => actions.classList.toggle('top-bar--actions--open'));
+  document.body.appendChild(actions);
+  document.body.appendChild(toggle);
+  try {
+    render(<Tour { ...props({ initialStep : 'yours' }) } />);
+    expect(onThemes).toHaveBeenCalledTimes(1);
+    expect(actions.classList.contains('top-bar--actions--open')).toBe(false);
+  }
+  finally {
+    actions.remove();
+    toggle.remove();
+    window.matchMedia = original;
+  }
+});
+
+test('the cleaning step unfolds the menu without a panel', () => {
+  // Step 11 shows just the button: the menu opens on the eraser and
+  // no panel opens under it.
+  const original = window.matchMedia;
+  window.matchMedia = mockMatchMedia(true);
+  const onEraser = vi.fn();
+  const actions = document.createElement('div');
+  actions.className = 'top-bar--actions';
+  const eraser = document.createElement('button');
+  eraser.setAttribute('title', 'Clearing options');
+  eraser.addEventListener('click', onEraser);
+  actions.appendChild(eraser);
+  const toggle = document.createElement('button');
+  toggle.setAttribute('aria-label', 'Menu');
+  toggle.addEventListener('click', () => actions.classList.toggle('top-bar--actions--open'));
+  document.body.appendChild(actions);
+  document.body.appendChild(toggle);
+  try {
+    const { container } = render(<Tour { ...props({ initialStep : 'cleaning' }) } />);
+    expect(titleOf(container)).toBe('A clean slate');
+    expect(onEraser).not.toHaveBeenCalled();
+    expect(actions.classList.contains('top-bar--actions--open')).toBe(true);
+  }
+  finally {
+    actions.remove();
+    toggle.remove();
+    window.matchMedia = original;
+  }
+});
+
+test('the box menu stays untouched on wide screens', () => {
+  const original = window.matchMedia;
+  window.matchMedia = mockMatchMedia(false);
+  const bar = plantBoxBar();
+  try {
+    render(<Tour { ...props({ initialStep : 'settings' }) } />);
+    expect(bar.controls.classList.contains('box-top-bar-controls--open')).toBe(false);
+  }
+  finally {
+    bar.cleanup();
+    window.matchMedia = original;
+  }
+});
+
+test('the ring heals onto controls landing after arrival', async () => {
+  // The exit button lands a beat after the step (its panel commits
+  // separately): the ring follows it instead of missing it outright.
+  const eraser = document.createElement('button');
+  eraser.setAttribute('title', 'Clearing options');
+  eraser.addEventListener('click', () => {
+    const exit = document.createElement('button');
+    exit.className = 'btn top-bar--clear-btn';
+    exit.setAttribute('title', 'Erase all boxes in Test');
+    exit.getBoundingClientRect = () => ({ top : 60, left : 0, bottom : 90, right : 10, width : 10, height : 30, x : 0, y : 60, toJSON : () => ({}) }) as unknown as DOMRect;
+    document.body.appendChild(exit);
+  });
+  document.body.appendChild(eraser);
+  const { container, unmount } = render(<Tour { ...props({ initialStep : 'clean-notebook' }) } />);
+  try {
+    await waitFor(() => expect(container.querySelector('.tour--ring')).not.toBeNull());
+  }
+  finally {
+    unmount();
+    eraser.remove();
+    document.querySelectorAll('.top-bar--clear-btn').forEach((el) => el.remove());
   }
 });

--- a/src/components/Tour.tsx
+++ b/src/components/Tour.tsx
@@ -73,7 +73,7 @@ const THEMES_PANEL = '.top-bar--accent-pick'
 // button that marks its open panel.
 const ZEN_SELECTOR = '.top-bar--zen'
 const CLEAR_SELECTOR = '[title="Clearing options"]'
-const CLEAN_WORKSPACE_TITLE = 'Erase all notebooks and start over with the defaults'
+const CLEAN_WORKSPACE_TITLE = 'Erase all notebooks except the Manual and start over with the defaults'
 
 // The take-with-you and meta controls closing the tour: notebook
 // export, the per-box share-link control, the bug reporter, and the
@@ -82,6 +82,51 @@ const EXPORT_SELECTOR = '[title="Download this Notebook"]'
 const SHARE_SELECTOR = '[title="Copy the link to this Expression."]'
 const BUG_SELECTOR = '[title="Submit a bug or a feature request"]'
 const TOUR_SELECTOR = '[title="Guided tour"]'
+
+// The viewport width at or below which the box map steps out (see
+// the matching media query in App.css): the map step says so instead
+// of pointing at a strip the user cannot see.
+export const BOX_MAP_HIDE_WIDTH : number = 1371
+
+export function boxMapHidden () : boolean {
+  if (typeof window.matchMedia !== 'function') {
+    return false
+  }
+  return window.matchMedia(`(max-width: ${BOX_MAP_HIDE_WIDTH}px)`).matches
+}
+
+// The viewport width at or below which the top bar folds its action
+// cluster under the hamburger (see the media query in TopBar.css).
+export const TOP_BAR_MENU_WIDTH : number = 700
+
+export function topBarMenuFolded () : boolean {
+  if (typeof window.matchMedia !== 'function') {
+    return false
+  }
+  return window.matchMedia(`(max-width: ${TOP_BAR_MENU_WIDTH}px)`).matches
+}
+
+// The viewport width at or below which a box folds its title-bar
+// icons under its own hamburger (see the media query in BoxTopBar.css).
+export const BOX_BAR_MENU_WIDTH : number = 419
+
+export function boxBarMenuFolded () : boolean {
+  if (typeof window.matchMedia !== 'function') {
+    return false
+  }
+  return window.matchMedia(`(max-width: ${BOX_BAR_MENU_WIDTH}px)`).matches
+}
+
+// Steps explaining box settings: below 420px the bar icons fold
+// under the box hamburger (see BoxTopBar.css), so these steps keep
+// it open on arrival even when their own subject lives in the
+// already-open settings panel.
+const BOX_SETTINGS_STEPS : Array<string> = [ 'settings', 'set-sli', 'set-sde', 'set-eta', 'set-collapse', 'set-strategy' ]
+
+// Steps opening a top-bar panel on arrival (see the show-don't-tell
+// effect): the panel has priority, so the folded menu stays shut and
+// never overlaps it.
+const TOP_BAR_PANEL_STEPS : Array<string> = [ 'yours', 'theme-accent', 'theme-style', 'clean-notebook', 'clean-workspace' ]
 
 // The clearing panel's two exits: Clear notebook is the plain button
 // (its title carries the live notebook name), Clean workspace the
@@ -216,7 +261,7 @@ export const TOUR_STEPS : Array<TourStep> = [
   {
     id : 'clean-workspace',
     title : 'Clean entire workspace',
-    body : 'Clean entire workspace restarts everything from the defaults — every notebook, back to a clean slate. Showing only: the box we built stays put, yours to keep.',
+    body : 'Clean entire workspace restarts everything from the defaults — every notebook except the protected Manual, back to a clean slate. Showing only: the box we built stays put, yours to keep.',
     target : CLEAN_WORKSPACE_SELECTOR,
     needsPanel : true,
     dot : 'cleaning',
@@ -375,9 +420,39 @@ interface Ring {
   height : number
 }
 
+// The map step's body, with a narrow-screen rider when the map is
+// stepped out: no pointing at a strip the user cannot see.
+function stepBody (step : TourStep, mapHidden : boolean) : string {
+  if (step.id === 'boxmap' && mapHidden) {
+    return `${step.body} Your screen is too narrow to show it, though — the map only rides along on wider screens. Widen past 1372 pixels to see it; in normal mode scrolling between boxes works just fine without it.`
+  }
+  return step.body
+}
+
+// The element the current step rings: the tracked box's control, or
+// the document target — null when the step points at nothing alive.
+function ringSubject (step : TourStep, tracked : Element | null) : Element | null {
+  if (step.targetInTracked !== undefined) {
+    return tracked !== null && tracked.isConnected ? tracked.querySelector(step.targetInTracked) : null
+  }
+  if (step.target !== undefined) {
+    return document.querySelector(step.target)
+  }
+  return null
+}
+
 export default function Tour (props : Props) : JSX.Element {
   const { initialStep, onClose, onAddLambdaBox, onFillBoxEditor, onSetBoxSettings, onShowBoxMacros, onHideBoxMacros, onDeleteBox, onSetZenMode } : Props = props
   const [ id, setId ] = useState(() => stepById(initialStep).id)
+  // Narrow screens hide the box map (see App.css): tracked live so
+  // the map step's rider follows resizes mid-step.
+  const [ mapHidden, setMapHidden ] = useState<boolean>(() => boxMapHidden())
+  // Narrow screens fold the top-bar actions under the hamburger (see
+  // TopBar.css): tracked live with the map above.
+  const [ barFolded, setBarFolded ] = useState<boolean>(() => topBarMenuFolded())
+  // Narrow boxes fold their title-bar icons the same way (see
+  // BoxTopBar.css): tracked live with the rest.
+  const [ boxFolded, setBoxFolded ] = useState<boolean>(() => boxBarMenuFolded())
   // The box frame this tour run is working with. Session-only: a reload
   // forgets it, and the wait steps below loop back to 'add' instead of
   // ever touching a stranger's box.
@@ -558,6 +633,62 @@ export default function Tour (props : Props) : JSX.Element {
     return undefined
   }, [ id ])
 
+  // Narrow-mode visibility follows the viewport, not the step:
+  // re-read all of it on every resize so the boxmap rider and the
+  // menu syncs below never go stale mid-step.
+  useEffect(() => {
+    const onResize = () => {
+      setMapHidden(boxMapHidden())
+      setBarFolded(topBarMenuFolded())
+      setBoxFolded(boxBarMenuFolded())
+    }
+    window.addEventListener('resize', onResize)
+    return () => window.removeEventListener('resize', onResize)
+  }, [])
+
+  // Folded top bar (see TopBar.css): steps pointing at its action
+  // cluster open the hamburger on arrival, so the ring lands on
+  // living UI; steps pointing elsewhere close it, so its backdrop
+  // never blocks the page behind the card. Steps opening a panel
+  // keep it shut throughout: the panel has priority and the two
+  // dropdowns would only overlap.
+  useEffect(() => {
+    if (!barFolded) {
+      return
+    }
+    const subject : Element | null = ringSubject(current, tracked)
+    const needOpen : boolean =
+      subject !== null &&
+      subject.closest('.top-bar--actions') !== null &&
+      ! TOP_BAR_PANEL_STEPS.includes(id)
+    const open : boolean = document.querySelector('.top-bar--actions--open') !== null
+    if (needOpen !== open) {
+      (document.querySelector('[aria-label="Menu"]') as HTMLElement | null)?.click()
+    }
+  }, [ id, tracked, barFolded ])
+
+  // Folded box bar (see BoxTopBar.css): the gear hides under the box
+  // hamburger, and every Next tap shuts it again through its
+  // outside-tap listener — so every step explaining box settings
+  // re-opens it on arrival, whether its own subject is the gear or a
+  // row in the already-open panel. Steps pointing at other bar icons
+  // open it through the same subject check; steps pointing elsewhere
+  // close it.
+  useEffect(() => {
+    if (!boxFolded) {
+      return
+    }
+    const scope : Element | Document = tracked !== null && tracked.isConnected ? tracked : document
+    const subject : Element | null = ringSubject(current, tracked)
+    const needOpen : boolean =
+      (subject !== null && subject.closest('.box-top-bar-controls') !== null) ||
+      BOX_SETTINGS_STEPS.includes(id)
+    const open : boolean = scope.querySelector('.box-top-bar-controls--open') !== null
+    if (needOpen !== open) {
+      (scope.querySelector('.box-top-bar--compact-toggle') as HTMLElement | null)?.click()
+    }
+  }, [ id, tracked, boxFolded ])
+
   // Show, don't tell: the macros and themes steps open the real panels on
   // arrival, so the tour points at living UI instead of describing it.
   // The macros arrival is one atomic handoff — settings closed, dock
@@ -586,10 +717,16 @@ export default function Tour (props : Props) : JSX.Element {
       (document.querySelector('.top-bar--backdrop') as HTMLElement | null)?.click()
     }
 
-    // The finale only shows: open the clearing options so both exits
-    // read live, but press neither — the boxes stay put. Same re-open
-    // for the exit sub-steps, for the same backing-in reason as themes.
-    if ((id === 'cleaning' || id === 'clean-notebook' || id === 'clean-workspace') && document.querySelector(`[title="${CLEAN_WORKSPACE_TITLE}"]`) === null) {
+    // The finale only shows, one step at a time: the cleaning step
+    // shows just the button, and only the exit sub-steps open the
+    // clearing options so both exits read live — pressing neither, the
+    // boxes stay put. Same re-open for the sub-steps, for the same
+    // backing-in reason as themes; arriving back at the cleaning step
+    // closes the panel again, so the button always reads alone.
+    if (id === 'cleaning' && document.querySelector(`[title="${CLEAN_WORKSPACE_TITLE}"]`) !== null) {
+      (document.querySelector('.top-bar--backdrop') as HTMLElement | null)?.click()
+    }
+    if ((id === 'clean-notebook' || id === 'clean-workspace') && document.querySelector(`[title="${CLEAN_WORKSPACE_TITLE}"]`) === null) {
       (document.querySelector(CLEAR_SELECTOR) as HTMLElement | null)?.click()
     }
 
@@ -771,27 +908,39 @@ export default function Tour (props : Props) : JSX.Element {
   useEffect(() => {
     setRing(null)
 
-    const element : Element | null =
-      current.targetInTracked !== undefined ?
-        (tracked !== null && tracked.isConnected ? tracked.querySelector(current.targetInTracked) : null)
-      : current.target !== undefined ?
-        document.querySelector(current.target)
-      :
-        null
-
-    if (element === null) {
-      return
-    }
-
-    // The ring re-seats on resize, scroll, the element's own growth — a
-    // stepping box grows under it — and any DOM arrival: panels the tour
-    // itself opens (macros dock, clearing and theme options) land after
-    // this effect runs, so without the observer their rings would never
-    // appear. The rect guard keeps the observer from re-rendering on
-    // unrelated mutations.
+    // Late arrivals: panels, pickers and folded menus land after this
+    // runs — their state commits separately — so the subject re-resolves
+    // on every placement. The ring heals onto controls that were absent
+    // on arrival instead of missing them outright. Class toggles count
+    // as arrivals too: the folded menus open without touching the tree,
+    // and only an attribute watch catches the subject turning visible.
+    // The rect guard keeps the observers from re-rendering on unrelated
+    // mutations.
     let lastKey : string | null = null
+    let ro : ResizeObserver | null = null
+    let roEl : Element | null = null
 
     const place = () => {
+      const element : Element | null = ringSubject(current, tracked)
+
+      if (element !== roEl) {
+        ro?.disconnect()
+        roEl = element
+        ro = element !== null && typeof ResizeObserver !== 'undefined' ? new ResizeObserver(place) : null
+
+        if (element !== null && ro !== null) {
+          ro.observe(element)
+        }
+      }
+
+      if (element === null) {
+        if (lastKey !== 'null') {
+          lastKey = 'null'
+          setRing(null)
+        }
+        return
+      }
+
       const rect : DOMRect = element.getBoundingClientRect()
       const key : string =
         rect.width === 0 && rect.height === 0 ?
@@ -809,14 +958,10 @@ export default function Tour (props : Props) : JSX.Element {
 
     place()
 
-    const ro : ResizeObserver | null =
-      typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(place)
-
-    ro?.observe(element)
     window.addEventListener('resize', place)
     document.addEventListener('scroll', place, true)
     const mo : MutationObserver = new MutationObserver(place)
-    mo.observe(document.body, { childList : true, subtree : true })
+    mo.observe(document.body, { childList : true, subtree : true, attributes : true })
 
     return () => {
       ro?.disconnect()
@@ -853,7 +998,7 @@ export default function Tour (props : Props) : JSX.Element {
           }
         </p>
         <p className='tour--title'>{ current.title }</p>
-        <p className='tour--body'>{ renderBody(current.body) }</p>
+        <p className='tour--body'>{ renderBody(stepBody(current, mapHidden)) }</p>
         <div className='tour--dots' aria-hidden='true'>
           {
             MAIN_DOTS.map((dot : string) =>

--- a/src/screens/Notebook.test.tsx
+++ b/src/screens/Notebook.test.tsx
@@ -820,12 +820,6 @@ function mediaBlock (css : string, breakpoint : string) : string {
   return chunks.find((chunk : string) => new RegExp(`max-width\\s*:\\s*${breakpoint}`).test(chunk)) ?? ''
 }
 
-test('the bad-screen gate sits at 375px', () => {
-  // iPhone-SE-narrow stays usable; anything under it is out.
-  const css = readFileSync('src/App.css', 'utf8');
-  expect(mediaBlock(css, '374px')).toMatch(/#bad-screen-message\s*\{[^}]*display\s*:\s*block/);
-});
-
 test('narrow screens hide the box map instead of overlapping', () => {
   // Below the width where even the half map clears the slim column
   // (1372px), the map steps out entirely.

--- a/src/screens/Notebook.test.tsx
+++ b/src/screens/Notebook.test.tsx
@@ -813,6 +813,64 @@ test('narrow screens slim the column and halve the map', () => {
   expect(media).toMatch(/\.macro-dock\s*\{[^}]*\(100vw - 850px\)/);
 });
 
+// One breakpoint's own block: the chunk from its @media up to the
+// next @media (or the end), so wider blocks above never leak in.
+function mediaBlock (css : string, breakpoint : string) : string {
+  const chunks : Array<string> = css.split('@media')
+  return chunks.find((chunk : string) => new RegExp(`max-width\\s*:\\s*${breakpoint}`).test(chunk)) ?? ''
+}
+
+test('the bad-screen gate sits at 375px', () => {
+  // iPhone-SE-narrow stays usable; anything under it is out.
+  const css = readFileSync('src/App.css', 'utf8');
+  expect(mediaBlock(css, '374px')).toMatch(/#bad-screen-message\s*\{[^}]*display\s*:\s*block/);
+});
+
+test('narrow screens hide the box map instead of overlapping', () => {
+  // Below the width where even the half map clears the slim column
+  // (1372px), the map steps out entirely.
+  const css = readFileSync('src/App.css', 'utf8');
+  expect(mediaBlock(css, '1371px')).toMatch(/\.box-map\s*\{[^}]*display\s*:\s*none/);
+});
+
+test('below the slim column width the page goes fluid', () => {
+  // A fixed 810px column would overflow viewports under 850px, so
+  // the page padding owns the gutters instead.
+  const css = readFileSync('src/App.css', 'utf8');
+  expect(mediaBlock(css, '849px')).toMatch(/\.mainSpace\s*\{[^}]*max-width\s*:\s*none/);
+});
+
+test('below 480px the zen add-box docks to the page padding', () => {
+  // The fixed right offset would push the capped button past the
+  // left edge, so it rides the gutter instead.
+  const css = readFileSync('src/App.css', 'utf8');
+  expect(mediaBlock(css, '480px')).toMatch(/\.zen-add\s*\{[^}]*right\s*:\s*12px/);
+});
+
+test('below 580px the macro names give up their wide column', () => {
+  // Every builtin fits in 52px and longer user macros wrap — the :=
+  // column stays aligned, just further left.
+  const css = readFileSync('src/untyped-lambda-integration/styles/MacroList.css', 'utf8');
+  expect(mediaBlock(css, '579px')).toMatch(/\.macro-name\s*\{[^}]*min-width\s*:\s*52px/);
+});
+
+test('the zen picker options carry the card fill', () => {
+  // The picker floats over box content; transparent rows would let
+  // the box show through.
+  const css = readFileSync('src/App.css', 'utf8');
+  const options = css.match(/\.zen-add \.add-box--group\s*\{[^}]*\}/)?.[0] ?? '';
+  expect(options).toMatch(/background-color\s*:\s*var\(--surface\)/);
+});
+
+test('the macro pill joins the flow once the gutter runs out', () => {
+  // Below ~1080px the left gutter no longer fits the pill, so the
+  // dock rides the top of its own box and grows it when open.
+  const css = readFileSync('src/untyped-lambda-integration/styles/MacroList.css', 'utf8');
+  const media = mediaBlock(css, '1080px');
+  expect(media).toMatch(/\.macro-dock\s*\{[^}]*position\s*:\s*static/);
+  expect(media).toMatch(/\.macro-dock--open\s*\{[^}]*min-height\s*:\s*0/);
+});
+
 test('box map shows in normal mode too', () => {
   const state : NotebookState = {
     name : 'Test',
@@ -1108,6 +1166,94 @@ test('focusing a box collapses the old table and opens nothing unasked', () => {
     const patched = updateNotebook.mock.calls[0][0] as NotebookState;
     expect((patched.boxList[0] as UntypedLambdaState).macrolistOpen).toBe(false);
     expect((patched.boxList[1] as UntypedLambdaState).macrolistOpen).toBe(false);
+  }
+  finally {
+    unmount();
+  }
+});
+
+function TwoLambdaHarness () : JSX.Element {
+  const [ state, setState ] = useState<NotebookState>(() => ({
+    name : 'Test',
+    boxList : [ lambdaBox('a', false, false), lambdaBox('b', false, false) ],
+    activeBoxIndex : 0,
+    focusedBoxIndex : 0,
+    menuOpen : false,
+    settings : {},
+    __key : 'nb',
+  }));
+  return <Notebook state={ state } updateNotebook={ (patch : Partial<NotebookState>) => setState((prev) => ({ ...prev, ...patch })) } />;
+}
+
+test('pill toggles open on the first click, even unfocused', () => {
+  // The pill click bubbles into the container's focus sync, which
+  // recomputes the docks from pre-toggle props: the toggle must win
+  // anyway, not get swallowed into a focus move.
+  const { container, unmount } = render(<TwoLambdaHarness />);
+  try {
+    const heads = container.querySelectorAll('.macro-dock--head');
+    expect(heads.length).toBe(2);
+
+    fireEvent.click(heads[1]);
+
+    const frames = container.querySelectorAll('.box-frame');
+    expect(frames[1].querySelector('.macro-dock--open')).not.toBeNull();
+    expect(frames[0].querySelector('.macro-dock--open')).toBeNull();
+  }
+  finally {
+    unmount();
+  }
+});
+
+function ZenHarness () : JSX.Element {
+  const [ state, setState ] = useState<NotebookState>(() => ({
+    name : 'Test',
+    zenMode : true,
+    boxList : [ lambdaBox('a', false, false) ],
+    activeBoxIndex : 0,
+    // Fresh box after a refresh: focus never landed on it.
+    focusedBoxIndex : undefined,
+    menuOpen : false,
+    settings : {},
+    __key : 'nb',
+  }));
+  return <Notebook state={ state } updateNotebook={ (patch : Partial<NotebookState>) => setState((prev) => ({ ...prev, ...patch })) } />;
+}
+
+test('pill opens first try in zen on an unfocused box', () => {
+  // Zen restores nothing, so the bubbled focus sync recomputes the
+  // just-toggled dock closed: the toggle must win anyway, and the box
+  // must own the focus afterwards like every other control click.
+  const { container, unmount } = render(<ZenHarness />);
+  try {
+    fireEvent.click(container.querySelector('.macro-dock--head') as HTMLElement);
+
+    const frame = container.querySelector('.box-frame') as HTMLElement;
+    expect(frame.querySelector('.macro-dock--open')).not.toBeNull();
+    expect(frame.classList.contains('box-frame--focused')).toBe(true);
+  }
+  finally {
+    unmount();
+  }
+});
+
+test('pill survives a blur-first click from an editing box', () => {
+  // Live browsers blur the focused editor on mousedown, before the
+  // pill click lands: the blur collapse must not eat the toggle.
+  const { container, unmount } = render(<TwoLambdaHarness />);
+  try {
+    // Focus the first box, then blur it like a pill mousedown would.
+    fireEvent.click(container.querySelectorAll('.box-rail')[0]);
+    const editors = container.querySelectorAll('.box-frame')[0].querySelectorAll('textarea, input, [contenteditable="true"]');
+    if (editors.length > 0) {
+      (editors[0] as HTMLElement).focus();
+    }
+    fireEvent.focusOut(container.querySelectorAll('.boxContainer')[0]);
+
+    fireEvent.click(container.querySelectorAll('.macro-dock--head')[1]);
+
+    const frames = container.querySelectorAll('.box-frame');
+    expect(frames[1].querySelector('.macro-dock--open')).not.toBeNull();
   }
   finally {
     unmount();

--- a/src/styles/BoxTopBar.css
+++ b/src/styles/BoxTopBar.css
@@ -121,6 +121,119 @@
   color: var(--text);
 }
 
+/* Compact box menu toggle: a hamburger folding to an X, riding the
+   bar's right end. Hidden everywhere; the query below shows it where
+   the icon row folds into its popup. */
+.box-top-bar--compact-toggle {
+  display: none;
+  position: relative;
+  flex: 0 0 auto;
+}
+
+.box-top-bar--compact-bar {
+  position: absolute;
+  left: 6px;
+  width: 14px;
+  height: 2px;
+  border-radius: 1px;
+  background-color: currentColor;
+  transition: transform .18s ease-in-out, opacity .15s ease-in-out, top .18s ease-in-out;
+}
+
+.box-top-bar--compact-bar:nth-child(1) {
+  top: 8px;
+}
+
+.box-top-bar--compact-bar:nth-child(2) {
+  top: 12px;
+}
+
+.box-top-bar--compact-bar:nth-child(3) {
+  top: 16px;
+}
+
+.box-top-bar--compact-toggle--open .box-top-bar--compact-bar:nth-child(1) {
+  top: 12px;
+  transform: rotate(45deg);
+}
+
+.box-top-bar--compact-toggle--open .box-top-bar--compact-bar:nth-child(2) {
+  opacity: 0;
+}
+
+.box-top-bar--compact-toggle--open .box-top-bar--compact-bar:nth-child(3) {
+  top: 12px;
+  transform: rotate(-45deg);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .box-top-bar--compact-bar {
+    transition: none;
+  }
+}
+
+/* Below 420px the right-side icons crowd the bar, so they fold under
+   the toggle: closed they are gone entirely, open the very same node
+   drops as a horizontal icon popup over the bar's right end (anchored
+   to the box frame, which stays put). No labels — the icons alone
+   name themselves at this size. */
+@media (max-width: 419px) {
+  .box-top-bar-controls {
+    display: none;
+  }
+
+  .boxContainer:hover .box-top-bar--compact-toggle,
+  .boxContainer.active .box-top-bar--compact-toggle,
+  .boxContainer:focus-within .box-top-bar--compact-toggle {
+    display: inline-flex;
+  }
+
+  .box-top-bar-controls--open {
+    display: flex;
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    z-index: 777;
+    flex-direction: row;
+    gap: 2px;
+    background-color: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    box-shadow: var(--shadow);
+    padding: 6px;
+    opacity: 1;
+    animation: box-compact-in .15s ease-out;
+  }
+
+  .box-top-bar-controls--open .box-top-bar--controls-item {
+    width: 32px;
+    height: 32px;
+  }
+}
+
+@media (hover: none) and (max-width: 419px) {
+  .box-top-bar--compact-toggle {
+    display: inline-flex;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .box-top-bar-controls--open {
+    animation: none;
+  }
+}
+
+@keyframes box-compact-in {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
 .box-top-bar--menu {
   position: absolute;
   top: 40px;

--- a/src/styles/MiniMode.css
+++ b/src/styles/MiniMode.css
@@ -1,0 +1,87 @@
+/* Experiment (easter egg, uncommitted): the stripped mini mode below
+   MINI_MODE_WIDTH (see App.tsx) — the active box in forced zen, no top
+   bar, no way to add boxes. Delete this file and the mini branch in
+   the App render to revert. */
+
+/* No top bar above, so the page padding shrinks to the content —
+   symmetric top and bottom, so the card lands flush on both ends. */
+.mini-mode .mainSpace {
+  padding-top: 20px;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-bottom: 20px;
+}
+
+/* Fluid shrink below the 375 line: 14px there, tapering with the
+   viewport, floored where glyphs stop being glyphs. Paddings ride the
+   type in em, so fixed px gutters never eat the card — it keeps
+   breathing room until way too tiny. */
+.mini-mode {
+  font-size: max(10px, 3.733vw);
+}
+
+.mini-mode .boxContainer {
+  padding: 1em 0.8em 1.2em;
+}
+
+/* The floating add-box is the one zen furniture mini mode drops: no
+   new boxes down here, the box at hand is the whole app. */
+.mini-mode .zen-add {
+  display: none;
+}
+
+/* The map is already gone below 1372px; belt and braces in case the
+   mini knob ever climbs above it. */
+.mini-mode .box-map {
+  display: none;
+}
+
+/* No macro table down here: one box to read and step, and the panel
+   never behaved in the stripped layout — reverted to a plain hide. */
+.mini-mode .macro-dock {
+  display: none;
+}
+
+/* Run-only down here: stepping through reductions and exercise boxes
+   want the room this mode refuses to give. */
+.mini-mode .debug-controls--step,
+.mini-mode .open-as-exercise {
+  display: none;
+}
+
+/* Without the top bar the zen clamp keeps too much air — and since the
+   em paddings above shrank the box chrome, the old subtraction leaves
+   a gap at the bottom. Exact arithmetic instead (content-box, so the
+   chrome adds on): page 20 + 20, box 1em + 1.2em of its own 1.1em
+   type plus the 2px border. The card lands flush, square on square. */
+.mini-mode .mainSpace.zen .boxContainer {
+  height: calc(100vh - 40px - 2.2em - 2px);
+}
+
+/* Classic boxes keep fixed px gutters (and a single bottom border),
+   so they get their own subtraction: page 40, chrome 44 + 1. */
+#app[data-box-style='classic'] .mini-mode .mainSpace.zen .boxContainer {
+  height: calc(100vh - 85px);
+}
+
+/* Three lines of editor is plenty down here: the wrapper section
+   carries the height prop as inline style, so this needs the
+   hammer — and Monaco runs automaticLayout, so it re-lays itself
+   out at the forced height instead of clipping (cursor stays
+   visible, longer input still scrolls inside). */
+.mini-mode .editorContainer .editor > div > section {
+  height: 57px !important;
+}
+
+/* The pinned endpoint steps carry 12px of air each (the initial step
+   top and bottom, the current one on top). Halve it here so the
+   history sits a touch higher and the card fits a 250x250 square. */
+.mini-mode li.activeStep,
+.mini-mode .box-current-step,
+.mini-mode .box-initial-step {
+  margin-top: 6px;
+}
+
+.mini-mode .box-initial-step {
+  margin-bottom: 6px;
+}

--- a/src/styles/TopBar.css
+++ b/src/styles/TopBar.css
@@ -534,3 +534,120 @@
   gap: 8px;
   margin-top: 8px;
 }
+
+/* Dropdown labels: hidden in the bar, naming each row in the open
+   menu so the icons never stand alone in empty room. */
+.top-bar--action-label {
+  display: none;
+}
+
+/* Narrow-screen menu toggle: a hamburger folding to an X, riding the
+   far right end. Hidden on wide screens; the media query below shows
+   it and folds the action cluster into its dropdown. */
+.top-bar--menu-toggle {
+  display: none;
+  position: relative;
+  flex-shrink: 0;
+}
+
+.top-bar--menu-bar {
+  position: absolute;
+  left: 7px;
+  width: 18px;
+  height: 2px;
+  border-radius: 1px;
+  background-color: currentColor;
+  transition: transform .18s ease-in-out, opacity .15s ease-in-out, top .18s ease-in-out;
+}
+
+.top-bar--menu-bar:nth-child(1) {
+  top: 9px;
+}
+
+.top-bar--menu-bar:nth-child(2) {
+  top: 15px;
+}
+
+.top-bar--menu-bar:nth-child(3) {
+  top: 21px;
+}
+
+.top-bar--menu-toggle--open .top-bar--menu-bar:nth-child(1) {
+  top: 15px;
+  transform: rotate(45deg);
+}
+
+.top-bar--menu-toggle--open .top-bar--menu-bar:nth-child(2) {
+  opacity: 0;
+}
+
+.top-bar--menu-toggle--open .top-bar--menu-bar:nth-child(3) {
+  top: 15px;
+  transform: rotate(-45deg);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .top-bar--menu-bar {
+    transition: none;
+  }
+}
+
+/* Below 700px the right-hand cluster leaves the tabs no room, so it
+   folds under the toggle: closed it is gone entirely, open the very
+   same node drops down as a full-width-row panel — no duplicated
+   controls, no dead IDs. Tabs and the + beside them stay in the bar,
+   and the settings panels cap to the viewport. */
+@media (max-width: 700px) {
+  .top-bar--inner {
+    gap: 12px;
+    padding: 0 12px;
+  }
+
+  .top-bar--menu-toggle {
+    display: inline-flex;
+  }
+
+  .top-bar--actions {
+    display: none;
+  }
+
+  .top-bar--actions--open {
+    display: flex;
+    position: absolute;
+    top: calc(100% + 8px);
+    right: 12px;
+    z-index: 3;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 2px;
+    min-width: 200px;
+    margin-left: 0;
+    background-color: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    box-shadow: var(--shadow);
+    padding: 8px;
+  }
+
+  /* Roomy phone rows, icons untouched: easier to hit, nothing smaller. */
+  .top-bar--actions--open .top-bar--action,
+  .top-bar--actions--open .top-bar--zen {
+    width: 100%;
+    min-height: 40px;
+    justify-content: flex-start;
+    padding: 0 12px;
+  }
+
+  .top-bar--actions--open .top-bar--action-label {
+    display: inline;
+    margin-left: 10px;
+    font-size: 0.95em;
+    color: var(--text);
+    white-space: nowrap;
+  }
+
+  .top-bar--settings-panel {
+    right: 12px;
+    width: min(320px, calc(100vw - 24px));
+  }
+}

--- a/src/untyped-lambda-integration/MacroList.test.tsx
+++ b/src/untyped-lambda-integration/MacroList.test.tsx
@@ -34,6 +34,7 @@ function renderDock (macrolistOpen : boolean, setBoxState : (state : UntypedLamb
       isFocused={ true }
       isAnchorBox={ true }
       setBoxState={ setBoxState }
+      makeActive={ () => void 0 }
       addBox={ () => void 0 }
     />
   );
@@ -60,6 +61,7 @@ test('macro dock pill toggles the panel both ways', () => {
       isFocused={ true }
       isAnchorBox={ true }
       setBoxState={ setBoxState }
+      makeActive={ () => void 0 }
       addBox={ () => void 0 }
     />
   );
@@ -134,6 +136,7 @@ function dockElement (open : boolean) : JSX.Element {
       isFocused={ true }
       isAnchorBox={ true }
       setBoxState={ () => void 0 }
+      makeActive={ () => void 0 }
       addBox={ () => void 0 }
     />
   );

--- a/src/untyped-lambda-integration/UntypedLambdaBox.test.tsx
+++ b/src/untyped-lambda-integration/UntypedLambdaBox.test.tsx
@@ -18,6 +18,7 @@ function Harness ({ initial, host } : { initial : UntypedLambdaState, host? : HT
       isFocused={ true }
       isAnchorBox={ true }
       setBoxState={ setState }
+      makeActive={ () => void 0 }
       addBox={ () => void 0 }
       titleActionsHost={ host ? { current : host } : undefined }
     />
@@ -214,6 +215,7 @@ test('a second box panel dismisses the first', () => {
         isFocused={ false }
         isAnchorBox={ false }
         setBoxState={ setState }
+        makeActive={ () => void 0 }
         addBox={ () => void 0 }
       />
     );
@@ -374,6 +376,7 @@ function settingsHarness (initial : UntypedLambdaState) {
         isFocused={ true }
         isAnchorBox={ true }
         setBoxState={ setState }
+        makeActive={ () => void 0 }
         addBox={ () => void 0 }
       />
     );

--- a/src/untyped-lambda-integration/UntypedLambdaBox.tsx
+++ b/src/untyped-lambda-integration/UntypedLambdaBox.tsx
@@ -20,6 +20,7 @@ interface Props {
 
   setBoxState (state : UntypedLambdaState) : void
   addBox (box : UntypedLambdaState) : void
+  makeActive () : void
   titleActionsHost? : React.RefObject<HTMLSpanElement>
 }
 
@@ -136,7 +137,7 @@ export default class UntypedLambdaBox extends PureComponent<Props, State> {
   }
 
   render () {
-    const { state, isActive, isFocused, isAnchorBox, setBoxState, addBox, titleActionsHost } : Props = this.props
+    const { state, isActive, isFocused, isAnchorBox, setBoxState, addBox, makeActive, titleActionsHost } : Props = this.props
     const { settingsOpen, subtype, macrolistOpen, SLI, expandStandalones, strategy, SDE, ETA, collapseOldSteps, editor, minimized, history, submittedWith } : UntypedLambdaState = state
 
     // A submitted session stepped under different strategy/SLI/SDE can
@@ -253,7 +254,17 @@ export default class UntypedLambdaBox extends PureComponent<Props, State> {
               className='macro-dock--head'
               // The head remembers, not just toggles: focus syncs restore
               // this wish on refocus and never invent one of their own.
-              onClick={ () => setBoxState({ ...state, macrolistOpen : ! macrolistOpen, macrolistWanted : ! macrolistOpen }) }
+              onClick={ (e) => {
+                // Focus first, toggle second, never bubble: the bubbled
+                // focus sync recomputes docks from pre-toggle props and
+                // swallows the toggle on an unfocused box — always, in
+                // zen, which restores nothing. Ordered by hand, the
+                // toggle commits last and wins, and the box owns the
+                // focus afterwards like every other control click.
+                e.stopPropagation()
+                makeActive()
+                setBoxState({ ...state, macrolistOpen : ! macrolistOpen, macrolistWanted : ! macrolistOpen })
+              } }
               title={ macrolistOpen ? 'Hide macros for this box' : 'Show macros for this box' }
               aria-expanded={ macrolistOpen }
             >

--- a/src/untyped-lambda-integration/styles/MacroList.css
+++ b/src/untyped-lambda-integration/styles/MacroList.css
@@ -170,6 +170,32 @@
   padding: 0 14px 12px;
 }
 
+/* Narrow screens leave no left gutter for the dock: below ~1080px
+   the pill would slide over its own box, so it joins the flow
+   instead — a compact chip riding the top of the box, unfolding
+   downward in place. Open, it drops the overlay containment (no
+   bottom pin, no minimum card height) and simply grows the box. */
+@media (max-width: 1080px) {
+  .macro-dock {
+    position: static;
+    width: auto;
+    margin-bottom: 12px;
+  }
+
+  .macro-dock--open {
+    min-height: 0;
+  }
+}
+
+@media (max-width: 579px) {
+  /* Below 580px the name column stops reserving room for long names:
+     every builtin fits in 52px and longer user macros wrap — the :=
+     column stays aligned, just further left. */
+  .macro-name {
+    min-width: 52px;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .macro-dock--panel {
     transition: none;

--- a/src/untyped-lambda-integration/styles/Settings.css
+++ b/src/untyped-lambda-integration/styles/Settings.css
@@ -4,12 +4,13 @@
 
 /* Box-local settings float above the box (anchored to the container,
    which is positioned) instead of squeezing the history: right-docked
-   under the title bar, with their own capped scroll. */
+   under the title bar, with their own capped scroll. Above the macro
+   dock, so the panel always wins their overlap. */
 .box-settings {
   position: absolute;
   top: 60px;
   right: 8px;
-  z-index: 20;
+  z-index: 60;
   width: min(340px, calc(100% - 16px));
   margin: 0;
   padding: 12px 14px 16px;
@@ -19,6 +20,17 @@
   box-shadow: var(--shadow);
   max-height: 40vh;
   overflow-y: auto;
+}
+
+/* Below ~430px the capped panel outgrows the box: its padding adds
+   onto the fixed width, spilling past the left edge. Uncapped and
+   pinned to both sides instead — a fixed 8px gap left and right,
+   whatever the box. */
+@media (max-width: 429px) {
+  .box-settings {
+    width: auto;
+    left: 8px;
+  }
 }
 
 .untyped-lambda-settings-label {


### PR DESCRIPTION
Ships the sub-375px stripped mini-mode easter egg plus the responsive narrow-screen work and 178 commits of develop. Verified: tsc clean, 252/252 tests green.