### PR TITLE
Pre-fill bug reports with diagnostics

### DIFF
--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -5,6 +5,7 @@ import { Accent, BoxStyle, GlobalSettings, NotebookState } from '../Types'
 
 import '../styles/TopBar.css'
 import { decodeNotebook } from '../Constants'
+import { buildBugReportURL } from '../misc/BugReport'
 import { Theme } from '../contexts/Theme'
 import UntypedLambdaCalculusSet from '../untyped-lambda-integration/Settings'
 import {
@@ -257,7 +258,7 @@ export default function TopBar (props : Props) : JSX.Element {
             title='Submit a bug or a feature request'
             target="_blank"
             rel="noopener noreferrer"
-            href='https://github.com/lambdulus/frontend/issues'
+            href={ buildBugReportURL({ notebooks, activeNotebookIndex, theme, accent, boxStyle, settings }) }
             onClick={ () => setMenuOpen(false) }
           >
             <Bug size={ 17 } strokeWidth={ 1.75 } />

--- a/src/misc/BugReport.test.ts
+++ b/src/misc/BugReport.test.ts
@@ -1,0 +1,100 @@
+import { test, expect } from 'vitest';
+
+import { BoxType, NotebookState } from '../Types';
+import { Theme } from '../contexts/Theme';
+import { EvaluationStrategy, UntypedLambdaState, UntypedLambdaType } from '../untyped-lambda-integration/Types';
+import { buildBugReportURL, BugReportInput } from './BugReport';
+
+function box (expression : string) : UntypedLambdaState {
+  return {
+    __key : 'box-1',
+    type : BoxType.UNTYPED_LAMBDA,
+    title : 'Box 1',
+    minimized : false,
+    settingsOpen : false,
+    subtype : UntypedLambdaType.ORDINARY,
+    expression,
+    ast : null,
+    history : [],
+    isRunning : false,
+    breakpoints : [],
+    timeoutID : undefined,
+    timeout : 5000,
+    strategy : EvaluationStrategy.NORMAL,
+    SDE : false,
+    ETA : false,
+    SLI : false,
+    expandStandalones : false,
+    collapseOldSteps : true,
+    macrolistOpen : false,
+    macrotable : {},
+    editor : { placeholder : '', content : expression, syntaxError : null },
+  };
+}
+
+function input (expression : string) : BugReportInput {
+  const notebook : NotebookState = {
+    name : 'Notebook 1',
+    zenMode : false,
+    boxList : [box(expression)],
+    activeBoxIndex : 0,
+    focusedBoxIndex : 0,
+    menuOpen : false,
+    settings : {},
+    __key : 'notebook-1',
+  };
+  return {
+    notebooks : [notebook],
+    activeNotebookIndex : 0,
+    theme : Theme.Dark,
+    accent : 'blue',
+    boxStyle : 'cards',
+    settings : {},
+  };
+}
+
+function bodyOf (url : string) : string {
+  const params : URLSearchParams = new URLSearchParams(new URL(url).search);
+  const body : string | null = params.get('body');
+  expect(body).not.toBeNull();
+  return body as string;
+}
+
+test('bug report links to a new pre-filled issue', () => {
+  const url : string = buildBugReportURL(input('(\\x.x)'));
+  expect(url.startsWith('https://github.com/lambdulus/frontend/issues/new?')).toBe(true);
+
+  const params : URLSearchParams = new URLSearchParams(new URL(url).search);
+  expect(params.get('labels')).toBe('bug');
+  expect(params.get('title')).toBe('[bug]: ');
+
+  const body : string = bodyOf(url);
+  expect(body).toContain('## What happened');
+  expect(body).toContain('## Diagnostics');
+  expect(body).toContain('Normal Evaluation');
+  expect(body).toContain('(\\x.x)');
+});
+
+test('diagnostics carry the environment facts', () => {
+  const body : string = bodyOf(buildBugReportURL(input('x')));
+  expect(body).toMatch(/Viewport: \d+x\d+/);
+  expect(body).toContain('Commit: ');
+  expect(body).toContain('Dark');
+  expect(body).toContain('Notebook 1');
+});
+
+test('long expressions are truncated, special chars survive', () => {
+  const expression : string = '(λx.x & y # z)\n'.repeat(40);
+  const body : string = bodyOf(buildBugReportURL(input(expression)));
+  // The round-tripped body holds the 300-char preview, not the whole expression.
+  expect(body).toContain(expression.slice(0, 300));
+  expect(body).not.toContain(expression);
+  expect(body).toContain('first 300');
+});
+
+test('empty notebook does not break the link', () => {
+  const shaped : BugReportInput = input('x');
+  shaped.notebooks = [];
+  const body : string = bodyOf(buildBugReportURL(shaped));
+  expect(body).toContain('none open');
+});

--- a/src/misc/BugReport.ts
+++ b/src/misc/BugReport.ts
@@ -1,0 +1,118 @@
+import { Accent, BoxState, BoxStyle, BoxType, GlobalSettings, NotebookState } from '../Types'
+import { Theme } from '../contexts/Theme'
+import { UntypedLambdaState } from '../untyped-lambda-integration/Types'
+
+// The "Report a bug" icon deep-links to a new issue with the boring
+// parts already filled in: build stamps, browser facts, and a snapshot
+// of the workspace that is tedious to dictate and easy to get wrong.
+// Everything sits in one editable Diagnostics section, so reporting
+// stays one click while nothing is sent silently.
+export interface BugReportInput {
+  notebooks : Array<NotebookState>
+  activeNotebookIndex : number
+  theme : Theme
+  accent : Accent
+  boxStyle : BoxStyle
+  settings : GlobalSettings
+}
+
+const ISSUES_URL = 'https://github.com/lambdulus/frontend/issues/new'
+const EXPRESSION_PREVIEW_LENGTH = 300
+
+function env (name : string) : string {
+  const value : unknown = (import.meta.env as Record<string, unknown>)[name]
+  return typeof value === 'string' && value.length > 0 ? value : 'unknown'
+}
+
+function environmentLines () : Array<string> {
+  const lines : Array<string> = []
+  lines.push(`- App version: ${ env('VITE_VERSION_INFO') }`)
+  lines.push(`- Commit: ${ env('VITE_COMMIT') }`)
+  lines.push(`- Reported at: ${ new Date().toISOString() }`)
+
+  if (typeof window !== 'undefined') {
+    lines.push(`- Page: ${ window.location.href }`)
+    lines.push(`- Viewport: ${ window.innerWidth}x${ window.innerHeight } @ ${ window.devicePixelRatio }x`)
+    if (typeof window.screen !== 'undefined') {
+      lines.push(`- Screen: ${ window.screen.width }x${ window.screen.height }`)
+    }
+  }
+
+  if (typeof navigator !== 'undefined') {
+    lines.push(`- Browser: ${ navigator.userAgent }`)
+    lines.push(`- Language: ${ navigator.language }`)
+  }
+
+  return lines
+}
+
+function workspaceLines (input : BugReportInput) : Array<string> {
+  const notebook : NotebookState | undefined = input.notebooks[input.activeNotebookIndex]
+
+  if (notebook === undefined) {
+    return ['- Notebook: none open']
+  }
+
+  const lines : Array<string> = [
+    `- Notebook: "${ notebook.name }" (${ input.notebooks.length } notebooks, ${ notebook.boxList.length } boxes, zen: ${ notebook.zenMode ?? false })`,
+    `- Look: ${ Theme[input.theme] }, accent ${ input.accent }, ${ input.boxStyle } boxes`,
+  ]
+  return lines.concat(boxLines(notebook.boxList[notebook.activeBoxIndex]))
+}
+
+function boxLines (box : BoxState | undefined) : Array<string> {
+  if (box === undefined) {
+    return ['- Active box: none']
+  }
+
+  const lines : Array<string> = [
+    `- Active box: "${ box.title }" (${ box.type }, minimized: ${ box.minimized })`,
+  ]
+
+  if (box.type === BoxType.UNTYPED_LAMBDA) {
+    const state : UntypedLambdaState = box as UntypedLambdaState
+    lines.push(`- Strategy: ${ state.strategy }, SDE: ${ state.SDE }, ETA: ${ state.ETA }, SLI: ${ state.SLI }`)
+    lines.push(`- History: ${ state.history.length } steps, running: ${ state.isRunning }`)
+    lines.push(`- Macros: ${ Object.keys(state.macrotable ?? {}).length } defined, dock open: ${ state.macrolistOpen }`)
+    lines.push(`- Breakpoints: ${ state.breakpoints.length }`)
+
+    if (state.editor?.syntaxError) {
+      lines.push(`- Syntax error: ${ String(state.editor.syntaxError).slice(0, 200) }`)
+    }
+
+    const expression : string = state.expression ?? ''
+    const preview : string = expression.slice(0, EXPRESSION_PREVIEW_LENGTH).replace(/`/g, "'")
+    const scope : string = expression.length > EXPRESSION_PREVIEW_LENGTH ? `, first ${ EXPRESSION_PREVIEW_LENGTH }` : ''
+    lines.push(`- Expression (${ expression.length } chars${ scope }):`)
+    lines.push('```')
+    lines.push(preview || '(empty)')
+    lines.push('```')
+  }
+
+  return lines
+}
+
+export function buildBugReportURL (input : BugReportInput) : string {
+  const body : Array<string> = [
+    '## What happened',
+    '<!-- describe the bug -->',
+    '',
+    '## What I expected',
+    '<!-- what should have happened instead -->',
+    '',
+    '## Steps to reproduce',
+    '<!-- 1. ... 2. ... -->',
+    '',
+    '## Diagnostics',
+    '<!-- collected automatically when you clicked Report a bug; delete anything you would rather not share -->',
+    ...environmentLines(),
+    ...workspaceLines(input),
+  ]
+
+  const params : URLSearchParams = new URLSearchParams({
+    title : '[bug]: ',
+    labels : 'bug',
+    body : body.join('\n'),
+  })
+  return `${ ISSUES_URL }?${ params.toString() }`
+}


### PR DESCRIPTION
Report-a-bug deep-links to a new issue with title, bug label, skeleton, and auto-collected Diagnostics (build stamps, browser facts, workspace snapshot). Tests: 256 green, tsc clean.